### PR TITLE
docs(pack-infra): fold the Distribution & Updates spec into the operating layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+Every released version gets an entry here — required by Distribution Spec §24. A version with no
+entry is not a release.
+
+**Sections**, in this order, omitting any that is empty: `Added` · `Changed` · `Fixed` ·
+`Removed`.
+
+**Write it for the person installing it, not for the person who wrote it.** *"Reduced Born in
+Chaos forest spawn"* is an entry; *"tuned incontrol.json"* is not — it names the file instead of
+the effect.
+
+**A version number here must match a git tag and the distributed artifact** (`v0.1.0-alpha`,
+`v0.4.0-beta`, `v1.0.0`). A build from `develop` or a feature branch is a **dev build**: it gets
+no entry, no tag, and is never handed to a friend as if it were a release.
+
+---
+
+## Unreleased
+
+### Added
+
+- Repository operating layer: agent memory (ledger, ship log, memory vault), enforcement hooks and
+  guards, domain glossary, workflow and tracker conventions, ADRs.
+- Four design documents under `docs/` — the main handoff plan plus the Crafting Assistance,
+  Natural Wildlife & Ecology, and Distribution & Updates specs.
+
+_No pack yet. There is no `pack.toml`, no mods, no config and no KubeJS, so there is nothing
+installable and nothing to release. The first entry below this one will be `v0.1.0-alpha`, and it
+cannot be cut until the release gate in Distribution Spec §16 passes._

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,14 +19,17 @@ The design document is the source of truth for intent:
 **`docs/Industrial Civilization Survival — Claude Code Handoff & Implementation Plan.md`**
 (read it before any pack work; unqualified `§N` references throughout this repo are to it).
 
-Two standalone addon specs layer on top of it. Both share the same platform constraints and the
-same design rules, and both have their own section numbering — **cite them by name, never as a
-bare `§N`**:
+Three further specs layer on top of it. All share the same platform constraints and the same
+design rules, and each numbers its own sections — **cite them by name, never as a bare `§N`**:
 
-| Document | Adds | Cite as |
+| Document | What it governs | Cite as |
 |---|---|---|
 | `docs/Addon Spec — Crafting Assistance + Tactical Tracker.md` | JEI, Jade, Jade Addons, Crafting Tweaks, Mouse Tweaks, Polymorph, and a re-themed Player Microchip tracker | *Crafting Spec §N* |
 | `docs/Addon Spec — Natural Wildlife & Ecology.md` | Naturalist, Critters and Companions, Ecologics — the ordinary-animal layer that makes monsters read as abnormal. Carries its own phase list, W0–W9 | *Wildlife Spec §N* / *Wildlife Spec W3* |
+| `docs/ADDON-MODPACK-DISTRIBUTION-AND-UPDATES.md` | **Release engineering, not content.** Source of truth, what counts as the pack, versioning, the release gate, branching, changelog, friend installation and updates | *Distribution Spec §N* |
+
+The Distribution Spec is the one that constrains **this repository's own process**, not the game.
+Its §22 branching model and §16 release gate govern how work ships; see `docs/agents/workflow.md`.
 
 Untamed Wilds and Alex's Mobs are **rejected** by the Wildlife Spec (§2, §54) — high overlap,
 unnecessary entity diversity, and Alex's Mobs carries fantasy creatures that collide with the
