### PR TITLE
docs(pack-infra): land the agents docs layer and fold in the wildlife spec

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,11 +177,16 @@ The intended shape is in §7 of the design document.
 
 ## What is mechanically enforced
 
-| Layer | Binds | Blocks |
-|---|---|---|
-| `.claude/hooks/t4-gate` (`PreToolUse`) | Claude only | `gh pr create` with no issue · dangerous git · `gh pr merge` when `verify` fails |
-| `.githooks/pre-push` | every agent + human on this clone | push with no issue ref · large dirty tree · committed artifacts · missing gate ledger |
-| `.github/workflows/t4-verify.yml` | everyone, including a human merging on the web | a red `lint`, `test`, or `guards` check |
+| Layer | Binds | Blocks | State |
+|---|---|---|---|
+| `.claude/hooks/t4-gate` (`PreToolUse`) | Claude only | `gh pr create` with no issue · dangerous git · `gh pr merge` when `verify` fails | ✅ active |
+| `.githooks/pre-push` | every agent + human on this clone | push with no issue ref · large dirty tree · committed artifacts · missing gate ledger | ⚠️ installed, **not enabled** |
+| `T4 main gate` ruleset | everyone | direct push to `main` · force-push · branch deletion · merge with unresolved threads | ✅ active |
+| `.github/workflows/t4-verify.yml` | everyone, including a human merging on the web | a red `lint`, `test`, or `guards` check | ❌ **cannot run** — see #1 |
+
+**Actions is billing-locked on this account (#1)**, so no check can report and none is required
+by the ruleset. Do not add `required_status_checks` or set `"requireGreenCI": true` until a run
+goes green — either would deadlock every PR on a check that never reports.
 
 **The pre-push guards are opt-in per clone and not yet enabled.** Run once:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,10 +19,18 @@ The design document is the source of truth for intent:
 **`docs/Industrial Civilization Survival — Claude Code Handoff & Implementation Plan.md`**
 (read it before any pack work; unqualified `§N` references throughout this repo are to it).
 
-A second, standalone spec layers on top of it:
-**`docs/Addon Spec — Crafting Assistance + Tactical Tracker.md`** — adds JEI, Jade, Jade Addons,
-Crafting Tweaks, Mouse Tweaks, Polymorph and a re-themed Player Microchip tracker. It shares the
-same platform constraints and the same design rules; cite it as *Addon Spec §N*.
+Two standalone addon specs layer on top of it. Both share the same platform constraints and the
+same design rules, and both have their own section numbering — **cite them by name, never as a
+bare `§N`**:
+
+| Document | Adds | Cite as |
+|---|---|---|
+| `docs/Addon Spec — Crafting Assistance + Tactical Tracker.md` | JEI, Jade, Jade Addons, Crafting Tweaks, Mouse Tweaks, Polymorph, and a re-themed Player Microchip tracker | *Crafting Spec §N* |
+| `docs/Addon Spec — Natural Wildlife & Ecology.md` | Naturalist, Critters and Companions, Ecologics — the ordinary-animal layer that makes monsters read as abnormal. Carries its own phase list, W0–W9 | *Wildlife Spec §N* / *Wildlife Spec W3* |
+
+Untamed Wilds and Alex's Mobs are **rejected** by the Wildlife Spec (§2, §54) — high overlap,
+unnecessary entity diversity, and Alex's Mobs carries fantasy creatures that collide with the
+threat layer.
 
 **Engineering north-star.** Every change is judged by §35: *does this create another meaningful
 problem for the player to solve through engineering, logistics, preparation or teamwork?* A
@@ -148,12 +156,15 @@ DONE.md                       ship log — newest on top
 
 docs/
   Industrial Civilization Survival — ….md    the design document (source of truth for intent)
+  Addon Spec — Crafting Assistance ….md      JEI / Jade / tactical tracker
+  Addon Spec — Natural Wildlife ….md         Naturalist / Critters / Ecologics, phases W0–W9
   OPEN-WORK-LEDGER.md         open work, tracked and untracked — read at session start
   agents/
-    domain.md                 domain glossary — what the words mean here
+    domain.md                 domain glossary — WHAT THE WORDS MEAN here
+    reading-domain-docs.md    WHICH FILES to read before exploring, and when
     workflow.md               how to plan and implement here
-    issue-tracker.md          ⚠ NOT YET WRITTEN — see the ledger, Track 0
-    triage-labels.md          ⚠ NOT YET WRITTEN — see the ledger, Track 0
+    issue-tracker.md          GitHub conventions, gh path, bilingual body rule
+    triage-labels.md          the 25 labels that exist and what each one means
   adr/
     README.md                 ADR index + conventions
     0001-…                    CI gate scoped to what a modpack repo can check
@@ -236,3 +247,26 @@ none, say so in one line. Full procedure in the `t4-agent-memory` skill.
 **Reconcile before you stop.** Session-local todos go back to the ledger and to their issues.
 New work discovered mid-session gets a ledger row and, if non-trivial, an issue — otherwise it
 vanishes into MD, which is the failure the ledger exists to prevent.
+
+---
+
+## Agent skills
+
+### Issue tracker
+
+GitHub Issues on `xenodeve/minecraft-100day`, via the `gh` CLI — installed but **not on PATH**
+(`"/c/Program Files/GitHub CLI/gh.exe"`). Issue, PRD and PR bodies are bilingual: English plus a
+full Thai mirror. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+The five canonical roles with their names unchanged, plus this repo's Component / Type /
+Severity / Lifecycle groups — 25 labels, all present on the tracker. Every issue takes at least
+one triage-state label and exactly one Component. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context. Two files, deliberately not one: the **glossary** is `docs/agents/domain.md`
+(*what the words mean*), and the **consumer rules** are `docs/agents/reading-domain-docs.md`
+(*which files to read before exploring*). The upstream skill wants both at `domain.md`; they were
+split because the glossary was there first. See `docs/agents/reading-domain-docs.md`.

--- a/DONE.md
+++ b/DONE.md
@@ -6,6 +6,40 @@
 
 ---
 
+## docs/agents layer completed + third design doc folded in (2026-08-25, `/setup-matt-pocock-skills`, branch `chore/3-land-agents-docs-layer`)
+
+**Goal:** close the one hole the bootstrap could not fill itself, and stop the operating layer
+from being silently out of date the moment a new design document lands.
+
+**Shipped (#3 — the pocock hand-off):**
+- `docs/agents/issue-tracker.md` — GitHub conventions, the `gh` full path (it is not on PATH),
+  the bilingual-body rule, the merge gate's real state, and `/wayfinder` operations.
+- `docs/agents/triage-labels.md` — the five canonical roles (identity mapping) plus this repo's
+  Component / Type / Severity / Lifecycle groups, and what each Component owns.
+- `docs/agents/reading-domain-docs.md` — pocock's consumer rules, at a path that does not
+  destroy the glossary. The collision is upstream as `xeno-skills#334`.
+- `CLAUDE.md` — an `## Agent skills` block pointing at all three.
+
+**Shipped (#4 — Natural Wildlife & Ecology):**
+- `docs/agents/domain.md` — seven new terms: Natural/Anomalous world, Spawn Budget, Entity
+  Density Priority, Duplicate Species Audit, Wildlife Roster, Survival tax, W-phase. Both
+  language halves.
+- `CLAUDE.md` — the two addon specs now have a citation convention (*Crafting Spec §N* /
+  *Wildlife Spec W3*) because three documents with independent `§N` numbering were about to
+  make every reference ambiguous.
+- `docs/OPEN-WORK-LEDGER.md` — Track 4 (W0–W9), Track 0 reconciled, and Phase 2 rescoped to
+  sweep all three documents in one pass rather than three.
+
+**Validation:** `node scripts/validate/verify.mjs` → passed. Not verified: nothing here can be —
+no mod was installed and no world was launched. Every claim in these files is about the repo, not
+about the pack.
+
+**Report:** none warranted — no bug fixed, no architectural decision reversed. ADR 0001 stands.
+
+**Next:** unchanged — ledger Phase 0 and Phase 2.
+
+---
+
 ## T4 operating layer bootstrapped (2026-08-25, `/t4-project-bootstrap`, branch `main`)
 
 **Goal:** turn a directory holding one design document into an agent-primary repo — one where a

--- a/DONE.md
+++ b/DONE.md
@@ -40,8 +40,19 @@ means. Left absent rather than written wrong. Tracked in the ledger, Track 0.
 
 **Report:** `docs/adr/0001-ci-gate-scoped-to-modpack-reality.md`.
 
-**Next:** ledger Phase 0 (install packwiz + Java 17, enable `core.hooksPath`, run
-`/setup-matt-pocock-skills`) and Phase 2 (resolve the Create major version) — they do not block
-each other.
+**Remote state:** `xenodeve/minecraft-100day` (public). 23 triage labels created, 2 already
+existed (`wontfix`, and GitHub's default `bug`, renamed to `Bug`), 0 failed. Ruleset
+`T4 main gate` active — PR-only, no force-push, no deletion, unresolved threads block merge.
+Secret scanning and push protection enabled; Dependabot alerts and security PRs enabled.
+`secret_scanning_validity_checks` and `secret_scanning_non_provider_patterns` were **not**
+enabled — the API accepts the PATCH, returns 200, and leaves both `disabled`.
+
+**Blocked:** GitHub Actions is billing-locked on the account, so `T4 verify` cannot run and the
+three checks are not required by the ruleset. Filed as #1 with the reasoning for omitting them
+rather than adding checks that would deadlock every PR.
+
+**Next:** ledger Phase 0 — resolve #1, install packwiz + Java 17, enable `core.hooksPath`, run
+`/setup-matt-pocock-skills` — and Phase 2 (resolve the Create major version), which is not
+blocked by any of them.
 
 ---

--- a/docs/Addon Spec — Natural Wildlife & Ecology.md
+++ b/docs/Addon Spec — Natural Wildlife & Ecology.md
@@ -1,0 +1,1777 @@
+
+# Addon Spec — Natural Wildlife & Ecology
+## Claude Code CLI Implementation Handoff
+
+> **Project:** Industrial Civilization Survival  
+> **Platform:** Minecraft 1.20.1 Forge  
+> **Purpose:** เพิ่มระบบสัตว์ธรรมชาติและ ecology ให้โลกมีชีวิตมากขึ้น โดยไม่เปลี่ยน modpack ให้กลายเป็น zoo simulator, fantasy RPG หรือ entity-heavy kitchen sink pack
+>
+> เอกสารนี้ต้องสามารถใช้เป็น standalone implementation context สำหรับ Claude Code CLI ได้โดยไม่ต้องมี conversation history
+
+---
+
+# 1. Feature Summary
+
+เพิ่ม wildlife/ecology layer ให้โลกของ Industrial Civilization Survival
+
+เป้าหมายคือทำให้โลกมี contrast ระหว่าง:
+
+```text
+Natural World
+vs
+Hostile / Anomalous World
+```
+
+เช่น:
+
+```text
+Deer
+Birds
+Fish
+Otters
+Small animals
+Normal wildlife
+
+        ↓
+
+Vanilla hostile mobs
+
+        ↓
+
+Born in Chaos anomalies
+
+        ↓
+
+Horde crisis
+
+        ↓
+
+Ice & Fire territorial creatures
+
+        ↓
+
+Dragon territory
+```
+
+สัตว์ธรรมดามีความสำคัญต่อ atmosphere ของ pack
+
+เพราะโลกที่มีเพียง:
+
+```text
+Zombie
+Skeleton
+Monster
+Dragon
+```
+
+จะทำให้ monster กลายเป็นเรื่องปกติ
+
+แต่โลกที่มี:
+
+```text
+Deer
+Birds
+Fish
+Otter
+Livestock
+Normal forest
+
+↓
+
+สิ่งผิดธรรมชาติปรากฏขึ้น
+```
+
+จะทำให้ hostile encounters มี impact มากกว่า
+
+---
+
+# 2. Mods Added By This Addon
+
+เพิ่ม 3 mods:
+
+```text
+1. Naturalist
+2. Critters and Companions
+3. Ecologics
+```
+
+สถานะ:
+
+```text
+Naturalist
+→ CORE
+
+Critters and Companions
+→ CORE
+
+Ecologics
+→ CORE
+```
+
+ไม่เพิ่ม:
+
+```text
+Untamed Wilds
+Alex's Mobs
+```
+
+ใน Core Pack ณ ตอนนี้
+
+เหตุผล:
+
+- overlap สูง
+- เพิ่ม entity diversity เกินความจำเป็น
+- มีโอกาสทำให้ spawn ecosystem รก
+- เพิ่มภาระ AI/pathfinding
+- Alex's Mobs มี fantasy creatures จำนวนหนึ่งที่ overlap กับ threat layer
+
+สามารถ reconsider ได้ภายหลังหากพบ ecological niche ที่ยังขาดจริง
+
+---
+
+# 3. Naturalist
+
+## Source
+
+```text
+https://www.curseforge.com/minecraft/mc-mods/naturalist
+```
+
+## Status
+
+```text
+CORE
+SPAWN BALANCE REQUIRED
+PERFORMANCE TEST REQUIRED
+```
+
+## Role
+
+Naturalist เป็น wildlife backbone หลักของ modpack
+
+ใช้เติมสัตว์ธรรมชาติขนาดกลางและใหญ่ เช่น:
+
+```text
+Deer
+Birds
+Predators
+Large mammals
+Reptiles
+Aquatic animals
+Biome-specific wildlife
+```
+
+Exact roster ต้อง inspect จาก version ที่เลือกจริง
+
+อย่า hard-code assumptions จาก wiki/version อื่น
+
+---
+
+# 4. Naturalist Design Role
+
+Naturalist ไม่ควรเป็น:
+
+```text
+อีกหนึ่ง progression mod
+```
+
+และไม่ควรเป็น:
+
+```text
+mob collection game
+```
+
+หน้าที่หลักคือ:
+
+```text
+World Ecology
+Atmosphere
+Environmental Identity
+Natural Food Chain
+Exploration Flavor
+```
+
+สัตว์ควรรู้สึกว่า:
+
+> พวกมันอยู่ในโลกเพราะ biome นั้นเหมาะกับมัน
+
+ไม่ใช่:
+
+> ทุก biome มีสัตว์ 15 ตัวเดินเต็มพื้นที่
+
+---
+
+# 5. Critters and Companions
+
+## Source
+
+```text
+https://www.curseforge.com/minecraft/mc-mods/critters-and-companions
+```
+
+## Status
+
+```text
+CORE
+LIGHTWEIGHT ECOLOGY LAYER
+SPAWN BALANCE REQUIRED
+```
+
+## Role
+
+เติมสัตว์ขนาดเล็กและ ambient creatures ที่ Naturalist ไม่ได้เน้น
+
+ตัวอย่างประเภท:
+
+```text
+Otters
+Ferrets
+Small mammals
+Small aquatic life
+Insects
+Small reptiles
+Companion-like creatures
+```
+
+Exact entities ต้อง inspect registry จริง
+
+---
+
+# 6. Critters and Companions Design Role
+
+Naturalist:
+
+```text
+Major Wildlife
+```
+
+Critters and Companions:
+
+```text
+Small Wildlife
++
+Environmental Detail
+```
+
+สอง mod ต้อง complement กัน
+
+ไม่ควรเกิด:
+
+```text
+Naturalist Animal A
++
+Critters Animal B
+
+ที่ทำ ecosystem role เดียวกัน
+และ spawn พร้อมกันจำนวนมาก
+```
+
+หาก overlap ให้:
+
+1. เปรียบเทียบ behavior
+2. เปรียบเทียบ visuals
+3. เปรียบเทียบ compatibility
+4. เลือกตัวหลัก
+5. ลดหรือปิด spawn อีกตัว
+
+---
+
+# 7. Ecologics
+
+## Source
+
+```text
+https://www.curseforge.com/minecraft/mc-mods/ecologics
+```
+
+## Status
+
+```text
+CORE
+VANILLA+ ECOLOGY
+WORLDGEN TEST REQUIRED
+```
+
+## Role
+
+Ecologics ไม่ใช่ wildlife mod แบบตรง ๆ
+
+มันเติม:
+
+```text
+Biome detail
+Vegetation
+Environmental features
+Small wildlife
+Vanilla-like ecosystem content
+```
+
+หน้าที่คือทำให้โลกธรรมชาติดูสมบูรณ์ขึ้น
+
+โดยไม่ดึง visual identity ไปไกลจาก Minecraft
+
+---
+
+# 8. Ecology Philosophy
+
+Core principle:
+
+> Wildlife should make the world feel alive, not crowded.
+
+เป้าหมายไม่ใช่ maximize entity count
+
+ต้องการ:
+
+```text
+Forest
+→ Deer occasionally
+→ Birds frequently
+→ Small animals
+
+River
+→ Fish
+→ Otter / aquatic wildlife
+
+Plains
+→ Herd animals occasionally
+
+Coast
+→ Marine wildlife
+
+Remote Wilderness
+→ More natural wildlife
+```
+
+ไม่ต้องการ:
+
+```text
+เดิน 20 blocks
+→ Deer 8 ตัว
+→ Birds 20 ตัว
+→ Ferrets 6 ตัว
+→ Elephants 4 ตัว
+→ Monster 15 ตัว
+```
+
+---
+
+# 9. Natural vs Hostile Density
+
+Daytime ecosystem:
+
+```text
+Wildlife dominant
+Hostile mobs low
+```
+
+Night:
+
+```text
+Wildlife activity reduced where appropriate
+Hostile pressure increases
+```
+
+Deep Frontier:
+
+```text
+Normal wildlife
+↓
+gradually less predictable
+↓
+Anomalous creatures more common
+```
+
+Dragon territory:
+
+```text
+Normal wildlife density significantly reduced
+```
+
+Conceptually:
+
+```text
+Normal Region
+
+Wildlife: █████
+Monsters: ██
+Apex:     ░
+
+
+Frontier
+
+Wildlife: ████
+Monsters: ████
+Apex:     █
+
+
+Danger Zone
+
+Wildlife: ██
+Monsters: █████
+Apex:     ██
+
+
+Dragon Territory
+
+Wildlife: █
+Monsters: ███
+Dragon:   █████
+```
+
+Exact implementation depends on available spawn controls
+
+Do not invent config capabilities.
+
+---
+
+# 10. Relationship With Existing Threat Mods
+
+Existing threat stack:
+
+```text
+Vanilla Hostiles
+Born in Chaos
+The Hordes
+Enhanced AI
+Improved Mobs
+IceAndFire Community Edition
+In Control!
+```
+
+Wildlife mods must coexist with this stack.
+
+---
+
+# 11. Born in Chaos Relationship
+
+Born in Chaos represents:
+
+```text
+Anomalous / Corrupted / Horror Wildlife
+```
+
+Naturalist/Critters/Ecologics represent:
+
+```text
+Normal Ecology
+```
+
+Contrast is intentional.
+
+Example:
+
+```text
+Healthy Forest
+
+Birds
+Deer
+Small mammals
+
+↓
+
+Night falls
+
+↓
+
+Normal animal activity decreases
+
+↓
+
+Born in Chaos creature appears
+```
+
+That contrast is desirable.
+
+Do not make Born in Chaos spawn so densely that normal wildlife becomes irrelevant.
+
+---
+
+# 12. IceAndFire Relationship
+
+IceAndFire Community Edition represents:
+
+```text
+Mythical Wildlife
+Regional Predators
+Apex Creatures
+```
+
+Examples conceptually include:
+
+```text
+Troll
+Cyclops
+Sea Serpent
+Hydra
+Dragon
+```
+
+These should not behave like common wildlife.
+
+Natural wildlife should help communicate territorial danger.
+
+Example:
+
+```text
+Normal Forest
+
+many signs of wildlife
+
+↓
+
+Approaching Dragon Territory
+
+fewer animals
+
+↓
+
+burned terrain / destruction
+
+↓
+
+Dragon encounter
+```
+
+This is preferred environmental storytelling.
+
+---
+
+# 13. Dragon Territory Ecology
+
+If technically feasible through config/In Control/datapack:
+
+reduce normal animal spawning near areas associated with Dragon territories.
+
+Do not hard-code complicated integration in Alpha.
+
+Phase 1:
+
+```text
+Tune globally/by biome
+```
+
+Future:
+
+```text
+Regional ecosystem suppression
+```
+
+Possible desirable behavior:
+
+```text
+Dragon territory
+
+↓ Passive animals
+↓ Herd frequency
+↓ Ambient wildlife
+
+↑ Signs of danger
+```
+
+But only implement if technically reliable.
+
+---
+
+# 14. The Hordes Relationship
+
+Horde events must not permanently destroy wildlife ecology.
+
+Problem to avoid:
+
+```text
+Horde spawns
+↓
+kills every passive mob
+↓
+area remains biologically empty forever
+```
+
+Test:
+
+- Horde AI interaction with animals
+- Passive mob collateral deaths
+- Respawn rates
+- Long-term local population
+
+If wildlife is wiped too easily:
+
+adjust:
+
+```text
+Horde targeting
+spawn recovery
+animal density
+```
+
+using available configuration.
+
+---
+
+# 15. Enhanced AI / Improved Mobs
+
+Verify whether these mods affect passive animals.
+
+Desired:
+
+```text
+Enhanced hostile intelligence
+```
+
+Not:
+
+```text
+Every deer running expensive AI logic
+```
+
+Inspect exact entity/tag behavior.
+
+If passive entities are unnecessarily modified:
+
+exclude them where configurable.
+
+---
+
+# 16. In Control!
+
+In Control should eventually become the primary high-level spawn director for the pack where appropriate.
+
+Use it for:
+
+```text
+Spawn restrictions
+Biome rules
+Dimension rules
+Density management
+Threat zoning
+```
+
+But:
+
+> Do not assume configuration keys.
+
+Claude Code must inspect exact documentation/version being installed.
+
+No invented keys.
+
+---
+
+# 17. Spawn Budget
+
+Server performance is more important than having maximum wildlife density.
+
+Define an approximate conceptual budget:
+
+```text
+Passive Wildlife
++
+MineColonies NPCs
++
+Hostile Monsters
++
+Horde Entities
++
+Projectiles
++
+Create Contraptions
++
+Valkyrien Skies Physics
+```
+
+ทั้งหมดแชร์ CPU budget เดียวกัน
+
+Natural wildlife is the easiest layer to reduce when entity count becomes excessive.
+
+---
+
+# 18. Entity Density Priority
+
+If server performance is under pressure, reduce in this order:
+
+```text
+1. Ambient decorative wildlife density
+2. Small critter density
+3. Duplicate species
+4. Common passive animal density
+```
+
+Before reducing:
+
+```text
+Important hostile encounter design
+MineColonies core functionality
+Create systems
+```
+
+Wildlife must enhance the game
+
+not consume the server.
+
+---
+
+# 19. Spawn Cap Philosophy
+
+Avoid a world where passive mob cap is constantly saturated.
+
+Investigate:
+
+- Vanilla mob categories
+- Naturalist spawn categories
+- Critters spawn categories
+- Ecologics entities
+- Per-mod spawn configs
+- Biome modifiers
+
+Need to know whether mods share:
+
+```text
+CREATURE
+AMBIENT
+WATER_CREATURE
+WATER_AMBIENT
+```
+
+or use custom behavior.
+
+Do not guess.
+
+---
+
+# 20. Duplicate Species Audit
+
+Create:
+
+```text
+docs/wildlife-roster.md
+```
+
+Recommended table:
+
+```text
+Species / Role
+Source Mod
+Biome
+Spawn Weight
+Gameplay Role
+Overlap
+Decision
+```
+
+Example:
+
+```text
+Deer
+Naturalist
+Forest
+Medium
+Ambient / Food
+None
+KEEP
+```
+
+For duplicates:
+
+```text
+Duck
+Mod A
+Mod B
+
+↓
+
+Compare
+
+↓
+
+KEEP A
+REDUCE B
+```
+
+---
+
+# 21. Wildlife Roster Categories
+
+Classify all new animals into:
+
+## Ambient
+
+```text
+Birds
+Insects
+Small decorative animals
+```
+
+## Small Wildlife
+
+```text
+Ferrets
+Otters
+Small mammals
+```
+
+## Medium Wildlife
+
+```text
+Deer
+Boars
+Predators
+```
+
+## Large Wildlife
+
+```text
+Large mammals
+Large reptiles
+```
+
+## Aquatic
+
+```text
+Fish
+Marine mammals
+Aquatic reptiles
+```
+
+Purpose:
+
+easy spawn-budget management later.
+
+---
+
+# 22. Dangerous Normal Animals
+
+Not every dangerous creature needs to be supernatural.
+
+If Naturalist contains predators:
+
+allow them to remain dangerous.
+
+Examples conceptually:
+
+```text
+Bear
+Alligator
+Large predator
+```
+
+But damage must remain believable.
+
+Do not transform ordinary wildlife into bullet sponges.
+
+Example desired combat:
+
+```text
+Large predator
+→ dangerous at close range
+→ several rifle rounds
+→ dies normally
+```
+
+Not:
+
+```text
+Bear
+→ 80 rifle rounds
+```
+
+---
+
+# 23. Gun Interaction
+
+Main combat system:
+
+```text
+TaCZ
+```
+
+Wildlife must respond sensibly to firearms.
+
+Test:
+
+```text
+9mm
+5.56
+7.62
+Shotgun
+```
+
+against representative animals.
+
+Goal:
+
+Firearms should feel like firearms.
+
+Normal wildlife should generally have much lower TTK than:
+
+```text
+Born in Chaos elites
+IceAndFire creatures
+Dragons
+```
+
+---
+
+# 24. Attract to Sound Interaction
+
+Existing mod:
+
+```text
+Attract to Sound
+```
+
+Gunfire can attract monsters.
+
+Need to verify whether wildlife reacts to sound.
+
+Possible desirable future behavior:
+
+```text
+Gunshot
+↓
+Nearby wildlife flees
+↓
+Nearby monsters investigate
+```
+
+This would be excellent ecology behavior.
+
+But:
+
+```text
+DO NOT assume supported
+```
+
+If base mods do not support wildlife sound reactions:
+
+do not build custom system in Alpha.
+
+Document as future enhancement.
+
+---
+
+# 25. Hunting
+
+Wildlife naturally introduces hunting.
+
+Desired:
+
+```text
+Hunting = optional survival activity
+```
+
+Not:
+
+```text
+Mandatory grinding progression
+```
+
+Potential:
+
+- Meat
+- Leather
+- Food diversity
+- Early survival resources
+
+Farmer's Delight can provide downstream food usage if compatible.
+
+But agriculture must remain valuable.
+
+---
+
+# 26. Hunting vs Farming Balance
+
+Avoid:
+
+```text
+Hunting produces infinite superior food
+```
+
+or:
+
+```text
+Farming makes wildlife pointless
+```
+
+Ideal:
+
+```text
+Early Game
+Hunting useful
+
+Settlement
+Farming more reliable
+
+Industrial Civilization
+Agriculture becomes main supply
+
+Hunting remains exploration/survival option
+```
+
+This supports civilization progression.
+
+---
+
+# 27. No Trophy-Grind Focus
+
+Do not turn wildlife into:
+
+```text
+rare drop hunting
+legendary animal grind
+RPG loot farming
+```
+
+unless the mod itself requires minimal unavoidable mechanics.
+
+The pack is not Monster Hunter.
+
+---
+
+# 28. Animal Breeding
+
+Audit which added creatures can be:
+
+```text
+bred
+tamed
+domesticated
+```
+
+Prevent unintended economy exploits.
+
+Potential issue:
+
+```text
+Rare resource
+↓
+breed animal infinitely
+↓
+bypass industrial production
+```
+
+If discovered:
+
+adjust recipe/drop/breeding behavior with config/datapack/KubeJS where appropriate.
+
+---
+
+# 29. Companion Animals
+
+Critters and Companions may contain tameable animals.
+
+Keep if they provide:
+
+```text
+Atmosphere
+Companionship
+Minor utility
+```
+
+Avoid allowing companion animals to become:
+
+```text
+OP combat army
+infinite transport
+major logistics bypass
+```
+
+---
+
+# 30. Biome Identity
+
+Wildlife should reinforce biome identity.
+
+Example desired mapping:
+
+```text
+Forest
+→ deer / birds / forest wildlife
+
+River
+→ otters / aquatic creatures
+
+Wetlands
+→ reptiles / amphibious wildlife
+
+Savanna
+→ large grazing animals
+
+Ocean
+→ marine wildlife
+
+Cold regions
+→ cold-adapted wildlife
+```
+
+Exact animals must follow actual mod biome tags/config.
+
+Do not manually force inaccurate biome placement without reason.
+
+---
+
+# 31. Civilization Interaction
+
+As cities expand:
+
+```text
+Wilderness
+↓
+Farms
+↓
+Settlements
+↓
+Industrial City
+```
+
+animal distribution should naturally shift due to terrain/building activity where vanilla spawning mechanics already cause it.
+
+No need for complicated custom urban ecology simulation in Alpha.
+
+Potential emergent result:
+
+```text
+City Center
+→ almost no large wildlife
+
+Suburbs / farmland
+→ livestock/small wildlife
+
+Frontier
+→ full wildlife ecosystem
+```
+
+Perfectly acceptable.
+
+---
+
+# 32. MineColonies Interaction
+
+Test wildlife around MineColonies settlements.
+
+Potential issues:
+
+```text
+Animals blocking NPC paths
+NPC guards attacking harmless animals
+Farmers interacting unexpectedly
+Animal entities accumulating inside colony
+```
+
+Profile large colony + wildlife population.
+
+If necessary:
+
+reduce wildlife spawn around heavily populated chunks.
+
+Do not implement until measured.
+
+---
+
+# 33. Road / Railway Interaction
+
+Create rail network will cross wilderness.
+
+Wildlife near tracks is desirable aesthetically.
+
+However monitor:
+
+```text
+Animals standing on rails
+Train collision spam
+Entity accumulation
+Pathfinding around trains
+```
+
+Do not add artificial rail avoidance unless actual problem occurs.
+
+---
+
+# 34. Ecologics Worldgen
+
+Ecologics can affect environment/world generation.
+
+Before adding to existing production world:
+
+test:
+
+```text
+New world generation
+Biome transitions
+Structures/features
+Create resources
+TFMG resources
+Oil generation
+IceAndFire worldgen
+MineColonies
+```
+
+Primary concern:
+
+worldgen compatibility.
+
+---
+
+# 35. World Generation Rule
+
+Worldgen-affecting mods must be locked before public survival world begins where possible.
+
+Once pack enters persistent multiplayer:
+
+avoid removing worldgen content casually.
+
+Document exact version.
+
+---
+
+# 36. Implementation Strategy
+
+Preferred order:
+
+```text
+Config
+↓
+Datapack
+↓
+In Control
+↓
+KubeJS
+↓
+Custom Java compatibility code
+```
+
+Custom Java mod is last resort.
+
+---
+
+# 37. KubeJS Scope
+
+KubeJS may be used for:
+
+```text
+Recipe integration
+Drop adjustments
+Item cleanup
+Food integration
+Disabled items
+Tooltip clarification
+```
+
+Do not try to reproduce full mob AI/spawn systems in KubeJS unless absolutely necessary.
+
+---
+
+# 38. Phase W0 — Install & Registry Audit
+
+Install:
+
+```text
+Naturalist
+Critters and Companions
+Ecologics
+```
+
+Record:
+
+```text
+Exact version
+Dependencies
+Forge compatibility
+Client/server requirement
+Config locations
+Entity registry IDs
+Biome tags
+```
+
+Update:
+
+```text
+docs/compatibility-matrix.md
+```
+
+---
+
+# 39. Phase W1 — Basic Compatibility
+
+Create clean test world.
+
+Verify:
+
+```text
+Client boot
+Dedicated server boot
+World creation
+World reload
+Multiplayer join
+```
+
+No crashes.
+
+---
+
+# 40. Phase W2 — Wildlife Roster Audit
+
+Generate:
+
+```text
+docs/wildlife-roster.md
+```
+
+For every significant creature record:
+
+```text
+Entity ID
+Mod
+Biome
+Category
+Spawn behavior
+Hostile/Neutral/Passive
+Tameable
+Breedable
+Drops
+Overlap
+Decision
+```
+
+---
+
+# 41. Phase W3 — Spawn Baseline
+
+Observe multiple test regions:
+
+```text
+Forest
+Plains
+River
+Ocean
+Swamp/Wetland
+Cold biome
+Hot biome
+```
+
+Record:
+
+```text
+Passive entity count
+Species diversity
+Spawn frequency
+Visual density
+```
+
+No custom tuning yet.
+
+First measure defaults.
+
+---
+
+# 42. Phase W4 — Duplicate Cleanup
+
+Identify duplicated ecological roles.
+
+Decisions:
+
+```text
+KEEP
+REDUCE
+RARE
+DISABLE
+```
+
+Goal:
+
+each species should contribute something distinct.
+
+---
+
+# 43. Phase W5 — Threat Integration
+
+Install/test simultaneously with:
+
+```text
+Born in Chaos
+IceAndFire CE
+The Hordes
+Enhanced AI
+Improved Mobs
+In Control
+```
+
+Check:
+
+```text
+Passive vs hostile density
+Day/night balance
+Predator interactions
+Horde collateral
+Dragon-region behavior
+```
+
+---
+
+# 44. Phase W6 — Performance Test
+
+Representative scenario:
+
+```text
+MineColonies settlement
++
+50–100 wildlife entities
++
+Hostile mobs
++
+Create factory
++
+TaCZ gunfire
+```
+
+Measure:
+
+```text
+MSPT
+TPS
+Entity tick time
+Memory
+Client FPS
+```
+
+Use Spark or equivalent profiler already chosen for pack performance work.
+
+---
+
+# 45. Phase W7 — Density Tuning
+
+Only after profiling:
+
+adjust:
+
+```text
+Spawn weights
+Group sizes
+Biome restrictions
+Rare species
+Passive density
+```
+
+Do not randomly reduce every value.
+
+Tune based on measured population.
+
+---
+
+# 46. Phase W8 — Food / Drop Integration
+
+Test drops against:
+
+```text
+Farmer's Delight
+Vanilla food
+Existing farming
+```
+
+Prevent:
+
+```text
+duplicate meats
+useless items
+overpowered food
+```
+
+Where necessary:
+
+use tags/KubeJS recipes to unify equivalent resources.
+
+---
+
+# 47. Phase W9 — Persistent World Test
+
+Run long-term world simulation/playtest.
+
+Check after:
+
+```text
+10 Minecraft days
+25 Minecraft days
+50 Minecraft days
+```
+
+Questions:
+
+- Is wildlife still present?
+- Is one species dominating?
+- Are passive caps saturated?
+- Do Horde events wipe local ecology?
+- Are animals accumulating around cities?
+- Is server performance degrading?
+
+---
+
+# 48. Performance Budget
+
+Wildlife feature must remain subordinate to core gameplay.
+
+Core gameplay priority:
+
+```text
+Create
+Combat
+MineColonies
+Threats
+Infrastructure
+Logistics
+```
+
+Wildlife priority:
+
+```text
+Atmosphere
+Ecology
+Exploration
+```
+
+If wildlife costs too much performance:
+
+reduce wildlife.
+
+Never sacrifice core industrial systems just to keep 100 decorative animals loaded.
+
+---
+
+# 49. Recommended Density Philosophy
+
+Do not attempt exact values until testing.
+
+General rule:
+
+```text
+Small Ambient Creatures
+→ individually common
+→ small group sizes
+
+Medium Wildlife
+→ moderate
+
+Large Wildlife
+→ uncommon
+
+Large Exotic Wildlife
+→ rare
+```
+
+This creates scale.
+
+---
+
+# 50. Rare Encounter Principle
+
+Seeing a large animal should sometimes feel noteworthy.
+
+Example:
+
+```text
+Bird
+→ common
+
+Otter
+→ occasional
+
+Deer herd
+→ notable
+
+Large exotic animal
+→ memorable
+```
+
+Avoid every creature appearing within five minutes of spawn.
+
+---
+
+# 51. Safe Region Philosophy
+
+Spawn region should feel relatively natural and understandable.
+
+Preferred:
+
+```text
+Normal animals
+Vanilla threats
+A few weaker anomalies
+```
+
+Deep Frontier:
+
+```text
+More unusual threats
+More dangerous wildlife
+Mythical territorial creatures
+```
+
+This supports progression geographically.
+
+---
+
+# 52. Relationship With Seasons
+
+Main Pack has:
+
+```text
+Serene Seasons
+```
+
+Test whether wildlife behavior/spawn changes automatically.
+
+Do not assume integration.
+
+Future enhancement could include:
+
+```text
+Winter
+→ fewer insects
+→ reduced some wildlife activity
+
+Spring
+→ increased wildlife
+
+```
+
+but:
+
+```text
+OUT OF SCOPE FOR ALPHA
+```
+
+unless mods already provide it reliably.
+
+---
+
+# 53. Do Not Add Survival Tax
+
+Do not use wildlife expansion as excuse to add:
+
+```text
+hunger overhaul
+thirst
+disease
+parasites
+animal diseases
+butchering minigame
+```
+
+unless explicitly approved later.
+
+Wildlife should increase immersion, not micromanagement.
+
+---
+
+# 54. Approved Wildlife Stack
+
+Final approved stack:
+
+```text
+Naturalist
++
+Critters and Companions
++
+Ecologics
+```
+
+Optional / not approved for Core:
+
+```text
+Untamed Wilds
+Alex's Mobs
+```
+
+Do not install optional mods without explicit decision.
+
+---
+
+# 55. Definition of Done
+
+Natural Wildlife & Ecology addon is Alpha-ready when:
+
+- All three mods run on exact Minecraft 1.20.1 Forge environment.
+- Client launches.
+- Dedicated server launches.
+- New world generates correctly.
+- Major biomes contain appropriate wildlife.
+- No severe duplicate-species problem.
+- Passive population does not overwhelm mob caps.
+- Wildlife and Born in Chaos coexist correctly.
+- IceAndFire ecosystem is not overwhelmed by normal animals.
+- Horde events do not permanently destroy wildlife population.
+- MineColonies remains functional.
+- Create infrastructure remains performant.
+- TaCZ combat with normal animals feels believable.
+- No significant MSPT regression.
+- Mod versions/configs are pinned.
+- Wildlife roster is documented.
+
+---
+
+# 56. Claude Code Hard Rules
+
+## DO
+
+1. Verify exact Forge 1.20.1 builds.
+2. Pin exact versions.
+3. Inspect dependencies.
+4. Inspect entity registry IDs.
+5. Measure default spawn behavior before tuning.
+6. Build a wildlife roster.
+7. Test multiple biomes.
+8. Test dedicated server.
+9. Profile entity performance.
+10. Use config/datapack/In Control before custom Java.
+11. Keep wildlife density restrained.
+12. Preserve contrast between normal nature and supernatural threats.
+
+## DO NOT
+
+1. Do not add Alex's Mobs automatically.
+2. Do not add Untamed Wilds automatically.
+3. Do not install more animal mods just for species count.
+4. Do not assume configuration keys.
+5. Do not make normal animals bullet sponges.
+6. Do not make every large animal hostile.
+7. Do not turn wildlife into mandatory grind.
+8. Do not let passive entities saturate server capacity.
+9. Do not create custom AI systems before profiling.
+10. Do not remove species merely because similar names exist without comparing behavior first.
+11. Do not allow wildlife systems to replace farming/logistics progression.
+12. Do not sacrifice core server performance for ambient density.
+
+---
+
+# 57. Final Feature Definition
+
+> **Natural Wildlife & Ecology adds a believable layer of ordinary animals and environmental life to Industrial Civilization Survival, creating a living natural world against which anomalous monsters, hordes and dragons feel genuinely abnormal and threatening.**
+
+The purpose is not:
+
+```text
+More mobs = better
+```
+
+The purpose is:
+
+```text
+Normal ecosystem
+      +
+Dangerous frontier
+      +
+Industrial civilization
+      =
+A world worth living in
+and therefore worth defending
+```
+
+Final additions:
+
+```text
+Naturalist
+Critters and Companions
+Ecologics
+```
+
+Total:
+
+```text
+3 additional Core mods
+```

--- a/docs/OPEN-WORK-LEDGER.md
+++ b/docs/OPEN-WORK-LEDGER.md
@@ -10,8 +10,10 @@
 **Legend:** ✅ done, pending merge · 🟢 buildable now · 🟡 gated (needs merge / resource /
 decision) · 🔴 **UNTRACKED** (MD-only, no GitHub issue — highest miss-risk)
 
-**Current state, stated plainly:** the repo has its operating layer and its two design
-documents. It has **no pack** — no `pack.toml`, no mods, no config, no KubeJS.
+**Current state, stated plainly:** the repo has its operating layer and its three design
+documents. It has **no pack** — no `pack.toml`, no mods, no config, no KubeJS. The mod list now
+stands at the main pack plus 7 QoL mods (Track 3) plus 3 wildlife mods (Track 4), and none of
+them has been version-checked against a Create major yet.
 
 ---
 
@@ -19,7 +21,7 @@ documents. It has **no pack** — no `pack.toml`, no mods, no config, no KubeJS.
 
 | Item | Status | Gate | Next action |
 |---|---|---|---|
-| `docs/agents/issue-tracker.md` + `docs/agents/triage-labels.md` | 🔴 | `/setup-matt-pocock-skills` is user-invocation-only — an agent cannot write these | Developer runs `/setup-matt-pocock-skills` in this repo, then the T4 delta (Component / Type / Severity groups) is appended |
+| `docs/agents/issue-tracker.md` + `docs/agents/triage-labels.md` + `reading-domain-docs.md` | ✅ | — | Developer ran `/setup-matt-pocock-skills`; output landed with the T4 delta appended (**#3**). Consumer rules went to `reading-domain-docs.md` so the glossary at `domain.md` survived |
 | Triage labels created on the GitHub repo | ✅ | — | 23 created, 2 already existed, 0 failed. `bug` renamed to `Bug` to match the vocabulary |
 | `git config core.hooksPath .githooks` on this clone | 🔴 | developer action, per-clone by design | Run it once; verify with `git config --get core.hooksPath` |
 | `T4 main gate` ruleset — PR-only, no force-push, no deletion | ✅ | — | Active. Direct pushes to `main` are blocked |
@@ -54,25 +56,46 @@ main pack. Not yet folded into the §24 phase list — where each lands is itsel
 |---|---|---|---|
 | JEI + Jade + Jade Addons + Crafting Tweaks + Mouse Tweaks + Polymorph | 🔴 | main pack must boot first | Decide which §24 phase each belongs to; they are QoL, so they follow the systems they describe |
 | Player Microchip re-themed as the tactical tracker | 🔴 | needs the Curios + radio layers to exist | Addon Spec §17–29; the re-theme is a resource-pack + KubeJS job, not a fork |
-| Hide disabled content from JEI | 🔴 | needs KubeJS + a decided mod list | Addon Spec §6 — must stay in sync with every mod removal |
+| Hide disabled content from JEI | 🔴 | needs KubeJS + a decided mod list | Crafting Spec §6 — must stay in sync with every mod removal |
+
+## Track 4 — Addon Spec (Natural Wildlife & Ecology)
+
+Source: `docs/Addon Spec — Natural Wildlife & Ecology.md`. Three CORE mods and a phase list of
+its own, W0–W9, gated behind the main pack. Folded into the operating layer under **#4**; the
+implementation work below is not started.
+
+| Item | Status | Gate | Next action |
+|---|---|---|---|
+| Naturalist + Critters and Companions + Ecologics | 🔴 | main pack must boot first | Wildlife Spec W0 — install, then dump the entity registry before touching a single spawn value |
+| `docs/wildlife-roster.md` + duplicate species audit | 🔴 | W0 registry dump | Wildlife Spec W2/W4 — compare **behaviour**, not names, before any KEEP / REDUCE call |
+| Spawn baseline + density tuning | 🔴 | must follow a profiling run, never precede it | Wildlife Spec W3/W6/W7 — *"Do not randomly reduce every value. Tune based on measured population."* |
+| Threat-layer coexistence (Born in Chaos, Ice & Fire, The Hordes) | 🔴 | needs the threat layer to exist | Wildlife Spec W5 — a Horde must not permanently wipe local ecology |
+| Serene Seasons interaction | 🔴 | out of scope for Alpha unless the mods already provide it | Wildlife Spec §52 — test, do not assume integration |
+
+**Standing constraint from this spec, applies outside Track 4:** under performance pressure the
+reduction order is ambient → small critters → duplicate species → common passives, and Create /
+MineColonies / hostile encounter design are cut **last**. Any future tuning session inherits this.
 
 ---
 
 ## Management Plan — phased execution order
 
 **Phase 0 — Unblock the tooling.** Resolve the GitHub Actions billing lock (**#1**), install
-`packwiz` and a Java 17 JDK, run `git config core.hooksPath .githooks`, and run
-`/setup-matt-pocock-skills`. Five small actions, and most of Track 0 plus two rows in Track 1
-depend on them. Only #1 needs money; the rest are minutes.
+`packwiz` and a Java 17 JDK, and run `git config core.hooksPath .githooks`. Three actions; only
+#1 needs money, the rest are minutes. `/setup-matt-pocock-skills` is done.
 
 **Phase 1 — Tracking hygiene.** File a GitHub issue for every remaining 🔴 row above, so the
 ledger stops being the only record. The triage label vocabulary is already installed.
 
 **Phase 2 — Resolve the Create version.** This is the multiplier. Every mod pin, every KubeJS
 recipe, and the entire Season 2 branch are downstream of it, and it is answerable today with
-research alone — no game launch required.
+research alone — no game launch required. **Scope it to all three documents at once:** the
+Crafting and Wildlife specs add 10 more mods, and sweeping them separately means doing the same
+CurseForge / Modrinth pass three times and reconciling three partial answers.
 
-**Phase 3 onward — the §24 phase list**, one phase per epic, one PRD per phase.
+**Phase 3 onward — the §24 phase list**, one phase per epic, one PRD per phase. The addon specs'
+own phases (Crafting Spec, and Wildlife Spec W0–W9) slot in behind the main-pack phase they
+depend on; deciding where each lands is itself open work in Tracks 3 and 4.
 
 **Gating summary:** Phase 2 is the multiplier and it is *not* blocked by Phase 0 — the version
 sweep needs only network access. Phase 0 and Phase 2 can run in parallel; everything after

--- a/docs/OPEN-WORK-LEDGER.md
+++ b/docs/OPEN-WORK-LEDGER.md
@@ -10,9 +10,8 @@
 **Legend:** ✅ done, pending merge · 🟢 buildable now · 🟡 gated (needs merge / resource /
 decision) · 🔴 **UNTRACKED** (MD-only, no GitHub issue — highest miss-risk)
 
-**Current state, stated plainly:** the repo has its operating layer and its design document.
-It has **no pack** — no `pack.toml`, no mods, no config, no KubeJS. Every row below is 🔴
-because no issues have been filed yet; Phase 1 fixes that.
+**Current state, stated plainly:** the repo has its operating layer and its two design
+documents. It has **no pack** — no `pack.toml`, no mods, no config, no KubeJS.
 
 ---
 
@@ -21,9 +20,10 @@ because no issues have been filed yet; Phase 1 fixes that.
 | Item | Status | Gate | Next action |
 |---|---|---|---|
 | `docs/agents/issue-tracker.md` + `docs/agents/triage-labels.md` | 🔴 | `/setup-matt-pocock-skills` is user-invocation-only — an agent cannot write these | Developer runs `/setup-matt-pocock-skills` in this repo, then the T4 delta (Component / Type / Severity groups) is appended |
-| Triage labels created on the GitHub repo | 🔴 | needs the repo to exist | `gh label create` for the five canonical roles + the T4 groups; report created / already-there / skipped |
+| Triage labels created on the GitHub repo | ✅ | — | 23 created, 2 already existed, 0 failed. `bug` renamed to `Bug` to match the vocabulary |
 | `git config core.hooksPath .githooks` on this clone | 🔴 | developer action, per-clone by design | Run it once; verify with `git config --get core.hooksPath` |
-| Branch ruleset on `main` (`lint`, `test`, `guards` required; direct push blocked) | 🔴 | the checks must run once before they are selectable | Push, let the workflow run, then create the ruleset |
+| `T4 main gate` ruleset — PR-only, no force-push, no deletion | ✅ | — | Active. Direct pushes to `main` are blocked |
+| `lint` / `test` / `guards` as **required status checks** | 🟡 | **#1** — GitHub Actions is billing-locked, so no check can ever report | Resolve the billing lock, confirm a green run, then add the three contexts to the ruleset |
 
 ## Track 1 — Blocking technical unknown
 
@@ -60,12 +60,13 @@ main pack. Not yet folded into the §24 phase list — where each lands is itsel
 
 ## Management Plan — phased execution order
 
-**Phase 0 — Unblock the tooling.** Install `packwiz` and a Java 17 JDK, run
-`git config core.hooksPath .githooks`, and run `/setup-matt-pocock-skills`. Four small actions,
-and three of the four rows in Track 0 plus two in Track 1 depend on them.
+**Phase 0 — Unblock the tooling.** Resolve the GitHub Actions billing lock (**#1**), install
+`packwiz` and a Java 17 JDK, run `git config core.hooksPath .githooks`, and run
+`/setup-matt-pocock-skills`. Five small actions, and most of Track 0 plus two rows in Track 1
+depend on them. Only #1 needs money; the rest are minutes.
 
-**Phase 1 — Tracking hygiene.** File a GitHub issue for every 🔴 row above, so the ledger stops
-being the only record. Create the triage labels first, since the issues need them.
+**Phase 1 — Tracking hygiene.** File a GitHub issue for every remaining 🔴 row above, so the
+ledger stops being the only record. The triage label vocabulary is already installed.
 
 **Phase 2 — Resolve the Create version.** This is the multiplier. Every mod pin, every KubeJS
 recipe, and the entire Season 2 branch are downstream of it, and it is answerable today with

--- a/docs/adr/0001-ci-gate-scoped-to-modpack-reality.md
+++ b/docs/adr/0001-ci-gate-scoped-to-modpack-reality.md
@@ -92,3 +92,25 @@ grows.
 
 - **Follow-ups:** add the `build` job and the `{ "context": "build" }` ruleset entry in the
   commit that introduces `pack.toml`. Revisit the TOML checker if it produces a false positive.
+
+## Postscript — the gate is armed, the checks are not (2026-08-25)
+
+Discovered immediately after the first push, and recorded here rather than in a second ADR
+because it does not overturn the decision above — it delays half of it.
+
+**GitHub Actions cannot run on this account** ([run 32779529796](https://github.com/xenodeve/minecraft-100day/actions/runs/32779529796)):
+*"The job was not started because your account is locked due to a billing issue."* Both jobs
+reported failure without executing a single step.
+
+So the `T4 main gate` ruleset was created **without** `required_status_checks`. It still blocks
+direct pushes to `main`, force-pushes, branch deletion, and merging with unresolved review
+threads — the parts that do not depend on a check reporting. `.claude/t4.json`
+`"requireGreenCI"` stays `false`, because with no CI at all `gh pr checks` reports non-zero and
+would deny every merge.
+
+Adding the required checks now would have been worse than omitting them: every PR would sit on
+*"Expected — waiting for status"* forever, and the first person who needs to land a PR disables
+the rule. A rule disabled once stays disabled, which is the exact failure this ADR set out to
+avoid.
+
+**Tracked as #1.** The decision above is unchanged; only its third tier is pending.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -60,6 +60,21 @@ Every mod in the master list carries exactly one status. These are the words use
 | **Outpost** | A remote holding connected by rail or road, reachable only by travelling. Nothing in this pack teleports. | "waypoint", "base 2" |
 | **Grid** | The city electrical hierarchy: Power Plant → HV → Substation → MV → Transformer → LV (§13). Immersive Engineering owns the grid; it does not own manufacturing. | "power network", "RF system" |
 
+## Wildlife & ecology
+
+From `docs/Addon Spec — Natural Wildlife & Ecology.md`. The layer exists so that monsters read as
+*abnormal*; a world of only zombies and dragons makes monsters ordinary.
+
+| Term | Definition | Aliases to avoid |
+|------|-----------|-----------------|
+| **Natural world** / **Anomalous world** | The contrast the wildlife layer exists to create. Deer, birds, fish and livestock are the baseline against which Born in Chaos and Ice & Fire read as wrong. Wildlife is atmosphere, never a threat tier. | "passive mobs" (that is a spawn category, not this) |
+| **Spawn Budget** | The single shared CPU budget that passive wildlife, MineColonies NPCs, hostile mobs, Horde entities, projectiles, Create contraptions and VS2 physics all draw from. Wildlife is the cheapest layer to cut, so it is the first one cut. | "entity limit", "mob cap" (the vanilla cap is one input to this, not the same thing) |
+| **Entity Density Priority** | The fixed order in which density is reduced under performance pressure: ambient decorative → small critters → duplicate species → common passive animals. Create, MineColonies and hostile encounter design are reduced **last**, and only deliberately. | "performance tuning" |
+| **Duplicate Species Audit** | The comparison pass over species that two mods both provide. Output is `docs/wildlife-roster.md` with a KEEP / REDUCE decision per row. Behaviour is compared before anything is cut — a shared name is not evidence of overlap. | "removing duplicates" |
+| **Wildlife Roster** | `docs/wildlife-roster.md`. Columns: Species/Role · Source Mod · Biome · Spawn Weight · Gameplay Role · Overlap · Decision. Like the compatibility matrix, it records what was **observed in a registry dump**, not what a mod page claims. | "animal list" |
+| **Survival tax** | An anti-pattern, never a feature. Thirst, disease, parasites, hunger overhauls and butchering minigames are out of scope — wildlife raises immersion, not micromanagement (§53). | "realism", "hardcore survival" |
+| **W-phase** | The wildlife addon's own phase list, W0–W9, separate from the main §24 phases and gated behind them. Cite as *Wildlife Spec W3*, never as a bare number. | "phase 3" (ambiguous with §24) |
+
 ## Process
 
 | Term | Definition | Aliases to avoid |
@@ -129,6 +144,21 @@ PR description, comment ใน config, identifier ของ KubeJS และใ�
 | **Frontier** | ดินแดนที่พ้นรัศมีปลอดภัยของนิคม ความอันตรายขึ้นกับระยะทางที่เดินทางและจำนวนวันที่รอดมา ไม่ใช่กฎตามปฏิทิน | "พื้นที่ endgame" |
 | **Outpost** | ที่มั่นห่างไกลที่เชื่อมด้วยรางหรือถนน ไปถึงได้ด้วยการเดินทางเท่านั้น ไม่มีอะไรใน pack นี้ที่ teleport ได้ | "waypoint", "ฐานสอง" |
 | **Grid** | ลำดับชั้นไฟฟ้าของเมือง: Power Plant → HV → Substation → MV → Transformer → LV (§13) Immersive Engineering เป็นเจ้าของ Grid แต่ไม่ได้เป็นเจ้าของการผลิต | "power network", "ระบบ RF" |
+
+## สัตว์ป่าและระบบนิเวศ
+
+มาจาก `docs/Addon Spec — Natural Wildlife & Ecology.md` ชั้นนี้มีอยู่เพื่อให้สัตว์ประหลาดอ่านออกว่า
+*ผิดธรรมชาติ* โลกที่มีแต่ zombie กับมังกรจะทำให้สัตว์ประหลาดกลายเป็นเรื่องปกติ
+
+| คำ | ความหมาย | ห้ามใช้ |
+|------|-----------|-----------------|
+| **Natural world** / **Anomalous world** | ความต่างที่ชั้นสัตว์ป่ามีอยู่เพื่อสร้างขึ้น กวาง นก ปลา และปศุสัตว์คือเส้นฐานที่ทำให้ Born in Chaos และ Ice & Fire อ่านออกว่าผิดปกติ สัตว์ป่าคือบรรยากาศ ไม่เคยเป็น threat tier | "passive mob" (นั่นคือ spawn category ไม่ใช่สิ่งนี้) |
+| **Spawn Budget** | งบ CPU ก้อนเดียวที่สัตว์ป่า, NPC ของ MineColonies, mob ศัตรู, entity ของ Horde, กระสุน, contraption ของ Create และ physics ของ VS2 แย่งกันใช้ สัตว์ป่าเป็นชั้นที่ตัดถูกที่สุด จึงเป็นชั้นแรกที่ถูกตัด | "entity limit", "mob cap" (cap ของ vanilla เป็นแค่หนึ่งใน input ไม่ใช่สิ่งเดียวกัน) |
+| **Entity Density Priority** | ลำดับตายตัวของการลดความหนาแน่นเมื่อ performance ตึง: ambient ประดับ → critter เล็ก → สปีชีส์ซ้ำ → สัตว์ passive ทั่วไป ส่วน Create, MineColonies และการออกแบบการปะทะกับศัตรูถูกลด**เป็นลำดับสุดท้าย** และต้องตั้งใจเท่านั้น | "การจูน performance" |
+| **Duplicate Species Audit** | รอบการเปรียบเทียบสปีชีส์ที่ mod สองตัวมีเหมือนกัน ผลลัพธ์คือ `docs/wildlife-roster.md` ที่มีคำตัดสิน KEEP / REDUCE รายแถว ต้องเทียบพฤติกรรมก่อนตัดอะไรทิ้ง — ชื่อที่ซ้ำกันไม่ใช่หลักฐานว่าทับซ้อนกัน | "ลบตัวซ้ำ" |
+| **Wildlife Roster** | `docs/wildlife-roster.md` คอลัมน์: Species/Role · Source Mod · Biome · Spawn Weight · Gameplay Role · Overlap · Decision เหมือน compatibility matrix มันบันทึกสิ่งที่**สังเกตได้จาก registry dump** ไม่ใช่สิ่งที่หน้าเว็บของ mod อ้าง | "ลิสต์สัตว์" |
+| **Survival tax** | เป็น anti-pattern ไม่เคยเป็น feature ความกระหายน้ำ โรค ปรสิต การรื้อระบบความหิว และมินิเกมชำแหละ อยู่นอกขอบเขต — สัตว์ป่าเพิ่มความสมจริง ไม่ใช่เพิ่มงานจุกจิก (§53) | "ความสมจริง", "hardcore survival" |
+| **W-phase** | phase list ของ addon สัตว์ป่าเอง คือ W0–W9 แยกจาก phase §24 ของ pack หลักและถูก gate ไว้ข้างหลัง อ้างอิงเป็น *Wildlife Spec W3* ห้ามอ้างเป็นตัวเลขเปล่า | "phase 3" (กำกวมกับ §24) |
 
 ## กระบวนการ
 

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,209 @@
+<!-- lang:en -->
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues on `xenodeve/minecraft-100day`. Use the `gh`
+CLI for all operations.
+
+> **`gh` path and auth.** `gh` is installed but **not on the shell PATH**. Call it as
+> `"/c/Program Files/GitHub CLI/gh.exe"` (v2.95.0). Authenticated as `xenodeve`; token scopes
+> include `repo` and `workflow`. `command -v gh` returns nothing — that is expected and does not
+> mean gh is missing. See `Obsidian-minecraft-100day/dev-machine-tooling.md`.
+
+## Language: bilingual bodies (English + Thai)
+
+Every issue body, PRD body, and PR description must be **bilingual**:
+
+- **Title**: English, conventional-commit style — e.g. `fix(combat): …`, `chore(pack-infra): …`.
+  The scope is normally the Component label.
+- **Body**: each section in English, then a mirrored Thai version — a `## สรุปภาษาไทย` section
+  covering the whole body, or `EN / TH` paired sections for long documents.
+- **The Thai must mirror the English exactly** — same detail, same sentence count, same bullets,
+  same tables. "สรุป" is not a summary; never shorten or omit.
+- Code identifiers, filenames, log excerpts, mod names, and acceptance-criteria checkboxes stay
+  English; the Thai explains them, never translates them.
+- **Review-reply comments may be English-only.** Anything a teammate reads in order to *decide*
+  gets both languages.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body-file <file>`. Use a file rather than
+  `--body` for anything multi-line — bilingual bodies contain characters that do not survive
+  shell quoting well.
+- **Read an issue**: `gh issue view <n> --comments`.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'`, with
+  `--label` and `--state` filters as needed.
+- **Comment**: `gh issue comment <n> --body-file <file>`.
+- **Apply / remove labels**: `gh issue edit <n> --add-label "..."` / `--remove-label "..."`.
+- **Close, always with a reason**: `gh issue close <n> --comment "<reason + evidence>"`. Valid
+  reasons: completed-with-evidence · cancelled · duplicate · wontfix · stale. Never close
+  silently, and never leave finished work open.
+
+`gh` infers the repo from `git remote -v` when run inside the clone.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** *(Set to `yes` if this repo starts treating external PRs as
+feature requests; `/triage` reads this flag.)*
+
+When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr`
+equivalents:
+
+- **Read a PR**: `gh pr view <n> --comments`, and `gh pr diff <n>` for the diff.
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments`,
+  then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE`
+  (drop `OWNER` / `MEMBER` / `COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label` / `--remove-label`,
+  `gh pr close`.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either — resolve
+with `gh pr view 42` and fall back to `gh issue view 42`.
+
+## Merge gate
+
+`main` is protected by the `T4 main gate` ruleset: direct pushes are blocked, `main` cannot be
+force-pushed or deleted, and an unresolved review thread blocks merge. **Required status checks
+are deliberately absent** while GitHub Actions is billing-locked — see #1 and
+`docs/adr/0001-ci-gate-scoped-to-modpack-reality.md`. Do not add them until a run goes green.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <n> --comments`.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
+
+- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog
+  body. `gh issue create --label wayfinder:map`.
+- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues
+  endpoint). Where sub-issues are not enabled, add the child to a task list in the map body and
+  put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>`
+  (`research` / `prototype` / `grilling` / `task`). Once claimed, the ticket is assigned to the
+  driving dev.
+- **Blocking**: GitHub's **native issue dependencies**. Add an edge with
+  `gh api --method POST repos/xenodeve/minecraft-100day/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`,
+  where `<blocker-db-id>` is the blocker's numeric **database id**
+  (`gh api repos/xenodeve/minecraft-100day/issues/<n> --jq .id` — *not* the `#number` or
+  `node_id`). GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only). Where
+  dependencies are unavailable, fall back to a `Blocked by: #<n>, #<n>` line at the top of the
+  child body. A ticket is unblocked when every blocker is closed.
+- **Frontier query**: list the map's open children, drop any with an open blocker
+  (`issue_dependencies_summary.blocked_by > 0`) or an assignee; first in map order wins.
+- **Claim**: `gh issue edit <n> --add-assignee @me` — the session's first write.
+- **Resolve**: `gh issue comment <n>`, then `gh issue close <n>`, then append a context pointer
+  to the map's Decisions-so-far.
+
+## Labels for wayfinding
+
+The `wayfinder:*` labels above are **not created yet** — this repo has not used `/wayfinder`.
+Create them with `gh label create` at first use rather than pre-creating a vocabulary nothing
+applies. See `docs/agents/triage-labels.md` for the labels that *do* exist.
+<!-- lang:end -->
+
+<!-- lang:th -->
+# Issue tracker: GitHub — ภาษาไทย
+
+Issue และ PRD ของ repo นี้อยู่ในรูปของ GitHub issue บน `xenodeve/minecraft-100day` ใช้ `gh` CLI
+สำหรับทุกการทำงาน
+
+> **path และ auth ของ `gh`** `gh` ติดตั้งแล้วแต่ **ไม่อยู่ใน PATH ของ shell** ให้เรียกเป็น
+> `"/c/Program Files/GitHub CLI/gh.exe"` (v2.95.0) login ในชื่อ `xenodeve` scope ของ token
+> มี `repo` และ `workflow` `command -v gh` จะไม่คืนอะไร — นั่นเป็นเรื่องปกติและไม่ได้แปลว่า
+> gh หายไป ดู `Obsidian-minecraft-100day/dev-machine-tooling.md`
+
+## ภาษา: body สองภาษา (อังกฤษ + ไทย)
+
+ทุก issue body, PRD body และ PR description ต้องเป็น **สองภาษา**:
+
+- **หัวข้อ**: อังกฤษ สไตล์ conventional-commit เช่น `fix(combat): …`, `chore(pack-infra): …`
+  โดยปกติ scope คือ Component label
+- **เนื้อหา**: แต่ละหัวข้อเป็นอังกฤษ แล้วตามด้วยฉบับไทยที่สะท้อนกัน — จะเป็นหัวข้อ
+  `## สรุปภาษาไทย` ที่ครอบทั้ง body หรือจับคู่ `EN / TH` รายหัวข้อสำหรับเอกสารยาวก็ได้
+- **ภาษาไทยต้องสะท้อนภาษาอังกฤษเป๊ะ ๆ** — รายละเอียดเท่ากัน จำนวนประโยคเท่ากัน bullet เท่ากัน
+  ตารางเท่ากัน "สรุป" ไม่ได้แปลว่าย่อ ห้ามตัดทอนหรือละ
+- Code identifier, ชื่อไฟล์, ท่อน log, ชื่อ mod และ checkbox ของ acceptance criteria คงเป็น
+  ภาษาอังกฤษ ภาษาไทยอธิบายรอบ ๆ มัน ไม่ใช่แปลมัน
+- **comment ที่ตอบ review เป็นอังกฤษอย่างเดียวได้** สิ่งใดที่เพื่อนร่วมทีมอ่านเพื่อ*ตัดสินใจ*
+  ต้องมีสองภาษา
+
+## ธรรมเนียมการใช้งาน
+
+- **สร้าง issue**: `gh issue create --title "..." --body-file <file>` ใช้ไฟล์แทน `--body`
+  สำหรับอะไรที่หลายบรรทัด — body สองภาษามีอักขระที่ผ่านการ quote ของ shell ได้ไม่ดี
+- **อ่าน issue**: `gh issue view <n> --comments`
+- **ลิสต์ issue**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'`
+  พร้อม `--label` และ `--state` ตามต้องการ
+- **comment**: `gh issue comment <n> --body-file <file>`
+- **ใส่ / ถอด label**: `gh issue edit <n> --add-label "..."` / `--remove-label "..."`
+- **ปิดพร้อมเหตุผลเสมอ**: `gh issue close <n> --comment "<เหตุผล + หลักฐาน>"` เหตุผลที่ใช้ได้:
+  completed-with-evidence · cancelled · duplicate · wontfix · stale ห้ามปิดเงียบ ๆ และห้ามปล่อย
+  งานที่เสร็จแล้วเปิดค้างไว้
+
+`gh` เดา repo จาก `git remote -v` ให้เองเมื่อรันอยู่ใน clone
+
+## Pull request ในฐานะช่องทาง triage
+
+**PR เป็นช่องทางรับคำขอ: ไม่** *(ตั้งเป็น `yes` ถ้า repo นี้เริ่มถือว่า PR จากภายนอกคือคำขอ
+feature; `/triage` อ่าน flag นี้)*
+
+เมื่อตั้งเป็น `yes` PR จะเดินผ่าน label และสถานะชุดเดียวกับ issue โดยใช้คำสั่ง `gh pr` ที่เทียบเท่า:
+
+- **อ่าน PR**: `gh pr view <n> --comments` และ `gh pr diff <n>` สำหรับดู diff
+- **ลิสต์ PR จากภายนอกเพื่อ triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments`
+  แล้วเก็บเฉพาะ `authorAssociation` ที่เป็น `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR` หรือ `NONE`
+  (ตัด `OWNER` / `MEMBER` / `COLLABORATOR` ออก)
+- **comment / label / close**: `gh pr comment`, `gh pr edit --add-label` / `--remove-label`,
+  `gh pr close`
+
+GitHub ใช้เลขชุดเดียวกันทั้ง issue และ PR ดังนั้น `#42` เปล่า ๆ อาจเป็นอย่างใดอย่างหนึ่ง —
+แก้ด้วยการลอง `gh pr view 42` ก่อน แล้วค่อยตกไปที่ `gh issue view 42`
+
+## ด่านก่อน merge
+
+`main` ถูกป้องกันด้วย ruleset `T4 main gate`: push ตรงถูกบล็อก `main` ถูก force-push หรือลบไม่ได้
+และ review thread ที่ยังไม่ resolve จะบล็อกการ merge **required status checks ไม่ถูกใส่ไว้โดย
+ตั้งใจ** ในขณะที่ GitHub Actions ยังถูกล็อกเรื่อง billing — ดู #1 และ
+`docs/adr/0001-ci-gate-scoped-to-modpack-reality.md` ห้ามใส่จนกว่าจะมี run ที่เขียว
+
+## เมื่อ skill บอกว่า "publish to the issue tracker"
+
+ให้สร้าง GitHub issue
+
+## เมื่อ skill บอกว่า "fetch the relevant ticket"
+
+ให้รัน `gh issue view <n> --comments`
+
+## การทำงานแบบ wayfinding
+
+ใช้โดย `/wayfinder` ตัว **map** คือ issue เดียวที่มี issue **ลูก** เป็น ticket
+
+- **Map**: issue เดียวที่ติด label `wayfinder:map` เก็บเนื้อหา Notes / Decisions-so-far / Fog
+  สร้างด้วย `gh issue create --label wayfinder:map`
+- **Ticket ลูก**: issue ที่ผูกกับ map ในฐานะ sub-issue ของ GitHub (`gh api` ที่ endpoint
+  sub-issues) ถ้าใช้ sub-issue ไม่ได้ ให้เพิ่มลูกลงใน task list ใน body ของ map แล้วใส่
+  `Part of #<map>` ไว้บนสุดของ body ลูก label: `wayfinder:<type>`
+  (`research` / `prototype` / `grilling` / `task`) เมื่อมีคนรับงานแล้ว ticket จะถูก assign ให้
+  dev ที่ขับงานนั้น
+- **การบล็อก**: ใช้ **native issue dependencies** ของ GitHub เพิ่มเส้นด้วย
+  `gh api --method POST repos/xenodeve/minecraft-100day/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`
+  โดย `<blocker-db-id>` คือ **database id** ที่เป็นตัวเลขของตัวบล็อก
+  (`gh api repos/xenodeve/minecraft-100day/issues/<n> --jq .id` — *ไม่ใช่* `#number` หรือ
+  `node_id`) GitHub รายงานผ่าน `issue_dependencies_summary.blocked_by` (นับเฉพาะตัวบล็อกที่ยัง
+  เปิดอยู่) ถ้าใช้ dependencies ไม่ได้ ให้ตกไปใช้บรรทัด `Blocked by: #<n>, #<n>` บนสุดของ body
+  ลูก ticket จะหลุดบล็อกเมื่อตัวบล็อกทุกตัวถูกปิด
+- **Frontier query**: ลิสต์ลูกที่ยังเปิดของ map ตัดตัวที่มีตัวบล็อกเปิดอยู่
+  (`issue_dependencies_summary.blocked_by > 0`) หรือมีคน assign แล้วออก ตัวแรกตามลำดับใน map ชนะ
+- **รับงาน**: `gh issue edit <n> --add-assignee @me` — เป็นการเขียนครั้งแรกของเซสชัน
+- **ปิดงาน**: `gh issue comment <n>` แล้ว `gh issue close <n>` แล้วต่อท้าย pointer ของบริบทลงใน
+  Decisions-so-far ของ map
+
+## Label สำหรับ wayfinding
+
+label `wayfinder:*` ข้างบน **ยังไม่ถูกสร้าง** — repo นี้ยังไม่เคยใช้ `/wayfinder` ให้สร้างด้วย
+`gh label create` ตอนใช้ครั้งแรก แทนที่จะสร้าง vocabulary ล่วงหน้าที่ไม่มีอะไรไปติดมัน ดู label
+ที่*มีอยู่จริง*ได้ที่ `docs/agents/triage-labels.md`
+<!-- lang:end -->

--- a/docs/agents/reading-domain-docs.md
+++ b/docs/agents/reading-domain-docs.md
@@ -1,0 +1,155 @@
+<!-- lang:en -->
+# Reading Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring.
+
+> **Why this file is not called `domain.md`.** `/setup-matt-pocock-skills` writes these consumer
+> rules to `docs/agents/domain.md`. In this repo that path already holds the **domain glossary** —
+> a different document that happens to share the filename. They live side by side:
+>
+> - **`docs/agents/domain.md`** — *what the words mean here*. The glossary.
+> - **`docs/agents/reading-domain-docs.md`** — *which files to read, and when*. This file.
+>
+> Reported upstream as [xenodeve/xeno-skills#334](https://github.com/xenodeve/xeno-skills/issues/334).
+
+## Before exploring, read these
+
+- **`docs/agents/domain.md`** — the canonical glossary for this repo. This is the one that
+  actually exists; read it first.
+- **`CONTEXT.md`** at the repo root — **does not exist yet**, and that is deliberate. The Seed
+  tier defers it until a bounded context is worth writing down. If it appears later it becomes
+  the system-context doc and defers to the glossary on any conflict.
+- **`docs/adr/`** — read the ADRs that touch the area you are about to work in, before proposing
+  an alternative. The index is `docs/adr/README.md`.
+- **The design documents** — for a modpack, intent lives in prose, not in code:
+  - `docs/Industrial Civilization Survival — Claude Code Handoff & Implementation Plan.md`
+  - `docs/Addon Spec — Crafting Assistance + Tactical Tracker.md`
+  - `docs/Addon Spec — Natural Wildlife & Ecology.md`
+
+If any of these do not exist, **proceed silently**. Do not flag their absence; do not suggest
+creating them upfront. They are created lazily, when a term or a decision actually resolves.
+
+## File structure
+
+Single-context repo — one glossary and one ADR directory for the whole repo:
+
+```
+/
+├── docs/
+│   ├── agents/
+│   │   ├── domain.md               ← the glossary
+│   │   └── reading-domain-docs.md  ← this file
+│   ├── adr/
+│   │   ├── README.md
+│   │   └── 0001-ci-gate-scoped-to-modpack-reality.md
+│   └── <the design documents>
+└── (config/, kubejs/, datapacks/ — created by the pack work, not yet present)
+```
+
+There is no `CONTEXT-MAP.md`, and no reason to expect one: a modpack is a single bounded context
+by nature. Revisit only if the repo ever gains a genuinely separate second deliverable — a
+Season 2 pack maintained in parallel would be the plausible case.
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept — an issue title, a refactor proposal, a hypothesis, a
+config comment, a KubeJS identifier — use the term exactly as `docs/agents/domain.md` defines it.
+Do not drift to a synonym listed under "aliases to avoid".
+
+**In this repo the aliases are not stylistic.** Each one carries a design assumption the pack
+rejected. Calling a Horde a "raid" imports MineColonies' event as if it were the same system;
+calling the Create layer "the main tech mod" invites a second one; "HP sponge" is named in the
+glossary specifically so that proposing one is recognisable as a proposal to break Rule 3.
+
+If the concept you need is not in the glossary yet, that is a signal — either you are inventing
+language the project does not use (reconsider), or there is a real gap worth adding.
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently
+overriding:
+
+> *Contradicts ADR-0001 (CI gate scoped to what a modpack repo can check) — but worth reopening
+> because…*
+
+The same applies to the design documents, which function as ADRs the pack was born with. §6 of
+the handoff doc lists mods rejected by design; re-adding one is a decision that needs a new
+stated reason recorded as an ADR, not a preference expressed in a PR body.
+<!-- lang:end -->
+
+<!-- lang:th -->
+# Reading Domain Docs — ภาษาไทย
+
+skill ด้านวิศวกรรมควรอ่านเอกสาร domain ของ repo นี้อย่างไรตอนสำรวจ
+
+> **ทำไมไฟล์นี้ไม่ได้ชื่อ `domain.md`** `/setup-matt-pocock-skills` เขียน consumer rules เหล่านี้
+> ลงที่ `docs/agents/domain.md` แต่ใน repo นี้ path นั้นเก็บ **domain glossary** อยู่แล้ว —
+> เป็นคนละเอกสารที่บังเอิญชื่อไฟล์เหมือนกัน ทั้งสองอยู่คู่กัน:
+>
+> - **`docs/agents/domain.md`** — *คำแต่ละคำแปลว่าอะไรที่นี่* คือ glossary
+> - **`docs/agents/reading-domain-docs.md`** — *ต้องอ่านไฟล์ไหน และอ่านเมื่อไร* คือไฟล์นี้
+>
+> รายงานไปที่ต้นทางแล้วที่ [xenodeve/xeno-skills#334](https://github.com/xenodeve/xeno-skills/issues/334)
+
+## ก่อนสำรวจ ให้อ่านสิ่งเหล่านี้
+
+- **`docs/agents/domain.md`** — glossary มาตรฐานของ repo นี้ เป็นตัวที่มีอยู่จริง อ่านตัวนี้ก่อน
+- **`CONTEXT.md`** ที่ราก repo — **ยังไม่มี** และนั่นเป็นความตั้งใจ Seed tier เลื่อนมันไว้จนกว่าจะมี
+  bounded context ที่คุ้มค่าจะเขียนลงไป ถ้ามันปรากฏขึ้นภายหลัง มันจะกลายเป็นเอกสาร
+  system-context และยอมให้ glossary ชนะเมื่อขัดกัน
+- **`docs/adr/`** — อ่าน ADR ที่แตะพื้นที่ที่คุณกำลังจะทำงาน ก่อนจะเสนอทางเลือกอื่น ดัชนีอยู่ที่
+  `docs/adr/README.md`
+- **เอกสารออกแบบ** — สำหรับ modpack เจตนาอยู่ในความเรียง ไม่ได้อยู่ในโค้ด:
+  - `docs/Industrial Civilization Survival — Claude Code Handoff & Implementation Plan.md`
+  - `docs/Addon Spec — Crafting Assistance + Tactical Tracker.md`
+  - `docs/Addon Spec — Natural Wildlife & Ecology.md`
+
+ถ้าไฟล์ใดไม่มี ให้ **ทำต่อไปเงียบ ๆ** อย่าไปทักว่ามันหายไป อย่าเสนอให้สร้างล่วงหน้า มันถูกสร้าง
+แบบ lazy เมื่อคำศัพท์หรือการตัดสินใจได้ข้อสรุปจริง ๆ
+
+## โครงสร้างไฟล์
+
+repo แบบ single-context — glossary หนึ่งตัวและไดเรกทอรี ADR หนึ่งตัวสำหรับทั้ง repo:
+
+```
+/
+├── docs/
+│   ├── agents/
+│   │   ├── domain.md               ← glossary
+│   │   └── reading-domain-docs.md  ← ไฟล์นี้
+│   ├── adr/
+│   │   ├── README.md
+│   │   └── 0001-ci-gate-scoped-to-modpack-reality.md
+│   └── <เอกสารออกแบบ>
+└── (config/, kubejs/, datapacks/ — ถูกสร้างโดยงานทำ pack ยังไม่มีตอนนี้)
+```
+
+ไม่มี `CONTEXT-MAP.md` และไม่มีเหตุให้คาดว่าจะมี: modpack เป็น bounded context เดียวโดยธรรมชาติ
+จะกลับมาทบทวนก็ต่อเมื่อ repo มี deliverable ที่แยกกันจริง ๆ ตัวที่สอง — กรณีที่เป็นไปได้คือ pack
+Season 2 ที่ดูแลคู่ขนานกันไป
+
+## ใช้คำศัพท์ตาม glossary
+
+เมื่อผลลัพธ์ของคุณเอ่ยถึงแนวคิดใน domain — หัวข้อ issue, ข้อเสนอ refactor, สมมติฐาน, comment ใน
+config, identifier ของ KubeJS — ให้ใช้คำตามที่ `docs/agents/domain.md` นิยามไว้เป๊ะ ๆ อย่าเลื่อน
+ไปใช้คำพ้องที่อยู่ในรายการ "ห้ามใช้"
+
+**ใน repo นี้ คำที่ห้ามใช้ไม่ใช่เรื่องสไตล์** แต่ละคำพ่วงสมมติฐานเชิงดีไซน์ที่ pack ปฏิเสธไปแล้ว
+การเรียก Horde ว่า "raid" คือการลากอีเวนต์ของ MineColonies เข้ามาราวกับเป็นระบบเดียวกัน การเรียก
+ชั้นของ Create ว่า "tech mod หลัก" คือการเปิดช่องให้มีตัวที่สอง ส่วน "HP sponge" ถูกใส่ไว้ใน
+glossary โดยเฉพาะ เพื่อให้การเสนอมันถูกจับได้ว่าเป็นการเสนอให้ละเมิด Rule 3
+
+ถ้าแนวคิดที่ต้องการยังไม่อยู่ใน glossary นั่นคือสัญญาณ — ไม่คุณกำลังคิดคำใหม่ที่โปรเจกต์ไม่ได้ใช้
+(ให้ทบทวน) ก็มีช่องว่างจริงที่ควรเติมเข้าไป
+
+## ทักเมื่อขัดกับ ADR
+
+ถ้าผลลัพธ์ของคุณขัดกับ ADR ที่มีอยู่ ให้พูดออกมาตรง ๆ แทนที่จะ override เงียบ ๆ:
+
+> *ขัดกับ ADR-0001 (CI gate scoped to what a modpack repo can check) — แต่คุ้มที่จะรื้อกลับมาคุย
+> เพราะ…*
+
+ใช้กับเอกสารออกแบบด้วยเช่นกัน เพราะมันทำหน้าที่เหมือน ADR ที่ pack เกิดมาพร้อมกับมัน §6 ของ
+handoff doc ระบุ mod ที่ถูกปฏิเสธโดยการออกแบบไว้ การเอากลับเข้ามาคือการตัดสินใจที่ต้องมีเหตุผล
+ใหม่ที่ระบุชัดและบันทึกเป็น ADR ไม่ใช่ความชอบที่แสดงออกใน body ของ PR
+<!-- lang:end -->

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,149 @@
+<!-- lang:en -->
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the
+actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding
+label string from this table.
+
+The mapping is identity here — this repo adopted the canonical names unchanged. Edit the
+right-hand column if that ever stops being true.
+
+**`ready-for-human` carries extra weight in this repo.** Most of the verification that matters
+here requires launching Minecraft, which no agent can do. An issue whose acceptance criteria
+include an observed in-game behaviour is `ready-for-human` even if every file change is
+mechanical.
+
+## Additional label groups
+
+Beyond the five roles, this repo uses four groups. They are the T4 delta — the canonical five
+come from the pocock skills, these do not.
+
+- **Component** — exactly one per issue:
+  `pack-infra` · `create` · `combat` · `threat` · `civilization` · `city-systems` ·
+  `progression` · `qol`
+- **Type** — one or more:
+  `Bug` · `Feature` · `tech-debt` · `security` · `Optimization` · `Cleanup` · `Test`
+- **Severity** — exactly one on any `Bug` or `security` issue:
+  `critical` · `Major` · `Minor`
+- **Lifecycle** — optional:
+  `Latent` (exists in the config or code but has not manifested yet) ·
+  `Dormant` (real, deliberately deprioritised)
+
+### What each Component owns
+
+| Label | Owns |
+|---|---|
+| `pack-infra` | packwiz, CI, hooks, guards, repo layout, tooling |
+| `create` | Create and its addons — the technological backbone |
+| `combat` | TaCZ, guns, ammunition, TTK, tactical gear |
+| `threat` | Mobs, Hordes, spawn director, Enhanced AI, dragons |
+| `civilization` | MineColonies, food, seasons, NPC settlement |
+| `city-systems` | Electricity, security, CCTV, lighting, radio |
+| `progression` | KubeJS recipes, quests, the balance curve |
+| `qol` | Immersion and quality-of-life, including both Addon Specs |
+
+## Conventions
+
+- Every issue carries **at least one triage-state label** and **exactly one Component label**.
+- **A `security` issue must be `critical` or `Major`.** A `Minor` security label is not valid.
+- A `Latent` bug that activates is upgraded to a full `Bug` issue with a severity.
+- `Optimization` in this repo usually means MSPT, TPS, entity count, chunk load, or client FPS —
+  see the performance sections of the design documents before opening one.
+
+## Installed state
+
+All 25 labels exist on `xenodeve/minecraft-100day` as of 2026-08-25 — **23 created, 2
+pre-existing** (`wontfix`, and GitHub's default `bug`, renamed to `Bug` so the tracker matches
+this file). GitHub's other default labels (`documentation`, `duplicate`, `enhancement`,
+`good first issue`, `help wanted`, `invalid`, `question`, `accessibility`) were left in place but
+are **not** part of this vocabulary; `enhancement` in particular duplicates `Feature` — prefer
+`Feature`.
+
+The `wayfinder:*` labels named in `docs/agents/issue-tracker.md` are **not** created. Create them
+at first use of `/wayfinder`.
+<!-- lang:end -->
+
+<!-- lang:th -->
+# Triage Labels — ภาษาไทย
+
+skill ต่าง ๆ พูดถึง triage role มาตรฐานห้าตัว ไฟล์นี้แม็ป role เหล่านั้นเข้ากับสตริง label จริงที่
+issue tracker ของ repo นี้ใช้
+
+| Label ใน mattpocock/skills | Label ใน tracker ของเรา | ความหมาย                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | maintainer ต้องประเมิน issue นี้  |
+| `needs-info`               | `needs-info`         | รอข้อมูลเพิ่มจากผู้รายงาน |
+| `ready-for-agent`          | `ready-for-agent`    | ระบุครบแล้ว พร้อมให้ agent ทำแบบ AFK  |
+| `ready-for-human`          | `ready-for-human`    | ต้องให้คนลงมือ            |
+| `wontfix`                  | `wontfix`            | จะไม่ดำเนินการ                       |
+
+เมื่อ skill พูดถึง role ตัวใด (เช่น "apply the AFK-ready triage label") ให้ใช้สตริง label ที่ตรงกัน
+จากตารางนี้
+
+การแม็ปที่นี่เป็นซ้าย=ขวา — repo นี้รับชื่อมาตรฐานมาใช้ตรง ๆ ให้แก้คอลัมน์ขวาถ้าวันหนึ่งมันไม่จริง
+อีกต่อไป
+
+**`ready-for-human` มีน้ำหนักพิเศษใน repo นี้** การ verify ที่สำคัญส่วนใหญ่ที่นี่ต้องเปิด Minecraft
+ซึ่งไม่มี agent ตัวไหนทำได้ issue ที่เกณฑ์การปิดงานมีพฤติกรรมที่ต้องสังเกตในเกม ถือเป็น
+`ready-for-human` แม้ว่าการแก้ไฟล์ทุกจุดจะเป็นงานเชิงกลก็ตาม
+
+## กลุ่ม label เพิ่มเติม
+
+นอกจาก role ทั้งห้า repo นี้ใช้อีกสี่กลุ่ม กลุ่มเหล่านี้คือส่วนต่างของ T4 — ห้าตัวมาตรฐานมาจาก
+skill ของ pocock ส่วนพวกนี้ไม่ใช่
+
+- **Component** — หนึ่งตัวต่อ issue เท่านั้น:
+  `pack-infra` · `create` · `combat` · `threat` · `civilization` · `city-systems` ·
+  `progression` · `qol`
+- **Type** — หนึ่งตัวหรือมากกว่า:
+  `Bug` · `Feature` · `tech-debt` · `security` · `Optimization` · `Cleanup` · `Test`
+- **Severity** — หนึ่งตัวเท่านั้นบน issue ที่เป็น `Bug` หรือ `security`:
+  `critical` · `Major` · `Minor`
+- **Lifecycle** — ใส่หรือไม่ใส่ก็ได้:
+  `Latent` (มีอยู่ใน config หรือโค้ดแล้วแต่ยังไม่แสดงอาการ) ·
+  `Dormant` (เป็นเรื่องจริง แต่จงใจลดความสำคัญ)
+
+### แต่ละ Component ดูแลอะไร
+
+| Label | ดูแล |
+|---|---|
+| `pack-infra` | packwiz, CI, hooks, guards, ผังของ repo, เครื่องมือ |
+| `create` | Create และ addon ของมัน — กระดูกสันหลังทางเทคโนโลยี |
+| `combat` | TaCZ, ปืน, กระสุน, TTK, อุปกรณ์ tactical |
+| `threat` | Mob, Horde, spawn director, Enhanced AI, มังกร |
+| `civilization` | MineColonies, อาหาร, ฤดูกาล, นิคมของ NPC |
+| `city-systems` | ไฟฟ้า, ความปลอดภัย, CCTV, แสงสว่าง, วิทยุ |
+| `progression` | KubeJS recipe, quest, เส้นโค้งของ balance |
+| `qol` | ความสมจริงและความสะดวก รวมถึง Addon Spec ทั้งสองใบ |
+
+## ธรรมเนียม
+
+- ทุก issue ต้องมี **triage-state label อย่างน้อยหนึ่งตัว** และ **Component label หนึ่งตัวพอดี**
+- **issue ที่เป็น `security` ต้องมี `critical` หรือ `Major`** label `security` ที่เป็น `Minor`
+  ถือว่าไม่ถูกต้อง
+- bug ที่เป็น `Latent` แล้วเกิดขึ้นจริง ให้อัปเกรดเป็น issue `Bug` เต็มตัวพร้อม severity
+- `Optimization` ใน repo นี้มักหมายถึง MSPT, TPS, จำนวน entity, การโหลด chunk หรือ FPS ฝั่ง
+  client — อ่านหัวข้อเรื่อง performance ในเอกสารออกแบบก่อนเปิด issue ประเภทนี้
+
+## สถานะที่ติดตั้งแล้ว
+
+label ทั้ง 25 ตัวมีอยู่บน `xenodeve/minecraft-100day` แล้ว ณ วันที่ 2026-08-25 — **สร้างใหม่ 23
+มีอยู่ก่อน 2** (`wontfix` และ `bug` ที่เป็นค่าเริ่มต้นของ GitHub ซึ่งถูกเปลี่ยนชื่อเป็น `Bug` เพื่อให้
+tracker ตรงกับไฟล์นี้) label เริ่มต้นอื่น ๆ ของ GitHub (`documentation`, `duplicate`,
+`enhancement`, `good first issue`, `help wanted`, `invalid`, `question`, `accessibility`) ถูกทิ้ง
+ไว้ตามเดิม แต่ **ไม่ใช่** ส่วนหนึ่งของ vocabulary นี้ โดยเฉพาะ `enhancement` ที่ซ้ำกับ `Feature` —
+ให้ใช้ `Feature`
+
+label `wayfinder:*` ที่ระบุไว้ใน `docs/agents/issue-tracker.md` **ยังไม่ถูกสร้าง** ให้สร้างตอนใช้
+`/wayfinder` ครั้งแรก
+<!-- lang:end -->


### PR DESCRIPTION
Closes #3. Closes #4.

## Two things the operating layer could not do for itself

### #3 — the `/setup-matt-pocock-skills` hand-off

`t4-project-bootstrap` step 5 delegates `issue-tracker.md` and `triage-labels.md` to a skill that
carries `disable-model-invocation`. The bootstrap left both files **absent** rather than writing
them from the wrong template. The developer ran the skill directly; this lands its output with
the T4 delta appended.

| File | What it carries |
|---|---|
| `docs/agents/issue-tracker.md` | pocock's GitHub template, plus the `gh` full path (it is **not** on PATH — this is the thing that cost a wrong "gh is missing" report during bootstrap), the bilingual-body rule, the merge gate's actual state, and `/wayfinder` operations |
| `docs/agents/triage-labels.md` | The five canonical roles as an identity mapping, plus Component / Type / Severity / Lifecycle, what each Component owns, and the installed state (25 labels: 23 created, 2 pre-existing) |
| `docs/agents/reading-domain-docs.md` | pocock's consumer rules, at a path that does not destroy the glossary |
| `CLAUDE.md` | An `## Agent skills` block pointing at all three |

**The path split, stated once so it does not get "fixed" later.** The upstream skill writes its
consumer rules to `docs/agents/domain.md`, which in this repo is the **glossary**. They are
different documents sharing a filename. `t4-project-bootstrap/SKILL.md` prescribes exactly this
resolution — *"take them at a different path and say which is which."* Verified before splitting
that no installed skill reads `docs/agents/domain.md` by path. Upstream as
[xenodeve/xeno-skills#334](https://github.com/xenodeve/xeno-skills/issues/334).

### #4 — a third design document

`docs/Addon Spec — Natural Wildlife & Ecology.md` (1776 lines) arrived after bootstrap. It adds
Naturalist, Critters and Companions and Ecologics as **CORE**, rejects Untamed Wilds and Alex's
Mobs, and brings its own phase list W0–W9.

- **`docs/agents/domain.md`** gains seven terms in both language halves: Natural/Anomalous world,
  **Spawn Budget**, **Entity Density Priority**, **Duplicate Species Audit**, **Wildlife Roster**,
  Survival tax, W-phase.
- **`CLAUDE.md`** gains a citation convention. Three documents each numbering their own sections
  `§1, §2, §3…` meant a bare `§17` was about to be ambiguous between *Spawn Budget*, *Tactical
  Tracker*, and *Sound System*. They are now *Crafting Spec §N* and *Wildlife Spec §N* / *W3*.
- **`docs/OPEN-WORK-LEDGER.md`** gains Track 4, reconciles Track 0, and **rescopes Phase 2**: the
  Create-version sweep now covers all three documents in one pass. Doing it per-document means
  running the same CurseForge / Modrinth query three times and reconciling three partial answers.

**One standing constraint escaped Track 4 on purpose** — Wildlife Spec §18/§48 fixes the order in
which density is cut under load (ambient → small critters → duplicates → common passives, with
Create / MineColonies / hostile design cut **last**). That binds every future tuning session, not
just the wildlife work, so it is written into the glossary and called out in the ledger.

## Branch note

This branch contains the commit from the still-open PR for #1. `main` does not have it yet, and
branching cleanly off `main` would have meant re-editing `CLAUDE.md` and the ledger from their
pre-correction text. Whichever PR merges first, the other is unaffected.

## Verification

`node scripts/validate/verify.mjs` → passed (2 JSON, 0 TOML, 27 files scanned for placeholders,
0 KubeJS scripts).

**Not verified, and cannot be:** no mod was installed and no world was launched. Every claim in
these files is about the repository, not about the pack. CI cannot run — see #1.

---

## สรุปภาษาไทย

Closes #3. Closes #4.

## สองสิ่งที่ operating layer ทำให้ตัวเองไม่ได้

### #3 — การส่งงานให้ `/setup-matt-pocock-skills`

`t4-project-bootstrap` step 5 มอบ `issue-tracker.md` และ `triage-labels.md` ให้ skill ที่ติด
`disable-model-invocation` เซสชัน bootstrap จึงปล่อยทั้งสองไฟล์ให้ **ไม่มี** แทนที่จะเขียนจาก
template ที่ผิด developer รัน skill นั้นเองแล้ว PR นี้นำผลลัพธ์ลงพร้อมส่วนต่างของ T4 ที่ต่อท้าย

| ไฟล์ | มีอะไรอยู่ |
|---|---|
| `docs/agents/issue-tracker.md` | template GitHub ของ pocock บวก path เต็มของ `gh` (มัน **ไม่** อยู่ใน PATH — เรื่องนี้คือสาเหตุที่รายงานผิดว่า "gh หายไป" ตอน bootstrap) กฎ bilingual body สถานะจริงของด่านก่อน merge และการทำงานแบบ `/wayfinder` |
| `docs/agents/triage-labels.md` | role มาตรฐานห้าตัวแบบซ้าย=ขวา บวก Component / Type / Severity / Lifecycle แต่ละ Component ดูแลอะไร และสถานะที่ติดตั้งแล้ว (25 label: สร้างใหม่ 23 มีอยู่ก่อน 2) |
| `docs/agents/reading-domain-docs.md` | consumer rules ของ pocock ที่ path ซึ่งไม่ทำลาย glossary |
| `CLAUDE.md` | block `## Agent skills` ที่ชี้ไปทั้งสามไฟล์ |

**การแยก path พูดไว้ครั้งเดียวเพื่อไม่ให้ถูก "แก้" ทีหลัง** skill ต้นทางเขียน consumer rules ของมัน
ลงที่ `docs/agents/domain.md` ซึ่งใน repo นี้คือ **glossary** มันเป็นคนละเอกสารที่ใช้ชื่อไฟล์
เดียวกัน `t4-project-bootstrap/SKILL.md` กำหนดวิธีแก้แบบนี้ไว้ตรง ๆ — *"take them at a different
path and say which is which"* ตรวจก่อนแยกแล้วว่าไม่มี skill ที่ติดตั้งอยู่ตัวไหนอ่าน
`docs/agents/domain.md` แบบระบุ path รายงานต้นทางที่
[xenodeve/xeno-skills#334](https://github.com/xenodeve/xeno-skills/issues/334)

### #4 — เอกสารออกแบบใบที่สาม

`docs/Addon Spec — Natural Wildlife & Ecology.md` (1776 บรรทัด) มาถึงหลัง bootstrap มันเพิ่ม
Naturalist, Critters and Companions และ Ecologics เป็น **CORE** ปฏิเสธ Untamed Wilds กับ Alex's
Mobs และพก phase list ของตัวเองคือ W0–W9 มาด้วย

- **`docs/agents/domain.md`** เพิ่มเจ็ดคำในทั้งสองภาษา: Natural/Anomalous world,
  **Spawn Budget**, **Entity Density Priority**, **Duplicate Species Audit**, **Wildlife Roster**,
  Survival tax, W-phase
- **`CLAUDE.md`** เพิ่มธรรมเนียมการอ้างอิง เอกสารสามใบที่ต่างก็นับหัวข้อของตัวเองเป็น `§1, §2, §3…`
  ทำให้ `§17` เปล่า ๆ กำลังจะกำกวมระหว่าง *Spawn Budget*, *Tactical Tracker* และ *Sound System*
  ตอนนี้กลายเป็น *Crafting Spec §N* และ *Wildlife Spec §N* / *W3*
- **`docs/OPEN-WORK-LEDGER.md`** เพิ่ม Track 4 ปรับ Track 0 ให้ตรงความจริง และ **ปรับขอบเขต
  Phase 2**: การกวาดเวอร์ชัน Create ตอนนี้ครอบเอกสารทั้งสามใบในรอบเดียว การทำทีละใบแปลว่าต้อง
  รัน query CurseForge / Modrinth ชุดเดิมสามครั้งแล้วมานั่งประสานคำตอบที่ไม่ครบสามชุด

**มีข้อจำกัดถาวรหนึ่งข้อที่จงใจให้หลุดออกมาจาก Track 4** — Wildlife Spec §18/§48 กำหนดลำดับการตัด
ความหนาแน่นเมื่อเครื่องตึงไว้ตายตัว (ambient → critter เล็ก → ตัวซ้ำ → passive ทั่วไป โดย Create /
MineColonies / การออกแบบการปะทะถูกตัด**เป็นลำดับสุดท้าย**) มันผูกทุกเซสชัน tuning ในอนาคต ไม่ใช่
แค่งานสัตว์ป่า จึงถูกเขียนลง glossary และชี้ไว้ใน ledger

## หมายเหตุเรื่อง branch

branch นี้มี commit จาก PR ของ #1 ที่ยังเปิดอยู่รวมอยู่ด้วย `main` ยังไม่มีมัน และการแตก branch
จาก `main` ตรง ๆ จะแปลว่าต้องกลับไปแก้ `CLAUDE.md` กับ ledger จากข้อความก่อนแก้อีกรอบ ไม่ว่า PR
ไหนจะ merge ก่อน อีกใบก็ไม่ได้รับผลกระทบ

## การ verify

`node scripts/validate/verify.mjs` → ผ่าน (JSON 2 ไฟล์, TOML 0 ไฟล์, สแกนหา placeholder 27 ไฟล์,
KubeJS 0 ไฟล์)

**สิ่งที่ยังไม่ได้ verify และ verify ไม่ได้:** ไม่มี mod ตัวไหนถูกติดตั้ง และไม่มี world ไหนถูกเปิด
ทุกคำกล่าวอ้างในไฟล์เหล่านี้พูดถึง repository ไม่ได้พูดถึงตัว pack ส่วน CI รันไม่ได้ — ดู #1
