### PR TITLE
docs(pack-infra): record the real state of the CI gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,11 +177,16 @@ The intended shape is in §7 of the design document.
 
 ## What is mechanically enforced
 
-| Layer | Binds | Blocks |
-|---|---|---|
-| `.claude/hooks/t4-gate` (`PreToolUse`) | Claude only | `gh pr create` with no issue · dangerous git · `gh pr merge` when `verify` fails |
-| `.githooks/pre-push` | every agent + human on this clone | push with no issue ref · large dirty tree · committed artifacts · missing gate ledger |
-| `.github/workflows/t4-verify.yml` | everyone, including a human merging on the web | a red `lint`, `test`, or `guards` check |
+| Layer | Binds | Blocks | State |
+|---|---|---|---|
+| `.claude/hooks/t4-gate` (`PreToolUse`) | Claude only | `gh pr create` with no issue · dangerous git · `gh pr merge` when `verify` fails | ✅ active |
+| `.githooks/pre-push` | every agent + human on this clone | push with no issue ref · large dirty tree · committed artifacts · missing gate ledger | ⚠️ installed, **not enabled** |
+| `T4 main gate` ruleset | everyone | direct push to `main` · force-push · branch deletion · merge with unresolved threads | ✅ active |
+| `.github/workflows/t4-verify.yml` | everyone, including a human merging on the web | a red `lint`, `test`, or `guards` check | ❌ **cannot run** — see #1 |
+
+**Actions is billing-locked on this account (#1)**, so no check can report and none is required
+by the ruleset. Do not add `required_status_checks` or set `"requireGreenCI": true` until a run
+goes green — either would deadlock every PR on a check that never reports.
 
 **The pre-push guards are opt-in per clone and not yet enabled.** Run once:
 

--- a/DONE.md
+++ b/DONE.md
@@ -40,8 +40,19 @@ means. Left absent rather than written wrong. Tracked in the ledger, Track 0.
 
 **Report:** `docs/adr/0001-ci-gate-scoped-to-modpack-reality.md`.
 
-**Next:** ledger Phase 0 (install packwiz + Java 17, enable `core.hooksPath`, run
-`/setup-matt-pocock-skills`) and Phase 2 (resolve the Create major version) — they do not block
-each other.
+**Remote state:** `xenodeve/minecraft-100day` (public). 23 triage labels created, 2 already
+existed (`wontfix`, and GitHub's default `bug`, renamed to `Bug`), 0 failed. Ruleset
+`T4 main gate` active — PR-only, no force-push, no deletion, unresolved threads block merge.
+Secret scanning and push protection enabled; Dependabot alerts and security PRs enabled.
+`secret_scanning_validity_checks` and `secret_scanning_non_provider_patterns` were **not**
+enabled — the API accepts the PATCH, returns 200, and leaves both `disabled`.
+
+**Blocked:** GitHub Actions is billing-locked on the account, so `T4 verify` cannot run and the
+three checks are not required by the ruleset. Filed as #1 with the reasoning for omitting them
+rather than adding checks that would deadlock every PR.
+
+**Next:** ledger Phase 0 — resolve #1, install packwiz + Java 17, enable `core.hooksPath`, run
+`/setup-matt-pocock-skills` — and Phase 2 (resolve the Create major version), which is not
+blocked by any of them.
 
 ---

--- a/docs/OPEN-WORK-LEDGER.md
+++ b/docs/OPEN-WORK-LEDGER.md
@@ -10,9 +10,8 @@
 **Legend:** ✅ done, pending merge · 🟢 buildable now · 🟡 gated (needs merge / resource /
 decision) · 🔴 **UNTRACKED** (MD-only, no GitHub issue — highest miss-risk)
 
-**Current state, stated plainly:** the repo has its operating layer and its design document.
-It has **no pack** — no `pack.toml`, no mods, no config, no KubeJS. Every row below is 🔴
-because no issues have been filed yet; Phase 1 fixes that.
+**Current state, stated plainly:** the repo has its operating layer and its two design
+documents. It has **no pack** — no `pack.toml`, no mods, no config, no KubeJS.
 
 ---
 
@@ -21,9 +20,10 @@ because no issues have been filed yet; Phase 1 fixes that.
 | Item | Status | Gate | Next action |
 |---|---|---|---|
 | `docs/agents/issue-tracker.md` + `docs/agents/triage-labels.md` | 🔴 | `/setup-matt-pocock-skills` is user-invocation-only — an agent cannot write these | Developer runs `/setup-matt-pocock-skills` in this repo, then the T4 delta (Component / Type / Severity groups) is appended |
-| Triage labels created on the GitHub repo | 🔴 | needs the repo to exist | `gh label create` for the five canonical roles + the T4 groups; report created / already-there / skipped |
+| Triage labels created on the GitHub repo | ✅ | — | 23 created, 2 already existed, 0 failed. `bug` renamed to `Bug` to match the vocabulary |
 | `git config core.hooksPath .githooks` on this clone | 🔴 | developer action, per-clone by design | Run it once; verify with `git config --get core.hooksPath` |
-| Branch ruleset on `main` (`lint`, `test`, `guards` required; direct push blocked) | 🔴 | the checks must run once before they are selectable | Push, let the workflow run, then create the ruleset |
+| `T4 main gate` ruleset — PR-only, no force-push, no deletion | ✅ | — | Active. Direct pushes to `main` are blocked |
+| `lint` / `test` / `guards` as **required status checks** | 🟡 | **#1** — GitHub Actions is billing-locked, so no check can ever report | Resolve the billing lock, confirm a green run, then add the three contexts to the ruleset |
 
 ## Track 1 — Blocking technical unknown
 
@@ -60,12 +60,13 @@ main pack. Not yet folded into the §24 phase list — where each lands is itsel
 
 ## Management Plan — phased execution order
 
-**Phase 0 — Unblock the tooling.** Install `packwiz` and a Java 17 JDK, run
-`git config core.hooksPath .githooks`, and run `/setup-matt-pocock-skills`. Four small actions,
-and three of the four rows in Track 0 plus two in Track 1 depend on them.
+**Phase 0 — Unblock the tooling.** Resolve the GitHub Actions billing lock (**#1**), install
+`packwiz` and a Java 17 JDK, run `git config core.hooksPath .githooks`, and run
+`/setup-matt-pocock-skills`. Five small actions, and most of Track 0 plus two rows in Track 1
+depend on them. Only #1 needs money; the rest are minutes.
 
-**Phase 1 — Tracking hygiene.** File a GitHub issue for every 🔴 row above, so the ledger stops
-being the only record. Create the triage labels first, since the issues need them.
+**Phase 1 — Tracking hygiene.** File a GitHub issue for every remaining 🔴 row above, so the
+ledger stops being the only record. The triage label vocabulary is already installed.
 
 **Phase 2 — Resolve the Create version.** This is the multiplier. Every mod pin, every KubeJS
 recipe, and the entire Season 2 branch are downstream of it, and it is answerable today with

--- a/docs/adr/0001-ci-gate-scoped-to-modpack-reality.md
+++ b/docs/adr/0001-ci-gate-scoped-to-modpack-reality.md
@@ -92,3 +92,25 @@ grows.
 
 - **Follow-ups:** add the `build` job and the `{ "context": "build" }` ruleset entry in the
   commit that introduces `pack.toml`. Revisit the TOML checker if it produces a false positive.
+
+## Postscript — the gate is armed, the checks are not (2026-08-25)
+
+Discovered immediately after the first push, and recorded here rather than in a second ADR
+because it does not overturn the decision above — it delays half of it.
+
+**GitHub Actions cannot run on this account** ([run 32779529796](https://github.com/xenodeve/minecraft-100day/actions/runs/32779529796)):
+*"The job was not started because your account is locked due to a billing issue."* Both jobs
+reported failure without executing a single step.
+
+So the `T4 main gate` ruleset was created **without** `required_status_checks`. It still blocks
+direct pushes to `main`, force-pushes, branch deletion, and merging with unresolved review
+threads — the parts that do not depend on a check reporting. `.claude/t4.json`
+`"requireGreenCI"` stays `false`, because with no CI at all `gh pr checks` reports non-zero and
+would deny every merge.
+
+Adding the required checks now would have been worse than omitting them: every PR would sit on
+*"Expected — waiting for status"* forever, and the first person who needs to land a PR disables
+the rule. A rule disabled once stays disabled, which is the exact failure this ADR set out to
+avoid.
+
+**Tracked as #1.** The decision above is unchanged; only its third tier is pending.


### PR DESCRIPTION
Closes #1 partially — records the state; the billing lock itself stays open there.

## What this changes

The bootstrap commit described a three-tier enforcement stack. Two tiers are live and one
cannot run, and the docs did not say so. This reconciles them.

| File | What changes |
|---|---|
| `CLAUDE.md` | The *What is mechanically enforced* table gains a **State** column. The CI row reads ❌ **cannot run** with a pointer to #1, plus an explicit instruction not to add `required_status_checks` or set `"requireGreenCI": true` until a run goes green. |
| `docs/OPEN-WORK-LEDGER.md` | Track 0 reconciled against what actually happened — labels ✅, ruleset ✅, required checks 🟡 gated on #1. Phase 0 of the management plan now names #1 first and notes it is the only item that costs money. |
| `docs/adr/0001-…` | A postscript, not a second ADR: the decision is unchanged, only its third tier is pending. Records why omitting the checks beats adding checks that can never report. |
| `DONE.md` | Remote state, the label counts, and the two secret-scanning options that were **not** enabled despite the API returning 200. |

## Why a postscript and not ADR 0002

ADR 0002 would imply the earlier decision was overturned. It was not — the scoping decision
(two checks instead of four, one script behind both gates) stands exactly as written. What
changed is that the server-side tier is temporarily unreachable for an account-level reason
that has nothing to do with the design.

## Verification

`node scripts/validate/verify.mjs` → passed (2 JSON, 0 TOML, 23 files scanned for placeholders,
0 KubeJS scripts).

CI cannot run on this PR — that is the subject of the PR.

---

## สรุปภาษาไทย

Closes #1 บางส่วน — บันทึกสถานะไว้ ส่วนตัวการล็อก billing ยังคงเปิดค้างอยู่ที่ issue นั้น

### เปลี่ยนอะไรบ้าง

commit ตอน bootstrap อธิบายว่ามีชั้นบังคับใช้สามชั้น ความจริงคือสองชั้นทำงานอยู่และหนึ่งชั้น
รันไม่ได้ ซึ่งเอกสารไม่ได้บอกไว้ PR นี้ทำให้เอกสารตรงกับความจริง

| ไฟล์ | เปลี่ยนอะไร |
|---|---|
| `CLAUDE.md` | ตาราง *What is mechanically enforced* เพิ่มคอลัมน์ **State** แถวของ CI เขียนว่า ❌ **cannot run** พร้อมชี้ไปที่ #1 และเพิ่มคำสั่งชัดเจนว่าห้ามใส่ `required_status_checks` หรือตั้ง `"requireGreenCI": true` จนกว่าจะมี run ที่เขียว |
| `docs/OPEN-WORK-LEDGER.md` | Track 0 ถูกปรับให้ตรงกับสิ่งที่เกิดขึ้นจริง — labels ✅, ruleset ✅, required checks 🟡 ติดที่ #1 ส่วน Phase 0 ของแผนบริหารตอนนี้ระบุ #1 เป็นอันดับแรก และหมายเหตุว่ามันเป็นรายการเดียวที่ต้องใช้เงิน |
| `docs/adr/0001-…` | เพิ่มเป็น postscript ไม่ใช่ ADR ตัวที่สอง: การตัดสินใจไม่ได้เปลี่ยน มีแค่ tier ที่สามที่ยังค้าง บันทึกไว้ว่าทำไมการไม่ใส่ check ถึงดีกว่าการใส่ check ที่ไม่มีวันรายงานผล |
| `DONE.md` | สถานะฝั่ง remote, จำนวน label และ secret-scanning สองตัวที่ **ไม่ได้** ถูกเปิด ทั้งที่ API ตอบ 200 |

### ทำไมถึงเป็น postscript ไม่ใช่ ADR 0002

ADR 0002 จะสื่อว่าการตัดสินใจเดิมถูกล้ม ซึ่งไม่ใช่ — การตัดสินใจเรื่องขอบเขต (สอง check แทนสี่,
สคริปต์เดียวอยู่หลัง gate ทั้งสอง) ยังยืนอยู่ตามที่เขียนไว้ทุกประการ สิ่งที่เปลี่ยนคือ tier ฝั่ง
server เข้าถึงไม่ได้ชั่วคราวด้วยเหตุผลระดับบัญชีที่ไม่เกี่ยวกับการออกแบบเลย

### การ verify

`node scripts/validate/verify.mjs` → ผ่าน (JSON 2 ไฟล์, TOML 0 ไฟล์, สแกนหา placeholder 23 ไฟล์,
KubeJS 0 ไฟล์)

CI รันบน PR นี้ไม่ได้ — ซึ่งก็คือเรื่องที่ PR นี้พูดถึงพอดี