@@ -151,6 +154,7 @@ ledger.
 
 ```
 CLAUDE.md                     this file
+CHANGELOG.md                  one entry per released version — a version without one is not a release
 DONE.md                       ship log — newest on top
 .gitignore                    mod jars are NEVER committed (see the file for why)
 
@@ -158,16 +162,18 @@ docs/
   Industrial Civilization Survival — ….md    the design document (source of truth for intent)
   Addon Spec — Crafting Assistance ….md      JEI / Jade / tactical tracker
   Addon Spec — Natural Wildlife ….md         Naturalist / Critters / Ecologics, phases W0–W9
+  ADDON-MODPACK-DISTRIBUTION-AND-UPDATES.md  release engineering — governs THIS repo's process
   OPEN-WORK-LEDGER.md         open work, tracked and untracked — read at session start
   agents/
     domain.md                 domain glossary — WHAT THE WORDS MEAN here
     reading-domain-docs.md    WHICH FILES to read before exploring, and when
-    workflow.md               how to plan and implement here
+    workflow.md               how to plan and implement here, branching, release tags
     issue-tracker.md          GitHub conventions, gh path, bilingual body rule
     triage-labels.md          the 25 labels that exist and what each one means
   adr/
     README.md                 ADR index + conventions
     0001-…                    CI gate scoped to what a modpack repo can check
+    0002-…                    operate without a server-side CI tier
 
 Obsidian-minecraft-100day/    team memory vault; Home.md is the index
 

--- a/DONE.md
+++ b/DONE.md
@@ -6,6 +6,38 @@
 
 ---
 
+## Distribution & Updates spec folded in (2026-08-25, branch `chore/7-fold-distribution-spec`)
+
+**Goal:** a fourth design document arrived, and unlike the first three it constrains **this
+repository's process** rather than the game. Reconcile it against infrastructure that already
+exists in a different shape.
+
+**Shipped (#7):**
+- `docs/agents/domain.md` — eight distribution terms in both language halves: Source of truth,
+  Pack-owned files, Config ownership (PACK CONTROLLED / USER PREFERENCE), Side classification,
+  Server pack, Release gate, Config drift, Dev build.
+- `docs/agents/workflow.md` — the §22 branching model, the branch-naming rule the issue-ref guard
+  actually enforces, the Season 2 quarantine branch, release tags, and the §16 release gate.
+- `CHANGELOG.md` — created, with the section shape and the rule that a version without an entry
+  is not a release.
+- `scripts/validate/verify.mjs` — header now maps the §15 validation checklist against what is
+  implemented and what each missing check is blocked on. Three of ten done; the rest need a
+  resolved pack, not effort.
+- `CLAUDE.md`, `docs/agents/reading-domain-docs.md`, `docs/OPEN-WORK-LEDGER.md` (Track 5).
+
+**Judgement call, flagged rather than buried:** the spec's `develop` branch was **not** created.
+Its purpose is to keep unfinished integration away from a `main` people are running, and nobody is
+running anything. It is deferred to the change that cuts the first `v0.x.0-alpha` tag, with the
+reasoning written into `docs/agents/workflow.md` and a 🟡 row in Track 5. Stated on #7 so it can be
+overruled in one comment.
+
+**Validation:** `node scripts/validate/verify.mjs` → passed. Nothing here is verifiable in game;
+no mod exists.
+
+**Next:** unchanged — install `packwiz` and Java 17, then the Create version sweep.
+
+---
+
 ## Switched to the two-tier enforcement mode (2026-08-25, `/t4-project-bootstrap` follow-up, branch `chore/1-operate-without-ci`)
 
 **Goal:** the billing lock on GitHub Actions cannot be resolved, so stop treating the missing CI

--- a/docs/ADDON-MODPACK-DISTRIBUTION-AND-UPDATES.md
+++ b/docs/ADDON-MODPACK-DISTRIBUTION-AND-UPDATES.md
@@ -1,0 +1,1706 @@
+# Addon Spec — Modpack Distribution, Updates & Friend Installation
+## Claude Code CLI Implementation Handoff
+
+> **Project:** Industrial Civilization Survival  
+> **Platform:** Minecraft 1.20.1 Forge / Java 17  
+> **Purpose:** สร้างระบบแจกจ่าย ติดตั้ง อัปเดต และทดสอบ modpack ให้เพื่อนสามารถใช้งานได้โดยไม่ต้องลง mod, config, KubeJS, resource pack หรือ compatibility fixes ด้วยตัวเอง
+>
+> เอกสารนี้ต้องสามารถใช้เป็น standalone implementation context สำหรับ Claude Code CLI ได้โดยไม่ต้องมี conversation history
+
+---
+
+# 1. Core Goal
+
+หลัง custom modpack เสร็จ ผู้เล่นต้องสามารถ:
+
+```text
+Receive Pack
+↓
+Import / Install
+↓
+Launch
+↓
+Join Server
+```
+
+โดยไม่ต้อง:
+
+```text
+Download 70+ mods manually
+Configure mods manually
+Copy KubeJS scripts manually
+Install resource packs manually
+Find matching versions manually
+Fix recipe configs manually
+```
+
+Core principle:
+
+> **The modpack is the product, not the mod list.**
+
+สิ่งที่ต้องแจกจ่ายจึงไม่ใช่เพียง `.jar` files แต่รวมถึง configuration และ custom integration ของทั้ง pack
+
+---
+
+# 2. Source of Truth
+
+ใช้:
+
+```text
+Git
++
+packwiz
+```
+
+เป็น development source of truth
+
+Recommended repository:
+
+```text
+industrial-civilization-survival/
+├── README.md
+├── CHANGELOG.md
+├── CLAUDE.md
+├── PROJECT_PLAN.md
+├── pack.toml
+├── index.toml
+│
+├── mods/
+├── config/
+├── defaultconfigs/
+├── kubejs/
+├── resourcepacks/
+├── datapacks/
+├── ftbquests/
+├── scripts/
+└── docs/
+```
+
+Git repository เป็นแหล่งข้อมูลหลักของ:
+
+- exact mod versions
+- configs
+- KubeJS
+- datapacks
+- quests
+- custom resource packs
+- balance changes
+- compatibility fixes
+- release metadata
+
+ห้ามใช้ launcher instance ของ developer เป็น source of truth เพียงอย่างเดียว
+
+---
+
+# 3. Why packwiz
+
+packwiz ใช้สำหรับจัดการ:
+
+```text
+Mod list
+Exact versions
+Download metadata
+Pack metadata
+Updates
+Export/build workflow
+```
+
+เป้าหมายคือให้ modpack reproducible
+
+กล่าวคือ:
+
+```text
+Fresh machine
++
+Repository
++
+Build process
+=
+Same pack
+```
+
+ไม่ควรเกิด:
+
+```text
+Developer PC works
+Friend PC missing 4 mods
+Server has another config
+```
+
+---
+
+# 4. Files That Belong to the Pack
+
+ต้องพิจารณาแจกไฟล์เหล่านี้:
+
+```text
+config/
+defaultconfigs/
+kubejs/
+resourcepacks/
+datapacks/
+ftbquests/
+```
+
+รวมถึงไฟล์ custom อื่นที่ pack ใช้จริง
+
+ตัวอย่าง:
+
+```text
+Tracker re-theme
+JEI hidden item rules
+Ammo recipes
+Spawn rules
+Dragon balance
+Horde settings
+Carry On blacklist
+SecurityCraft restrictions
+Immersive Engineering scope changes
+Create integration
+Wildlife tuning
+```
+
+ทั้งหมดนี้เป็นส่วนหนึ่งของ gameplay
+
+---
+
+# 5. Do Not Treat Mods Folder as the Pack
+
+ผิด:
+
+```text
+zip mods/
+send to friend
+```
+
+เพราะเพื่อนอาจได้:
+
+```text
+Correct mods
++
+Wrong recipes
++
+Wrong spawn rules
++
+Wrong progression
++
+Wrong textures
+```
+
+ผลคือ gameplay ไม่ใช่ Industrial Civilization Survival version เดียวกัน
+
+---
+
+# 6. Distribution Targets
+
+รองรับอย่างน้อย 3 ระดับ
+
+## A. Internal Development
+
+ใช้:
+
+```text
+Git + packwiz
+```
+
+สำหรับ developer
+
+---
+
+## B. Friends / Closed Beta
+
+Preferred:
+
+```text
+CurseForge-compatible profile
+or
+Modrinth .mrpack
+or
+Prism Launcher + packwiz updater
+```
+
+เลือกวิธีตาม compatibility และ licensing ของ mods จริง
+
+---
+
+## C. Public Stable Release
+
+Target:
+
+```text
+CurseForge
+and/or
+Modrinth
+```
+
+หลัง pack stable แล้ว
+
+---
+
+# 7. Recommended Friend Workflow
+
+สำหรับกลุ่มเพื่อน:
+
+```text
+Developer
+↓
+Update source repository
+↓
+Build release
+↓
+Publish version
+↓
+Friend imports pack
+↓
+Launcher downloads required mods
+↓
+Custom configs/assets included
+↓
+Launch
+```
+
+ครั้งแรก:
+
+```text
+Import once
+```
+
+ครั้งถัดไป:
+
+```text
+Update pack
+```
+
+แทนการ install ใหม่ทุกครั้ง
+
+---
+
+# 8. Versioning
+
+ใช้ semantic-ish pack versions:
+
+```text
+0.1.0-alpha
+0.2.0-alpha
+0.5.0-beta
+0.9.0-rc1
+1.0.0
+```
+
+หรือ:
+
+```text
+Alpha 1
+Alpha 2
+Beta 1
+Release 1.0
+```
+
+แต่ต้อง consistent
+
+Recommended:
+
+```text
+MAJOR.MINOR.PATCH
+```
+
+ตัวอย่าง:
+
+```text
+0.3.0
+```
+
+หมายถึง feature/progression update
+
+```text
+0.3.1
+```
+
+หมายถึง compatibility/bugfix
+
+---
+
+# 9. Exact Mod Version Pinning
+
+ทุก mod ต้อง pin exact version
+
+ไม่ใช้:
+
+```text
+latest
+```
+
+แบบ runtime assumption
+
+เพราะ update ของ mod หนึ่งตัวอาจทำให้:
+
+```text
+Create addon incompatibility
+KubeJS recipe break
+Entity registry change
+Config schema change
+World corruption
+```
+
+Update mod เป็น intentional operation เท่านั้น
+
+---
+
+# 10. Compatibility Matrix
+
+Maintain:
+
+```text
+docs/compatibility-matrix.md
+```
+
+Minimum columns:
+
+```text
+Mod
+Version
+Minecraft
+Forge
+Side
+Dependencies
+Status
+Known Issues
+Last Tested
+```
+
+ทุก release ต้องอ้างอิง matrix เดียวกัน
+
+---
+
+# 11. Client vs Server Classification
+
+แยก mods เป็น:
+
+```text
+COMMON
+SERVER
+CLIENT
+```
+
+ตัวอย่าง:
+
+Client candidates:
+
+```text
+Mouse Tweaks
+Not Enough Animations
+Eating Animation
+Client Dynamic Light
+```
+
+Common gameplay:
+
+```text
+Create
+TaCZ
+MineColonies
+Born in Chaos
+IceAndFire CE
+```
+
+Server-side logic/config อาจมีบางตัวที่ client ไม่จำเป็น
+
+แต่ต้อง inspect exact mod requirement ก่อน classify
+
+Do not guess.
+
+---
+
+# 12. Server Pack
+
+สร้าง server distribution แยกจาก client pack เมื่อเหมาะสม
+
+Server pack ต้อง:
+
+```text
+exclude unnecessary client-only mods
+include common mods
+include server configs
+include KubeJS
+include datapacks
+include quest data if required
+```
+
+Goal:
+
+```text
+Client Pack Version
+=
+Server Pack Version
+```
+
+ถ้า mismatch:
+
+server should reject or documentation should make mismatch obvious
+
+---
+
+# 13. Release Build Structure
+
+Recommended output:
+
+```text
+dist/
+├── client/
+├── server/
+├── manifests/
+└── checksums/
+```
+
+Example:
+
+```text
+dist/
+├── industrial-civilization-survival-0.4.0.mrpack
+├── industrial-civilization-survival-0.4.0-curseforge.zip
+├── industrial-civilization-survival-server-0.4.0.zip
+└── SHA256SUMS.txt
+```
+
+Exact output depends on selected platform/export tools
+
+---
+
+# 14. Build Script
+
+Create:
+
+```text
+scripts/build/
+```
+
+Possible commands:
+
+```text
+build-client
+build-server
+validate-pack
+generate-checksums
+```
+
+Goal:
+
+one deterministic release command
+
+Concept:
+
+```text
+Validate
+↓
+Resolve pack
+↓
+Build Client
+↓
+Build Server
+↓
+Checksum
+↓
+Release artifacts
+```
+
+---
+
+# 15. Validation Before Build
+
+Validate at minimum:
+
+```text
+pack metadata valid
+missing mods = 0
+duplicate mods = 0
+missing dependencies = 0
+unexpected client/server mods = 0
+KubeJS startup errors = 0
+broken config references = 0
+```
+
+If possible also validate:
+
+```text
+duplicate recipes
+missing resource pack assets
+invalid datapacks
+FTB Quests parse errors
+```
+
+---
+
+# 16. Release Gate
+
+ห้าม publish release เพราะแค่:
+
+```text
+Game launches once
+```
+
+Minimum gate:
+
+```text
+Clean client install
+Dedicated server boot
+Fresh world creation
+Client join
+Existing world load
+Recipe test
+Create machine test
+TaCZ test
+MineColonies test
+Threat spawn test
+Tracker test
+JEI/Jade test
+```
+
+---
+
+# 17. Clean Install Test
+
+ทุก release candidate ต้อง test บน clean instance
+
+ไม่ใช้ developer instance ที่มี cache เก่าเป็นหลักฐานเพียงอย่างเดียว
+
+Test:
+
+```text
+Empty launcher profile
+↓
+Import release artifact
+↓
+Launch
+↓
+Join test server
+```
+
+นี่จำลอง experience ของเพื่อนจริงที่สุด
+
+---
+
+# 18. Existing World Upgrade Test
+
+ถ้า release ใช้กับ world เดิม:
+
+copy test world
+
+แล้ว test:
+
+```text
+Old Pack Version
+↓
+Backup
+↓
+New Pack Version
+↓
+Load world
+↓
+Inspect critical systems
+```
+
+Critical systems:
+
+```text
+Create contraptions
+Trains
+MineColonies
+Storage
+Oil infrastructure
+KubeJS items
+FTB Quests
+IceAndFire worldgen/entities
+```
+
+---
+
+# 19. World Backup Rule
+
+ก่อน update multiplayer server:
+
+```text
+STOP SERVER
+↓
+BACKUP WORLD
+↓
+BACKUP CONFIG
+↓
+UPDATE
+↓
+BOOT
+↓
+VALIDATE
+```
+
+ไม่ update production world แบบไม่มี backup
+
+---
+
+# 20. Backup Retention
+
+Recommended minimum:
+
+```text
+Latest
+Previous release
+Known-good milestone
+```
+
+ตัวอย่าง:
+
+```text
+world-current
+world-before-0.4.0
+world-before-0.3.0
+```
+
+ถ้า storage พอ:
+
+ใช้ rolling backups เพิ่ม
+
+---
+
+# 21. Packwiz Update Workflow
+
+Concept:
+
+```text
+Change mod/config
+↓
+Update packwiz metadata
+↓
+Commit
+↓
+Test
+↓
+Tag release
+↓
+Build
+```
+
+อย่าแก้ไฟล์ใน launcher แล้วลืม sync กลับ repository
+
+Repository ต้อง reflect runtime state
+
+---
+
+# 22. Git Branching
+
+Simple strategy:
+
+```text
+main
+=
+stable / playable
+
+develop
+=
+integration
+
+feature/*
+=
+experimental changes
+```
+
+Season 2 high-risk stack:
+
+```text
+Valkyrien Skies
+Clockwork
+Warium
+TFMG advanced integration
+```
+
+ควรอยู่ branch แยกจนกว่าจะ stable
+
+ตัวอย่าง:
+
+```text
+feature/season2-aviation
+```
+
+---
+
+# 23. Release Tags
+
+Tag stable builds:
+
+```text
+v0.1.0-alpha
+v0.4.0-beta
+v1.0.0
+```
+
+Tag ต้องตรงกับ distributed artifact
+
+---
+
+# 24. Changelog
+
+ทุก version ต้องมี:
+
+```text
+CHANGELOG.md
+```
+
+Example:
+
+```text
+## 0.4.0
+
+Added
+- Naturalist
+- Critters and Companions
+- Ecologics
+
+Changed
+- Reduced Born in Chaos forest spawn
+- Rebalanced 5.56 production
+
+Fixed
+- Tracker frequency persistence
+- Polymorph recipe conflict
+```
+
+---
+
+# 25. Friend-Facing Release Notes
+
+อย่าให้เพื่อนอ่าน technical changelog อย่างเดียว
+
+สร้าง concise notes:
+
+```text
+What changed
+Do I need a new world?
+Do I need to update server?
+Any controls changed?
+Known issues?
+```
+
+Example:
+
+```text
+Version 0.4.0
+
+- Adds wildlife ecosystem.
+- Existing worlds supported; explore new chunks for some content.
+- Server and clients must both update.
+- Backup recommended.
+```
+
+---
+
+# 26. Import Experience
+
+Target friend UX:
+
+```text
+Download file
+↓
+Open launcher
+↓
+Import Modpack
+↓
+Choose RAM
+↓
+Launch
+```
+
+ไม่ควรมี manual post-install steps
+
+ถ้า manual step หลีกเลี่ยงไม่ได้:
+
+automation should be investigated first
+
+---
+
+# 27. Resource Packs
+
+Custom resource packs เช่น:
+
+```text
+Tactical Tracker re-theme
+Custom pack UI
+Item naming
+Textures
+```
+
+ควรถูก enabled automatically if platform allows
+
+ผู้เล่นไม่ควรต้อง:
+
+```text
+Options
+↓
+Resource Packs
+↓
+Enable 4 packs manually
+```
+
+ทุก install
+
+ถ้ามี multiple packs:
+
+พิจารณารวม pack-owned assets เป็น:
+
+```text
+Industrial Civilization Resources
+```
+
+หนึ่งชุด
+
+---
+
+# 28. Datapacks
+
+Pack-owned datapacks ควร distribute ผ่าน pack-controlled location
+
+ต้องมั่นใจว่า:
+
+```text
+new world
+existing world
+dedicated server
+```
+
+โหลด datapack ตรงกัน
+
+Do not require friends to manually copy into individual saves.
+
+---
+
+# 29. KubeJS
+
+KubeJS เป็น critical runtime component
+
+Release validation ต้อง inspect:
+
+```text
+latest.log
+KubeJS startup log
+server scripts
+client scripts
+```
+
+Release gate:
+
+```text
+0 fatal KubeJS errors
+```
+
+Warnings ต้อง review ไม่ใช่ ignore ทั้งหมด
+
+---
+
+# 30. Config Ownership
+
+Classify config files:
+
+```text
+PACK CONTROLLED
+USER PREFERENCE
+```
+
+Pack-controlled examples:
+
+```text
+Spawn balance
+Horde settings
+Recipe/progression
+SecurityCraft restrictions
+Carry On blacklist
+Weapon durability
+Oil balancing
+```
+
+User preference examples:
+
+```text
+HUD position
+Audio volume
+Some visual settings
+Keybinds
+```
+
+อย่า overwrite personal preferences โดยไม่จำเป็น
+
+---
+
+# 31. Config Migration
+
+เมื่อ mod update เปลี่ยน config schema:
+
+```text
+Compare old config
+↓
+Generate new default
+↓
+Migrate intentional settings
+↓
+Test
+```
+
+อย่า copy old file blindly
+
+---
+
+# 32. Licensing and Redistribution
+
+ก่อน public distribution:
+
+inspect license/download policy ของทุก mod
+
+Prefer launcher manifests ที่ให้ launcher ดาวน์โหลด mod จาก official platform
+
+Do not assume every `.jar` may legally be bundled directly.
+
+Record unusual redistribution constraints in:
+
+```text
+docs/distribution-licenses.md
+```
+
+---
+
+# 33. CurseForge Distribution
+
+Target use:
+
+```text
+Easy installation for CurseForge users
+```
+
+Export must include pack overrides/custom files while dependencies/mod downloads follow platform-supported mechanisms where applicable.
+
+Test import on fresh CurseForge profile before publishing.
+
+---
+
+# 34. Modrinth Distribution
+
+Target artifact:
+
+```text
+.mrpack
+```
+
+Advantages:
+
+```text
+portable pack format
+Prism-compatible ecosystem
+clear metadata
+```
+
+But every included mod/source must be validated for availability/permissions.
+
+---
+
+# 35. Prism Launcher
+
+Prism is recommended for technical friends/testers
+
+Potential workflow:
+
+```text
+Prism instance
++
+packwiz updater
+```
+
+Benefits:
+
+```text
+easy instance management
+logs accessible
+multiple pack versions
+good debugging workflow
+```
+
+---
+
+# 36. Automatic Update Philosophy
+
+For closed testing, ideal behavior:
+
+```text
+Friend launches/updater
+↓
+Checks pack version
+↓
+Downloads changed files/mods
+↓
+Launch
+```
+
+Do not implement a custom launcher unless existing tooling is insufficient.
+
+Use existing pack/update ecosystem first.
+
+---
+
+# 37. Update Safety
+
+Automatic update must never silently destroy:
+
+```text
+world saves
+screenshots
+options
+keybinds
+personal servers list
+```
+
+Pack updater should update pack-owned files only
+
+where tooling permits.
+
+---
+
+# 38. Config Drift Detection
+
+Potential validation tool:
+
+```text
+scripts/validate/config-drift
+```
+
+Goal:
+
+detect accidental local edits to pack-controlled config
+
+Useful for debugging:
+
+```text
+Friend A works
+Friend B behaves differently
+```
+
+Check whether pack-controlled configs differ
+
+---
+
+# 39. Checksums
+
+Generate SHA-256 for release artifacts where practical:
+
+```text
+SHA256SUMS.txt
+```
+
+Useful for:
+
+```text
+corrupted download
+wrong version
+release verification
+```
+
+---
+
+# 40. Server Join Version Check
+
+If practical, add a visible pack version string
+
+Examples:
+
+```text
+Industrial Civilization Survival 0.4.0
+```
+
+Possible locations:
+
+```text
+Main menu
+Server MOTD
+Quest intro
+Pack metadata
+```
+
+Goal:
+
+easy debugging
+
+```text
+"What version are you on?"
+```
+
+should have simple answer
+
+---
+
+# 41. Server Update Procedure
+
+Recommended documented procedure:
+
+```text
+1. Announce maintenance
+2. Stop server cleanly
+3. Backup world
+4. Backup current pack
+5. Deploy new server pack
+6. Start server
+7. Inspect logs
+8. Run smoke tests
+9. Allow players to join
+```
+
+---
+
+# 42. Friend Update Procedure
+
+Ideal:
+
+```text
+1. Download/import new release
+2. Keep existing saves if local
+3. Launch
+4. Confirm version
+5. Join server
+```
+
+No individual mod replacement instructions
+
+except emergency hotfix cases.
+
+---
+
+# 43. Hotfixes
+
+Example:
+
+```text
+0.4.0
+→ crash discovered
+→ 0.4.1
+```
+
+Hotfix should be full reproducible pack release
+
+not:
+
+```text
+"just send this one jar in Discord"
+```
+
+except temporary diagnosis
+
+Final fix belongs in source and release pipeline.
+
+---
+
+# 44. Development Builds
+
+Development releases should be clearly marked:
+
+```text
+DEV
+ALPHA
+BETA
+RC
+STABLE
+```
+
+Friends should know whether world safety is guaranteed.
+
+Example:
+
+```text
+0.3.0-alpha.4
+```
+
+---
+
+# 45. World Compatibility Labels
+
+Each release notes must specify one:
+
+```text
+SAFE FOR EXISTING WORLDS
+BACKUP STRONGLY RECOMMENDED
+NEW CHUNKS REQUIRED
+NEW WORLD RECOMMENDED
+NEW WORLD REQUIRED
+```
+
+Do not leave users guessing.
+
+---
+
+# 46. Performance Profiles
+
+Optional later:
+
+provide recommended profiles:
+
+```text
+Client Standard
+Client Low
+Server 2–4 players
+Server 5–8 players
+```
+
+Do not fork gameplay configs
+
+Only visual/performance options should differ where possible.
+
+---
+
+# 47. Recommended Memory Documentation
+
+README should tell friends recommended RAM allocation
+
+But measure before locking value.
+
+Do not use:
+
+```text
+allocate all available RAM
+```
+
+Provide tested range after full pack profiling.
+
+---
+
+# 48. README Friend Section
+
+Create:
+
+```text
+README.md
+```
+
+with:
+
+```text
+How to install
+Supported launchers
+Required Java
+Recommended RAM
+How to update
+How to join server
+Known issues
+Where to report bugs
+```
+
+Keep user-facing instructions short.
+
+---
+
+# 49. Bug Report Template
+
+Create:
+
+```text
+.github/ISSUE_TEMPLATE/
+```
+
+or equivalent
+
+Ask for:
+
+```text
+Pack version
+Launcher
+Java version
+RAM
+Singleplayer/server
+Steps to reproduce
+latest.log
+Crash report
+```
+
+Never ask friends to paste entire mod folder manually.
+
+---
+
+# 50. Release Artifact Naming
+
+Use consistent names:
+
+```text
+industrial-civilization-survival-0.4.0.mrpack
+
+industrial-civilization-survival-0.4.0-curseforge.zip
+
+industrial-civilization-survival-server-0.4.0.zip
+```
+
+Avoid:
+
+```text
+final.zip
+final2.zip
+final-real.zip
+pack-new.zip
+```
+
+---
+
+# 51. Build Reproducibility
+
+A release must be buildable again from:
+
+```text
+Git tag
+```
+
+If tag:
+
+```text
+v0.4.0
+```
+
+cannot reproduce distributed pack:
+
+release process is incomplete.
+
+---
+
+# 52. Secrets
+
+Never commit:
+
+```text
+server passwords
+API keys
+tokens
+private addresses if sensitive
+```
+
+Use:
+
+```text
+.env
+environment variables
+server deployment secrets
+```
+
+where appropriate
+
+Add secret patterns to `.gitignore`
+
+---
+
+# 53. Server-Specific Data
+
+Do not accidentally distribute:
+
+```text
+world/
+logs/
+playerdata/
+whitelist with unnecessary private info
+server backups
+```
+
+inside public client pack.
+
+---
+
+# 54. Custom Assets Ownership
+
+Pack-authored assets should be organized separately
+
+Example:
+
+```text
+resourcepacks/
+└── industrial-civilization-resources/
+```
+
+Document origin/license for any third-party asset
+
+Do not copy textures from mods unless permission allows it.
+
+---
+
+# 55. CI — Optional but Recommended
+
+After local workflow is stable, add CI for:
+
+```text
+metadata validation
+packwiz validation
+script linting
+artifact build
+checksum generation
+```
+
+Do not automate release publication before local build is deterministic.
+
+---
+
+# 56. Suggested Repository Structure
+
+```text
+industrial-civilization-survival/
+│
+├── .github/
+│   └── workflows/
+│
+├── mods/
+├── config/
+├── defaultconfigs/
+├── kubejs/
+├── datapacks/
+├── ftbquests/
+├── resourcepacks/
+│
+├── docs/
+│   ├── compatibility-matrix.md
+│   ├── distribution-licenses.md
+│   ├── progression.md
+│   ├── testing.md
+│   └── release-process.md
+│
+├── scripts/
+│   ├── build/
+│   ├── validate/
+│   └── release/
+│
+├── dist/
+│
+├── pack.toml
+├── index.toml
+├── README.md
+├── CHANGELOG.md
+└── CLAUDE.md
+```
+
+`dist/` may be ignored in Git if artifacts are attached to releases instead.
+
+---
+
+# 57. Initial Implementation Phases
+
+## Phase D0 — Bootstrap
+
+Set up:
+
+```text
+Git
+packwiz
+pack metadata
+directory structure
+```
+
+---
+
+## Phase D1 — Import Current Modpack
+
+Represent all currently approved mods through pack management
+
+Pin versions
+
+Resolve dependencies
+
+---
+
+## Phase D2 — Import Custom Layer
+
+Add:
+
+```text
+configs
+KubeJS
+resource packs
+quests
+datapacks
+```
+
+Verify source control coverage
+
+---
+
+## Phase D3 — Validation Scripts
+
+Create validation for:
+
+```text
+missing files
+duplicate mods
+pack metadata
+client/server classification
+```
+
+---
+
+## Phase D4 — Friend Build
+
+Produce first importable closed-beta artifact
+
+Test on fresh machine/instance
+
+---
+
+## Phase D5 — Server Build
+
+Generate server pack
+
+Test dedicated server
+
+---
+
+## Phase D6 — Update Test
+
+Install old version
+
+then update to new version
+
+Verify:
+
+```text
+world preserved
+options preserved where appropriate
+pack files updated
+server join succeeds
+```
+
+---
+
+## Phase D7 — Public Distribution Preparation
+
+Only after stable:
+
+```text
+license audit
+project metadata
+screenshots
+description
+release notes
+platform packaging
+```
+
+---
+
+# 58. Closed Beta Definition of Done
+
+Distribution system is ready for friends when:
+
+- A clean client can install from one package/import process.
+- No manual mod downloads are required.
+- Correct configs are included.
+- Correct KubeJS scripts are included.
+- Correct resource pack is included/enabled where possible.
+- FTB Quests are included.
+- Client can join dedicated server.
+- Pack versions can be identified easily.
+- Updating does not require replacing individual mods manually.
+- Existing saves survive supported updates.
+- Server backup procedure is documented.
+- Exact mod versions are pinned.
+- Build can be reproduced from Git.
+
+---
+
+# 59. Public Release Definition of Done
+
+Public release additionally requires:
+
+- Redistribution/license review complete.
+- Public README complete.
+- Changelog complete.
+- Clean install tested.
+- Server pack tested.
+- Existing-world compatibility documented.
+- Known issues documented.
+- No fatal KubeJS/config errors.
+- No development-only files included.
+- No secrets included.
+- Release artifacts use deterministic names.
+- Release tag corresponds to artifact.
+- Checksums generated where appropriate.
+
+---
+
+# 60. Claude Code Hard Rules
+
+## DO
+
+1. Use Git as source of truth.
+2. Use packwiz for pack dependency/version management.
+3. Pin exact versions.
+4. Keep custom configuration in source control.
+5. Build client and server distributions deliberately.
+6. Test on a clean instance.
+7. Backup worlds before upgrades.
+8. Document world compatibility for every release.
+9. Keep release artifacts reproducible.
+10. Prefer existing launcher/update ecosystems over custom launcher development.
+11. Audit mod redistribution rules before public release.
+12. Keep server/client version synchronized.
+
+## DO NOT
+
+1. Do not distribute only the `mods/` folder.
+2. Do not ask friends to configure the pack manually.
+3. Do not use `latest` versions automatically.
+4. Do not update production server without backup.
+5. Do not ship untested mod updates.
+6. Do not let developer launcher state become undocumented source of truth.
+7. Do not distribute secrets or server player data.
+8. Do not manually hotfix Discord copies without merging the change into source.
+9. Do not overwrite user preferences unnecessarily.
+10. Do not publish a public pack before licensing/redistribution review.
+
+---
+
+# 61. Final Distribution Architecture
+
+```text
+                 Git Repository
+                       │
+                       ▼
+                    packwiz
+                       │
+               ┌───────┴────────┐
+               │                │
+               ▼                ▼
+          Client Build      Server Build
+               │                │
+      ┌────────┼────────┐       │
+      │        │        │       │
+      ▼        ▼        ▼       ▼
+CurseForge  Modrinth   Prism  Dedicated
+ Profile    .mrpack   Update   Server
+      │        │        │       │
+      └────────┴────┬───┘       │
+                   ▼            │
+                Players ────────┘
+```
+
+---
+
+# 62. Final Feature Definition
+
+> **Industrial Civilization Survival must be distributed as a reproducible, versioned modpack where mods, configs, KubeJS integration, datapacks, quests and custom resources are treated as one product. Friends should be able to install or update the complete experience through a launcher/import workflow without manually recreating the developer's environment.**
+
+Target player experience:
+
+```text
+Import Pack
+↓
+Launch
+↓
+Play
+```
+
+Target developer experience:
+
+```text
+Change
+↓
+Commit
+↓
+Validate
+↓
+Build
+↓
+Test
+↓
+Release
+```
+
+This workflow ensures that every player receives the same Industrial Civilization Survival experience.

--- a/docs/OPEN-WORK-LEDGER.md
+++ b/docs/OPEN-WORK-LEDGER.md
@@ -11,10 +11,11 @@
 🔴 **UNTRACKED** (MD-only, no GitHub issue — highest miss-risk) · ⛔ decided won't-do (kept
 visible so it is not re-proposed as if it were open)
 
-**Current state, stated plainly:** the repo has its operating layer and its three design
-documents. It has **no pack** — no `pack.toml`, no mods, no config, no KubeJS. The mod list now
-stands at the main pack plus 7 QoL mods (Track 3) plus 3 wildlife mods (Track 4), and none of
-them has been version-checked against a Create major yet.
+**Current state, stated plainly:** the repo has its operating layer and its four design documents.
+It has **no pack** — no `pack.toml`, no mods, no config, no KubeJS. The mod list now stands at the
+main pack plus 7 QoL mods (Track 3) plus 3 wildlife mods (Track 4), and none of them has been
+version-checked against a Create major yet. Track 5 is the release machinery, which has nothing to
+release.
 
 ---
 
@@ -80,6 +81,29 @@ implementation work below is not started.
 **Standing constraint from this spec, applies outside Track 4:** under performance pressure the
 reduction order is ambient → small critters → duplicate species → common passives, and Create /
 MineColonies / hostile encounter design are cut **last**. Any future tuning session inherits this.
+
+## Track 5 — Distribution & release engineering
+
+Source: `docs/ADDON-MODPACK-DISTRIBUTION-AND-UPDATES.md`. Unlike Tracks 3 and 4 this one adds no
+mods — it governs how the pack ships, and parts of it constrain this repository's own process.
+Folded into the operating layer under **#7**.
+
+| Item | Status | Gate | Next action |
+|---|---|---|---|
+| Create `develop`, with its own ruleset | 🟡 | deliberately deferred — nothing to integrate and nobody running `main` | Create it in the same change that cuts the first `v0.x.0-alpha` tag. Distribution Spec §22; reasoning in `docs/agents/workflow.md` |
+| `scripts/build/` — `build-client`, `build-server`, `validate-pack`, `generate-checksums` | 🔴 | needs `pack.toml` | Distribution Spec §14. One deterministic release command, not four remembered ones |
+| Grow `verify.mjs` into `validate-pack` | 🔴 | each check is gated on its own prerequisite | Distribution Spec §15 — the seven-item checklist is mapped against what exists in the script's own header |
+| COMMON / SERVER / CLIENT side classification | 🔴 | needs the mod list | Distribution Spec §11 — **read each mod's actual requirement, never guess** |
+| Server pack, version-locked to the client pack | 🔴 | needs a built client pack | Distribution Spec §12 |
+| Config ownership map — PACK CONTROLLED vs USER PREFERENCE | 🔴 | needs `config/` to exist | Distribution Spec §30. Decides what an update may overwrite; getting it wrong destroys a player's keybinds |
+| `scripts/validate/config-drift` | 🔴 | needs the ownership map above | Distribution Spec §38 — the tool for "friend A works, friend B doesn't" |
+| Release gate — the 12 in-game tests | 🔴 | needs a launchable pack | Distribution Spec §16. **Not automatable.** Human protocol, sibling of §26–27 |
+| Checksums (`SHA256SUMS.txt`) + release tags + CurseForge / Modrinth publishing | 🔴 | needs a release | Distribution Spec §23, §33, §34, §39 |
+
+**Standing constraint from this spec, applies outside Track 5:** the pack is Git + packwiz — the
+manifest **plus** `config/`, `kubejs/`, `datapacks/`, `resourcepacks/`, `ftbquests/`. Zipping
+`mods/` and sending it gives someone the right jars and the wrong game (§5). `CHANGELOG.md` exists
+and every released version gets an entry.
 
 ---
 

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -75,6 +75,22 @@ From `docs/Addon Spec — Natural Wildlife & Ecology.md`. The layer exists so th
 | **Survival tax** | An anti-pattern, never a feature. Thirst, disease, parasites, hunger overhauls and butchering minigames are out of scope — wildlife raises immersion, not micromanagement (§53). | "realism", "hardcore survival" |
 | **W-phase** | The wildlife addon's own phase list, W0–W9, separate from the main §24 phases and gated behind them. Cite as *Wildlife Spec W3*, never as a bare number. | "phase 3" (ambiguous with §24) |
 
+## Distribution & release
+
+From `docs/ADDON-MODPACK-DISTRIBUTION-AND-UPDATES.md`. This vocabulary is about shipping the pack,
+and it is the only part of the design set that constrains this repository's own process.
+
+| Term | Definition | Aliases to avoid |
+|------|-----------|-----------------|
+| **Source of truth** | Git + packwiz. The pack is the *manifest plus the custom layer*, never a folder of jars. | "the mods folder", "the instance" |
+| **Pack-owned files** | `config/`, `defaultconfigs/`, `kubejs/`, `resourcepacks/`, `datapacks/`, `ftbquests/`, plus `pack.toml` / `index.toml`. These carry the gameplay. Shipping mods without them gives a friend the right jars and the wrong game (Distribution Spec §5). | "the pack files" (ambiguous with a built artifact) |
+| **Config ownership** | Every config file is either **PACK CONTROLLED** (spawn balance, Horde settings, recipes, Carry On blacklist, weapon durability — the pack decides) or **USER PREFERENCE** (HUD position, volume, keybinds — the player decides). An update overwrites the first kind and must not touch the second. | "default config" |
+| **Side classification** | Each mod is **COMMON**, **SERVER**, or **CLIENT**, recorded in packwiz side metadata. Must be read off the mod's actual requirement, never guessed (Distribution Spec §11). | "client mod" as a loose adjective |
+| **Server pack** | A separate distribution excluding client-only mods, whose version must equal the client pack's. A mismatch is either rejected or made loudly obvious. | "the server files" |
+| **Release gate** | The 12 in-game tests that must pass before publishing (Distribution Spec §16). *"Game launches once"* is explicitly not a release gate. None of it can be automated — it is the human protocol, the sibling of §26–27. | "smoke test", "QA" |
+| **Config drift** | A local edit to a PACK CONTROLLED file, diverging one install from the pack. The named symptom is "friend A works, friend B behaves differently" (Distribution Spec §38). | "local config" |
+| **Dev build** | An unreleased build from `develop` or a feature branch. Never handed to a friend as if it were a release; releases carry a tag. | "latest", "the current version" |
+
 ## Process
 
 | Term | Definition | Aliases to avoid |
@@ -159,6 +175,22 @@ PR description, comment ใน config, identifier ของ KubeJS และใ�
 | **Wildlife Roster** | `docs/wildlife-roster.md` คอลัมน์: Species/Role · Source Mod · Biome · Spawn Weight · Gameplay Role · Overlap · Decision เหมือน compatibility matrix มันบันทึกสิ่งที่**สังเกตได้จาก registry dump** ไม่ใช่สิ่งที่หน้าเว็บของ mod อ้าง | "ลิสต์สัตว์" |
 | **Survival tax** | เป็น anti-pattern ไม่เคยเป็น feature ความกระหายน้ำ โรค ปรสิต การรื้อระบบความหิว และมินิเกมชำแหละ อยู่นอกขอบเขต — สัตว์ป่าเพิ่มความสมจริง ไม่ใช่เพิ่มงานจุกจิก (§53) | "ความสมจริง", "hardcore survival" |
 | **W-phase** | phase list ของ addon สัตว์ป่าเอง คือ W0–W9 แยกจาก phase §24 ของ pack หลักและถูก gate ไว้ข้างหลัง อ้างอิงเป็น *Wildlife Spec W3* ห้ามอ้างเป็นตัวเลขเปล่า | "phase 3" (กำกวมกับ §24) |
+
+## การแจกจ่ายและการปล่อยเวอร์ชัน
+
+มาจาก `docs/ADDON-MODPACK-DISTRIBUTION-AND-UPDATES.md` คำศัพท์ชุดนี้ว่าด้วยการส่ง pack ออกไป และ
+เป็นส่วนเดียวในชุดเอกสารออกแบบที่บังคับกระบวนการของ repository นี้เอง
+
+| คำ | ความหมาย | ห้ามใช้ |
+|------|-----------|-----------------|
+| **Source of truth** | Git + packwiz ตัว pack คือ *manifest บวกชั้น custom* ไม่ใช่โฟลเดอร์ที่มี jar | "โฟลเดอร์ mods", "instance" |
+| **Pack-owned files** | `config/`, `defaultconfigs/`, `kubejs/`, `resourcepacks/`, `datapacks/`, `ftbquests/` บวก `pack.toml` / `index.toml` ไฟล์เหล่านี้คือตัว gameplay การส่ง mod ไปโดยไม่มีมันคือการให้เพื่อนได้ jar ที่ถูกแต่ได้เกมที่ผิด (Distribution Spec §5) | "ไฟล์ของ pack" (กำกวมกับ artifact ที่ build แล้ว) |
+| **Config ownership** | ไฟล์ config ทุกไฟล์เป็นอย่างใดอย่างหนึ่ง: **PACK CONTROLLED** (spawn balance, ค่า Horde, recipe, blacklist ของ Carry On, ความทนของอาวุธ — pack เป็นคนตัดสิน) หรือ **USER PREFERENCE** (ตำแหน่ง HUD, ระดับเสียง, ปุ่ม — ผู้เล่นเป็นคนตัดสิน) การอัปเดตทับแบบแรกได้ และห้ามแตะแบบหลัง | "config เริ่มต้น" |
+| **Side classification** | mod แต่ละตัวเป็น **COMMON**, **SERVER** หรือ **CLIENT** บันทึกไว้ใน side metadata ของ packwiz ต้องอ่านจากความต้องการจริงของ mod ห้ามเดา (Distribution Spec §11) | "client mod" แบบใช้เป็นคำขยายลอย ๆ |
+| **Server pack** | distribution แยกที่ตัด mod ฝั่ง client ออก และเวอร์ชันต้องเท่ากับ client pack ถ้าไม่ตรงต้องถูกปฏิเสธหรือทำให้เห็นชัดเจน | "ไฟล์เซิร์ฟเวอร์" |
+| **Release gate** | เทสต์ในเกม 12 ข้อที่ต้องผ่านก่อน publish (Distribution Spec §16) *"เกมเปิดได้ครั้งหนึ่ง"* ไม่ถือเป็น release gate โดยระบุชัด ไม่มีข้อไหนอัตโนมัติได้ — มันคือโปรโตคอลของคน พี่น้องกับ §26–27 | "smoke test", "QA" |
+| **Config drift** | การแก้ไฟล์ PACK CONTROLLED เฉพาะเครื่อง ทำให้ install หนึ่งเบี่ยงจาก pack อาการที่ระบุไว้คือ "เพื่อน A เล่นได้ เพื่อน B พฤติกรรมไม่เหมือนกัน" (Distribution Spec §38) | "config ในเครื่อง" |
+| **Dev build** | build ที่ยังไม่ปล่อย จาก `develop` หรือ feature branch ห้ามส่งให้เพื่อนราวกับว่าเป็น release ตัว release มี tag กำกับ | "ตัวล่าสุด", "เวอร์ชันปัจจุบัน" |
 
 ## กระบวนการ
 

--- a/docs/agents/reading-domain-docs.md
+++ b/docs/agents/reading-domain-docs.md
@@ -25,6 +25,7 @@ How the engineering skills should consume this repo's domain documentation when 
   - `docs/Industrial Civilization Survival — Claude Code Handoff & Implementation Plan.md`
   - `docs/Addon Spec — Crafting Assistance + Tactical Tracker.md`
   - `docs/Addon Spec — Natural Wildlife & Ecology.md`
+  - `docs/ADDON-MODPACK-DISTRIBUTION-AND-UPDATES.md` — governs this repo's own release process
 
 If any of these do not exist, **proceed silently**. Do not flag their absence; do not suggest
 creating them upfront. They are created lazily, when a term or a decision actually resolves.
@@ -103,6 +104,7 @@ skill ด้านวิศวกรรมควรอ่านเอกสา�
   - `docs/Industrial Civilization Survival — Claude Code Handoff & Implementation Plan.md`
   - `docs/Addon Spec — Crafting Assistance + Tactical Tracker.md`
   - `docs/Addon Spec — Natural Wildlife & Ecology.md`
+  - `docs/ADDON-MODPACK-DISTRIBUTION-AND-UPDATES.md` — governs this repo's own release process
 
 ถ้าไฟล์ใดไม่มี ให้ **ทำต่อไปเงียบ ๆ** อย่าไปทักว่ามันหายไป อย่าเสนอให้สร้างล่วงหน้า มันถูกสร้าง
 แบบ lazy เมื่อคำศัพท์หรือการตัดสินใจได้ข้อสรุปจริง ๆ

--- a/docs/agents/workflow.md
+++ b/docs/agents/workflow.md
@@ -16,6 +16,41 @@ When planning or implementing a change, follow this order:
 
 Hard ordering: **PRD → issues → PR**. Never open a PR without a referenced issue.
 
+## Branching and releases
+
+The target model is Distribution Spec §22:
+
+```
+main       stable / playable — what a friend has installed
+develop    integration
+feature/*  experimental changes
+```
+
+**`develop` does not exist yet, deliberately.** Its purpose is to keep unfinished integration away
+from a `main` that people are running, and nobody is running anything: there is no pack, no
+release, and one person on the repo. It is created — with its own ruleset — in the same change
+that cuts the first `v0.x.0-alpha` tag, which is the moment `main` starts meaning something to
+someone else. Tracked in the ledger.
+
+**Until then**, work branches off `main` and returns by PR. Name the branch so
+`.githooks/check-issue-ref` can see the issue number in the slug position:
+
+```
+chore/7-fold-distribution-spec        ✓  number right after the type prefix
+chore/fold-spec-7                     ✗  not in the slug position
+```
+
+**The Season 2 high-risk stack** — Valkyrien Skies, Clockwork, Warium, advanced TFMG integration —
+stays on its own branch (`feature/season2-aviation`) until it boots clean. It is never merged to
+`main` on the strength of "it worked once".
+
+**Release tags** are `v0.1.0-alpha`, `v0.4.0-beta`, `v1.0.0`. A tag must match the distributed
+artifact exactly, and every version gets a `CHANGELOG.md` entry. A build from `develop` or a
+feature branch is a **dev build** and is never handed to a friend as if it were a release.
+
+**Before publishing anything**, the release gate is Distribution Spec §16 — twelve in-game tests.
+*"The game launches once"* is explicitly not a release gate. None of it can be automated.
+
 ## What "test-first" means in a modpack repo
 
 This repo has no unit-test runner, so `/tdd` maps onto the pack's own evidence loop — the
@@ -88,6 +123,40 @@ Agent วางแผนและลงมือทำงานใน repo น�
 6. **`/tdd`** — เขียน test ก่อน แล้วค่อยทำให้ test ผ่าน
 
 ลำดับที่ห้ามสลับ: **PRD → issues → PR** ห้ามเปิด PR โดยไม่มี issue อ้างอิงเด็ดขาด
+
+## Branch และการปล่อยเวอร์ชัน
+
+โมเดลเป้าหมายคือ Distribution Spec §22:
+
+```
+main       stable / playable — สิ่งที่เพื่อนติดตั้งไว้
+develop    integration
+feature/*  การเปลี่ยนแปลงเชิงทดลอง
+```
+
+**`develop` ยังไม่มี โดยตั้งใจ** วัตถุประสงค์ของมันคือกันงาน integration ที่ยังไม่เสร็จออกจาก `main`
+ที่คนกำลังเล่นอยู่ และตอนนี้ไม่มีใครเล่นอะไรเลย: ไม่มี pack ไม่มี release และมีคนเดียวใน repo
+มันจะถูกสร้าง — พร้อม ruleset ของตัวเอง — ใน change เดียวกับที่ตัด tag `v0.x.0-alpha` แรก ซึ่งเป็น
+จังหวะที่ `main` เริ่มมีความหมายกับคนอื่น บันทึกไว้ใน ledger
+
+**จนกว่าจะถึงตอนนั้น** งานแตก branch จาก `main` แล้วกลับมาด้วย PR ตั้งชื่อ branch ให้
+`.githooks/check-issue-ref` เห็นเลข issue ในตำแหน่ง slug:
+
+```
+chore/7-fold-distribution-spec        ✓  เลขอยู่ถัดจาก type prefix ทันที
+chore/fold-spec-7                     ✗  ไม่ได้อยู่ในตำแหน่ง slug
+```
+
+**stack ความเสี่ยงสูงของ Season 2** — Valkyrien Skies, Clockwork, Warium, การ integrate TFMG
+ขั้นสูง — อยู่บน branch ของตัวเอง (`feature/season2-aviation`) จนกว่าจะ boot ผ่านสะอาด ห้าม merge
+เข้า `main` ด้วยเหตุผลว่า "มันเคยทำงานได้ครั้งหนึ่ง"
+
+**Release tag** ใช้รูป `v0.1.0-alpha`, `v0.4.0-beta`, `v1.0.0` tag ต้องตรงกับ artifact ที่แจกจ่าย
+เป๊ะ ๆ และทุกเวอร์ชันต้องมีรายการใน `CHANGELOG.md` ส่วน build จาก `develop` หรือ feature branch
+คือ **dev build** ห้ามส่งให้เพื่อนราวกับว่าเป็น release
+
+**ก่อน publish อะไรก็ตาม** release gate คือ Distribution Spec §16 — เทสต์ในเกม 12 ข้อ
+*"เกมเปิดได้ครั้งหนึ่ง"* ไม่ถือเป็น release gate โดยระบุชัด และไม่มีข้อไหนอัตโนมัติได้
 
 ## "test-first" ใน repo แบบ modpack แปลว่าอะไร
 

--- a/scripts/validate/verify.mjs
+++ b/scripts/validate/verify.mjs
@@ -16,6 +16,28 @@
 //   node scripts/validate/verify.mjs            # both
 //   node scripts/validate/verify.mjs lint
 //   node scripts/validate/verify.mjs test
+//
+// ---------------------------------------------------------------------------
+// This is the seed of `validate-pack` (Distribution Spec §14). Its §15 lists the
+// minimum a build must validate; three of those are implemented here and the
+// rest are blocked on a resolved pack, not on effort:
+//
+//   pack metadata valid          — needs pack.toml
+//   missing mods = 0             — needs packwiz index
+//   duplicate mods = 0           — needs packwiz index
+//   missing dependencies = 0     — needs packwiz index
+//   unexpected client/server     — needs packwiz side metadata
+//   KubeJS startup errors = 0    — needs a launched instance; not automatable here
+//   broken config references = 0 — needs the mod set to exist
+//   JSON / TOML syntax           — DONE (lint)
+//   unfilled placeholders        — DONE (lint), local addition
+//   KubeJS parses                — DONE (test)
+//
+// Add each check in the change that makes it possible, not before: a check that
+// cannot fail is a check nobody trusts. What this script does NOT and cannot do
+// is tell you the pack runs — that is the release gate (Distribution Spec §16),
+// twelve in-game tests, none of them automatable.
+// ---------------------------------------------------------------------------
 
 import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs'
 import { execFileSync } from 'node:child_process'


### PR DESCRIPTION
Closes #7.

## What is different about this document

The Crafting and Wildlife specs add mods. This one specifies **release engineering**, and three of
its sections describe infrastructure this repo already built during bootstrap — so folding it in
was reconciliation, not glossary work.

| Distribution Spec says | Repo had | Landed as |
|---|---|---|
| §14 `scripts/build/` with `validate-pack` | `scripts/validate/verify.mjs`, armed as the ship gate | The script's header now maps §15's ten checks against what exists — **3 done, 7 blocked on a resolved pack**, each with the specific prerequisite named |
| §22 `main` / `develop` / `feature/*` | `main` only, `chore/N-slug` PR branches | Model recorded in `docs/agents/workflow.md`; `develop` **deferred** — see below |
| §16 release gate, 12 in-game tests | nothing; §26–27 boot protocol is the nearest thing | Recorded as the human protocol it is. Explicitly **not** automatable, so it is not pretended into CI |
| §24 `CHANGELOG.md` per version | absent | Created |

## The one judgement call

**`develop` was not created.** Its stated purpose is keeping unfinished integration away from a
`main` that people are running. Nobody is running anything — no pack, no release, one person on
the repo. Creating it now buys an empty branch to keep in sync and a second place for a ruleset to
be wrong.

Deferred to the change that cuts the first `v0.x.0-alpha` tag, which is when `main` first means
"what a friend has installed". Reasoning is in `docs/agents/workflow.md` next to the model, and
Track 5 carries it as a 🟡 row rather than letting it become a silent omission.

**Overrule it in one comment if you'd rather have it from the start** — it is one command plus a
ruleset.

## Vocabulary added

Eight terms in both language halves of `docs/agents/domain.md`. Two are load-bearing beyond this
track:

- **Pack-owned files** — the pack is the manifest **plus** `config/`, `kubejs/`, `datapacks/`,
  `resourcepacks/`, `ftbquests/`. Zipping `mods/` and sending it gives someone the right jars and
  the wrong game (§5).
- **Config ownership** — every config file is PACK CONTROLLED or USER PREFERENCE. It decides what
  an update may overwrite; getting it wrong destroys a player's keybinds.

## Verification

`node scripts/validate/verify.mjs` → passed (2 JSON, 0 TOML, 31 files scanned, 0 KubeJS scripts).
The pre-push guards ran and passed.

Nothing here is verifiable in game — no mod exists yet. Every claim is about the repository.

---

## สรุปภาษาไทย

Closes #7

## เอกสารใบนี้ต่างจากใบอื่นอย่างไร

Crafting กับ Wildlife spec เพิ่ม mod ส่วนใบนี้ระบุ **release engineering** และสามหัวข้อของมัน
อธิบายโครงสร้างที่ repo นี้สร้างไว้แล้วตอน bootstrap การ fold เข้ามาจึงเป็นการปรับให้ตรงกัน ไม่ใช่
งาน glossary

| Distribution Spec บอกว่า | repo มีอยู่ | ลงเป็น |
|---|---|---|
| §14 `scripts/build/` ที่มี `validate-pack` | `scripts/validate/verify.mjs` ติดอาวุธเป็น ship gate แล้ว | header ของสคริปต์แม็ปเช็ค 10 ข้อของ §15 กับสิ่งที่มีอยู่ — **ทำแล้ว 3 ติดอยู่ 7** โดยระบุเงื่อนไขที่ติดของแต่ละข้อ |
| §22 `main` / `develop` / `feature/*` | มีแค่ `main` และ PR branch ชื่อ `chore/N-slug` | บันทึกโมเดลไว้ใน `docs/agents/workflow.md` ส่วน `develop` **เลื่อนไว้** — ดูด้านล่าง |
| §16 release gate เทสต์ในเกม 12 ข้อ | ไม่มี โปรโตคอล boot §26–27 ใกล้เคียงที่สุด | บันทึกไว้ตามที่มันเป็น คือโปรโตคอลของคน ระบุชัดว่า **อัตโนมัติไม่ได้** จึงไม่แกล้งยัดเข้า CI |
| §24 ต้องมี `CHANGELOG.md` ต่อเวอร์ชัน | ไม่มี | สร้างแล้ว |

## จุดเดียวที่ต้องใช้วิจารณญาณ

**ไม่ได้สร้าง `develop`** วัตถุประสงค์ที่ระบุไว้ของมันคือกันงาน integration ที่ยังไม่เสร็จออกจาก
`main` ที่คนกำลังเล่นอยู่ แต่ตอนนี้ไม่มีใครเล่นอะไร — ไม่มี pack ไม่มี release มีคนเดียวใน repo
การสร้างตอนนี้ได้มาแค่ branch ว่างที่ต้องคอย sync กับที่ที่ ruleset จะผิดได้เพิ่มอีกแห่ง

เลื่อนไปที่ change ซึ่งตัด tag `v0.x.0-alpha` แรก ซึ่งเป็นตอนที่ `main` เริ่มแปลว่า "สิ่งที่เพื่อน
ติดตั้งไว้" เหตุผลอยู่ใน `docs/agents/workflow.md` ข้าง ๆ ตัวโมเดล และ Track 5 เก็บมันไว้เป็นแถว 🟡
แทนที่จะปล่อยให้กลายเป็นการละเลยแบบเงียบ ๆ

**ถ้าอยากได้ตั้งแต่ต้น แย้งมาในคอมเมนต์เดียวได้เลย** — เป็นแค่คำสั่งเดียวบวก ruleset

## คำศัพท์ที่เพิ่ม

แปดคำในทั้งสองภาษาของ `docs/agents/domain.md` สองคำในนั้นรับน้ำหนักเกินขอบเขตของ track นี้:

- **Pack-owned files** — pack คือ manifest **บวก** `config/`, `kubejs/`, `datapacks/`,
  `resourcepacks/`, `ftbquests/` การ zip `mods/` ส่งไปคือการให้เขาได้ jar ที่ถูกและเกมที่ผิด (§5)
- **Config ownership** — ไฟล์ config ทุกไฟล์เป็น PACK CONTROLLED หรือ USER PREFERENCE มันตัดสินว่า
  การอัปเดตทับอะไรได้บ้าง ถ้าแยกผิดคือทำลายปุ่มที่ผู้เล่นตั้งไว้

## การ verify

`node scripts/validate/verify.mjs` → ผ่าน (JSON 2, TOML 0, สแกน 31 ไฟล์, KubeJS 0)
pre-push guards รันและผ่าน

ไม่มีอะไรในนี้ verify ในเกมได้ เพราะยังไม่มี mod ทุกคำกล่าวอ้างพูดถึง repository
