### PR TITLE
feat(pack-infra): add the Performance Spec §2 stack

### DIFF
--- a/DONE.md
+++ b/DONE.md
@@ -6,6 +6,56 @@
 
 ---
 
+## The pack exists and boots (2026-08-25, `/t4-afk` unattended run, branches `chore/9-*`, `feat/11-*`, `feat/13-*`)
+
+**Goal:** turn five design documents into a modpack a user can import into Minecraft.
+
+**Toolchain installed:** Temurin 17.0.20.1, Prism Launcher 11.0.3, Go 1.26.7, and packwiz built
+from source (`~/go/bin/packwiz.exe`) — packwiz publishes no releases, only CI artifacts, so source
+was the trustworthy route.
+
+**Shipped:**
+- **#9** — `docs/compatibility-matrix.md`. Every mod in five design documents swept against the
+  Modrinth API; Create's dependency ranges read from `META-INF/mods.toml` inside the jars.
+  **Create pinned to `6.0.8` — forced, not chosen**: the CORE addons intersect at `[6.0.8,6.1.0)`
+  and 6.0.8 is the newest 1.20.1 build.
+- **#11** — the pack. `pack.toml`, `index.toml`, `.packwizignore`, 83 mods pinned to exact
+  versions and hashes, `INSTALL.md`.
+- **#13** — the Performance Spec §2 stack: Embeddium, ModernFix, FerriteCore, Entity Culling,
+  ImmediatelyFast, ServerCore, FastSuite, Clumps, Chunky. 93 metafiles total.
+
+**Validation — run, not reasoned:**
+- Forge 47.4.23 dedicated server, Temurin 17, 6 GB heap. First boot: **failed**, one mod.
+  `cbc_firepower_components requires createbigcannons [5.8.0,5.9.0); currently 5.11.4`. Removed —
+  no version of it supports CBC ≥ 5.9.
+- Second boot, 76 jars: `Done (27.452s)!` — registries built, world generated, server live.
+- Third boot with the performance stack, 83 jars: green.
+- `node scripts/validate/verify.mjs` → passed; the TOML linter handled 85+ real packwiz metafiles.
+
+**Two of my own claims corrected mid-run, both load-bearing:**
+1. The matrix said `flywheel` and `ponder` were CurseForge-only dependencies to source by hand.
+   **They are bundled inside Create via Forge JarJar.** Acting on the wrong version put *Ponder for
+   KubeJS* — a different mod — into the pack. Removed before commit. Rule recorded: check
+   `META-INF/jarjar/` before hunting a Forge dependency.
+2. The sweep read every addon's range against `create` and stopped there, so it never saw that
+   `cbc_firepower_components` constrains `createbigcannons`. Only the boot caught it.
+
+**Findings that constrain distribution, recorded rather than smoothed:**
+- Four mods have third-party downloads disabled by their authors — TakKit, Flashier Flashlights,
+  Client Dynamic Light, Player Microchip. The CurseForge App handles them; every other route
+  requires the user to click a link. `INSTALL.md` names all four with URLs.
+- CameraCraft has no 1.20.1 Forge build anywhere; the CCTV layer needs another answer.
+- `TaCZ: Accelerated` is Core in Performance Spec §2 and CORE CANDIDATE in §19. Not added.
+
+**Not done, and not claimed:** the **client** has never been launched — that needs the developer's
+Microsoft account. No balance, no KubeJS, no configs. The pack runs; it does not yet play the way
+the design documents describe.
+
+**Artifact:** `build/Industrial-Civilization-Survival-0.1.0-alpha.zip` — CurseForge format,
+importable by CurseForge App, Prism, ATLauncher. Not committed (`.gitignore`).
+
+---
+
 ## Distribution & Updates spec folded in (2026-08-25, branch `chore/7-fold-distribution-spec`)
 
 **Goal:** a fourth design document arrived, and unlike the first three it constrains **this

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,7 +2,7 @@
 # Installing Industrial Civilization Survival
 
 **What you get:** a CurseForge-format modpack zip — `Industrial Civilization Survival 0.1.0-alpha`,
-Minecraft **1.20.1**, Forge **47.4.23**, **83 mods**.
+Minecraft **1.20.1**, Forge **47.4.23**, **93 mods**.
 
 **The official Minecraft launcher cannot import a modpack.** You need one of the launchers below.
 This is not a limitation of this pack; the official launcher has no modpack support at all.
@@ -12,7 +12,7 @@ This is not a limitation of this pack; the official launcher has no modpack supp
 ## Before you start
 
 - **Java 17.** Forge 47.x for 1.20.1 requires it. Both launchers below can install it for you.
-- **8 GB of RAM allocated to the game**, 6 GB minimum. 83 mods with Create contraptions,
+- **8 GB of RAM allocated to the game**, 6 GB minimum. 93 mods with Create contraptions,
   MineColonies pathfinding and Born in Chaos is not a light pack.
 - **~2 GB of disk** for the instance once mods are downloaded.
 
@@ -65,7 +65,7 @@ options or keybinds. The same four mods above still need manual download.
 
 ## First launch
 
-Expect **3–6 minutes** on first launch. Forge is loading 83 mods, and Create, MineColonies and
+Expect **3–6 minutes** on first launch. Forge is loading 93 mods, and Create, MineColonies and
 KubeJS all build registries and recipes on startup.
 
 **If it crashes**, the useful file is `logs/latest.log` in the instance folder — the last few
@@ -77,7 +77,7 @@ hundred lines name the mod. `crash-reports/` has the same information formatted 
 
 This is `0.1.0-alpha`. It is **the mod set, resolved and pinned** — and nothing else yet.
 
-- ✅ 83 mods at exact, verified versions; Create pinned to `6.0.8`
+- ✅ 93 mods at exact, verified versions; Create pinned to `6.0.8`
 - ❌ **No balance work.** Gun damage, mob health, spawn rates and ammunition costs are all at their
   mod defaults. The design intent — ammunition as an industrial resource, monsters that are
   dangerous through AI rather than health — is **not implemented yet**.
@@ -91,7 +91,7 @@ So it will run, and it will not yet play the way the design documents describe. 
 # วิธีติดตั้ง Industrial Civilization Survival
 
 **สิ่งที่คุณได้:** modpack zip รูปแบบ CurseForge — `Industrial Civilization Survival 0.1.0-alpha`,
-Minecraft **1.20.1**, Forge **47.4.23**, **83 mods**
+Minecraft **1.20.1**, Forge **47.4.23**, **93 mods**
 
 **Launcher ทางการของ Minecraft import modpack ไม่ได้** ต้องใช้ launcher ตัวใดตัวหนึ่งด้านล่าง
 นี่ไม่ใช่ข้อจำกัดของ pack นี้ แต่ launcher ทางการไม่มีฟีเจอร์ modpack เลย
@@ -101,7 +101,7 @@ Minecraft **1.20.1**, Forge **47.4.23**, **83 mods**
 ## ก่อนเริ่ม
 
 - **Java 17** Forge 47.x สำหรับ 1.20.1 ต้องใช้ launcher ทั้งสองตัวด้านล่างติดตั้งให้ได้
-- **แรมที่จัดให้เกม 8 GB** ขั้นต่ำ 6 GB — 83 mod ที่มีทั้ง contraption ของ Create, pathfinding ของ
+- **แรมที่จัดให้เกม 8 GB** ขั้นต่ำ 6 GB — 93 mod ที่มีทั้ง contraption ของ Create, pathfinding ของ
   MineColonies และ Born in Chaos ไม่ใช่ pack เบา ๆ
 - **พื้นที่ดิสก์ ~2 GB** สำหรับ instance หลังโหลด mod ครบ
 
@@ -153,7 +153,7 @@ java -jar packwiz-installer-bootstrap.jar http://localhost:8080/pack.toml
 
 ## การเปิดครั้งแรก
 
-คาดว่าจะใช้เวลา **3–6 นาที** ในการเปิดครั้งแรก Forge กำลังโหลด 83 mod และ Create, MineColonies
+คาดว่าจะใช้เวลา **3–6 นาที** ในการเปิดครั้งแรก Forge กำลังโหลด 93 mod และ Create, MineColonies
 กับ KubeJS ต่างก็สร้าง registry และ recipe ตอนเริ่มระบบ
 
 **ถ้ามันแครช** ไฟล์ที่มีประโยชน์คือ `logs/latest.log` ในโฟลเดอร์ instance — สองสามร้อยบรรทัดสุดท้าย
@@ -165,7 +165,7 @@ java -jar packwiz-installer-bootstrap.jar http://localhost:8080/pack.toml
 
 นี่คือ `0.1.0-alpha` มันคือ **ชุด mod ที่ resolve และ pin เรียบร้อยแล้ว** — และยังไม่มีอย่างอื่น
 
-- ✅ 83 mod ที่เวอร์ชันเป๊ะและตรวจสอบแล้ว Create pin ที่ `6.0.8`
+- ✅ 93 mod ที่เวอร์ชันเป๊ะและตรวจสอบแล้ว Create pin ที่ `6.0.8`
 - ❌ **ยังไม่มีงาน balance เลย** ดาเมจปืน เลือดม็อบ อัตรา spawn และต้นทุนกระสุน ยังเป็นค่า default
   ของแต่ละ mod ทั้งหมด เจตนาการออกแบบ — กระสุนเป็นทรัพยากรอุตสาหกรรม, สัตว์ประหลาดอันตราย
   เพราะ AI ไม่ใช่เพราะเลือดเยอะ — **ยังไม่ได้ถูกทำ**

--- a/docs/OPEN-WORK-LEDGER.md
+++ b/docs/OPEN-WORK-LEDGER.md
@@ -45,14 +45,16 @@ tier — is now a decided operating mode rather than a pending task, which is wh
 
 ## Track 2 — Pack construction (handoff doc §24, in order)
 
-Not startable until Track 1 resolves. Listed so they are visible, not so they are picked up.
-
 | Item | Status | Gate | Next action |
 |---|---|---|---|
-| Phase 0 — repository bootstrap + packwiz init + the five `docs/` files | 🔴 | packwiz | §32 Task 1–3 |
-| Phase 1 — Create baseline batch, one mod at a time | 🔴 | Create version decision | §24 Phase 1 |
-| Phase 2 — combat baseline + `docs/combat-baseline.md` TTK matrix | 🔴 | Phase 1 green | §24 Phase 2 |
-| Phases 3–13 | 🔴 | strictly sequential | see §24 |
+| Phase 0 — packwiz init, `pack.toml`, `index.toml`, `.packwizignore` | ✅ | — | MC 1.20.1 / Forge 47.4.23. **#11** |
+| Phase 1 — the Create stack | ✅ | — | Create pinned `6.0.8`; `cbc_firepower_components` removed — it cannot load with CBC 5.11 (**#11**) |
+| Mod set resolved and pinned | ✅ | — | 93 metafiles incl. the §2 performance stack (**#13**). Server boot green |
+| **Phase 2 — combat baseline, `docs/combat-baseline.md` TTK matrix** | 🟢 | **buildable now** | §24 Phase 2. Needs a launched *client* — the developer's account. This is where balance work actually starts |
+| Phases 3–13 | 🔴 | strictly sequential, after Phase 2 | see §24 |
+| Client boot test (§26 full protocol) | 🟡 | needs the developer's Microsoft account | Import per `INSTALL.md`, launch, create a world, reload, read `latest.log` |
+| Re-add `cbc_firepower_components` | 🟡 | needs an upstream release supporting CBC ≥ 5.9 | Watch the project; one `packwiz mr add` when it exists |
+| Re-evaluate `TaCZ: Accelerated` | 🟡 | needs a benchmark baseline | Performance Spec §2 calls it Core, §19 calls it CORE CANDIDATE. Resolve the contradiction with a measurement, not a reading |
 
 ## Track 3 — Addon Spec (Crafting Assistance + Tactical Tracker)
 

--- a/docs/compatibility-matrix.md
+++ b/docs/compatibility-matrix.md
@@ -2,7 +2,13 @@
 
 **This is a record of what has been observed, not of what should work.** A row is marked `PASS` in
 **Tested** only after the pack has been launched with that exact version and the boot protocol
-(§26) has run. Every Tested cell below is empty, because nothing has been launched yet.
+(§26) has run.
+
+**Tested cells are still empty, and that is correct.** A **dedicated server** boot has passed
+(see *Boot test* below) — every mod loaded, registries built, a world generated. That is not §26.
+§26 is the **client** protocol: launch, create a world, join, save, restart, reload, read
+`latest.log` and `crash-reports/`. The client has never been launched; it needs the developer's
+Microsoft account. Do not fill a Tested cell from the server result.
 
 - **Platform:** Minecraft `1.20.1` · Forge · Java 17
 - **Create:** pinned to **`6.0.8`** — see *The Create pin* below
@@ -69,15 +75,15 @@ the jar, and a `mods.toml` entry looks identical whether the dependency is bundl
 | Create | `mc1.20.1-6.0.8` | MR | COMMON | CORE | flywheel, ponder | |
 | Create: Steam 'n' Rails | `1.7.2+forge-mc1.20.1` | MR | COMMON | CORE | create | |
 | Create Big Cannons | `5.11.4` | MR | COMMON | CORE | create, ritchiesprojectilelib | |
-| CBC: Firepower Components | `0.2.0` | MR | COMMON | CORE | create-big-cannons | |
+| ~~CBC: Firepower Components~~ | `0.2.0` | MR | COMMON | **REMOVED** | create-big-cannons `[5.8.0,5.9.0)` | ❌ blocked the server boot — see *Boot test* |
 | Create Crafts & Additions | `1.20.1-1.3.3` | MR | COMMON | CORE | create | |
 | Create: Diesel Generators | `1.20.1-1.3.12` | MR | COMMON | CORE | create | |
 | Create: New Age | `1.2.0+forge-mc1.20.1` | MR | COMMON | SEASON 2 | create, esl | |
 | Create: Copycats+ | `3.0.8+mc.1.20.1-forge` | MR | COMMON | DEPENDENCY | create | optional CBC integration |
 | FramedBlocks | `9.4.3` | MR | COMMON | DEPENDENCY | — | optional CBC integration |
-| Flywheel | *see note* | CF | — | DEPENDENCY | — | |
-| Ponder | *see note* | CF | — | DEPENDENCY | — | |
-| Ritchie's Projectile Lib | *see note* | CF | — | DEPENDENCY | — | |
+| Flywheel | bundled in Create | — | — | **DO NOT ADD** | — | inside `create-1.20.1-6.0.8.jar` |
+| Ponder | bundled in Create | — | — | **DO NOT ADD** | — | inside `create-1.20.1-6.0.8.jar` |
+| Ritchie's Projectile Lib | `2.1.1+mc.1.20.1` | MR (`rpl`) | COMMON | DEPENDENCY | — | auto-resolved with CBC |
 | Electric Sheep Library (`esl`) | *see note* | CF | — | DEPENDENCY | — | Season 2 only |
 
 ## Guns / tactical combat
@@ -170,6 +176,35 @@ the jar, and a `mods.toml` entry looks identical whether the dependency is bundl
 
 ---
 
+## Performance stack (Performance Spec §2)
+
+| Mod | Version | Source | Side | Status | Tested |
+|---|---|---|---|---|---|
+| Embeddium | `0.3.31+mc1.20.1` | MR | CLIENT | CORE | |
+| ModernFix | `5.27.77+mc1.20.1` | MR | COMMON | CORE | |
+| FerriteCore | `6.0.1` | MR | COMMON | CORE | |
+| Entity Culling | `1.10.5` | MR | CLIENT | CORE | |
+| ImmediatelyFast | `1.2.7+1.20.2` | MR | CLIENT | CORE | packwiz resolved this, not the `1.5.5+1.20.4` the sweep saw — that build is 1.20.4-first |
+| ServerCore | `1.5.2+1.20.1` | MR | SERVER | CORE | |
+| FastSuite | `5.1.2` | MR | COMMON | CORE | pulls `Placebo 8.6.3` |
+| Clumps | `12.0.0.4` | MR | COMMON | CORE | |
+| Chunky | `1.3.146` | MR | COMMON | CORE | |
+| **TaCZ: Accelerated** | — | CF (`tacza`) | — | **NOT ADDED** | see below |
+
+**Chunky vs Chunk-Pregenerator resolved itself.** §2 forbids installing both without a reason.
+Chunk Pregenerator has a Modrinth project but **no 1.20.1 Forge build**, so there was no choice to
+make.
+
+**TaCZ: Accelerated is not in the pack, and the spec contradicts itself about it.** §2 lists it as
+item 9 of the *Approved Core Performance Stack*; §19 gives its status as
+`CORE CANDIDATE / PROMOTE AFTER BENCHMARK`. The stricter reading wins: it is not promoted until a
+benchmark exists, which matches §3's discipline for every other candidate and §33's rule that
+measurement precedes tuning. There is no baseline to measure against yet. Re-read §2 against §19
+before adding it.
+
+**§3 Experimental mods are all absent by design** — AI Improvements, Let Me Despawn, Alternate
+Current, Canary, TaCZ Optimization, Smooth Boot Reloaded. Each needs its own benchmark branch.
+
 ## Boot test — 2026-08-25, Forge dedicated server
 
 The first real test of the mod set. Forge 47.4.23 dedicated server, Temurin 17.0.20.1, 6 GB heap,
@@ -220,3 +255,19 @@ Microchip. They are named in the design documents but were not in the sweep list
 
 **Naturalist's newest 1.20.1 build is `5.0pre4`, a prerelease.** Pinning a prerelease into a CORE
 slot is a decision, not a default.
+
+### Boot 3 — with the Performance Spec §2 stack (2026-08-25)
+
+Same server, 83 jars after client-only filtering.
+
+```
+[06:05:52] Done (22.295s)! For help, type "help"
+```
+
+**Green.** And measurably faster than the same set without it: **27.452s → 22.295s** on identical
+hardware and heap.
+
+That is an observation, not a benchmark. It is one cold start on one machine with no world cache,
+and startup time is not the metric the Performance Spec cares about — §33–39 define the real ones
+(MSPT, TPS, entity tick time, client FPS) across four scenarios. Do not quote 22.295s as evidence
+the pack performs well; quote it only as evidence the stack loads and does not regress startup.

--- a/index.toml
+++ b/index.toml
@@ -51,6 +51,11 @@ hash = "a613f5d2df911fea606968bbdb56eebfd05ac02ada846cf0d2e56e72345d9338"
 metafile = true
 
 [[files]]
+file = "mods/chunky.pw.toml"
+hash = "0e17f9758f6f67ef87aa6f8d5afc47901521a05904cd8470ef65063b48e69d73"
+metafile = true
+
+[[files]]
 file = "mods/client-dynamic-light.pw.toml"
 hash = "237b0859d871b5f843ed689971ee1487a80c86db58aa656901b99d9c0d3a5f91"
 metafile = true
@@ -58,6 +63,11 @@ metafile = true
 [[files]]
 file = "mods/clothingcraft.pw.toml"
 hash = "876b1d3316748666d4933c02c09ea9a87b9faca7f1e3a1fbc717c8e4d57f4e0f"
+metafile = true
+
+[[files]]
+file = "mods/clumps.pw.toml"
+hash = "903352ffbd84d4b95fed905893f4715d9c3f88ec9fff6fb06f6e359e0b839dc3"
 metafile = true
 
 [[files]]
@@ -126,13 +136,33 @@ hash = "08d12a69200642b29a2c8aff6b337f661c8756c2624d23db4b969b0610195823"
 metafile = true
 
 [[files]]
+file = "mods/embeddium.pw.toml"
+hash = "5ec0c37f3f4ad07a40c10376668bca80334ddb7ad2bab06eb4de8f7aac339c8e"
+metafile = true
+
+[[files]]
 file = "mods/enhanced-ai.pw.toml"
 hash = "a7f9970f68f2520ecc16794420e83c66ef2e8fb1b5113ffed1303cdaa8b48ade"
 metafile = true
 
 [[files]]
+file = "mods/entityculling.pw.toml"
+hash = "fbad2488da791994cbb4a0541e2dd22c536dbe6ca8f7edfdd9af12120e283fd2"
+metafile = true
+
+[[files]]
 file = "mods/farmers-delight.pw.toml"
 hash = "a21b5d4f95cf3c7cbf704bb0b42138ec9271663a5a2c0ed7b9601e4bf179604e"
+metafile = true
+
+[[files]]
+file = "mods/fastsuite.pw.toml"
+hash = "ecac0e58853b90c2208ec25738b43f212d92c89f7742b61aca817b681deca352"
+metafile = true
+
+[[files]]
+file = "mods/ferrite-core.pw.toml"
+hash = "902bac905b93271f02bd0951a22bac06a3da24f5c237fcaeb469e14a7679e508"
 metafile = true
 
 [[files]]
@@ -183,6 +213,11 @@ metafile = true
 [[files]]
 file = "mods/iceandfire-ce.pw.toml"
 hash = "4d5aefab5b2b6d16b0e54fb85efc9c96f7cc9bb2c7d97286a9b9ecad9f539f02"
+metafile = true
+
+[[files]]
+file = "mods/immediatelyfast.pw.toml"
+hash = "835bd8b05a05ce6c0981ddc37c49e4c476aa0414cc2a5321fd9f8994193b6feb"
 metafile = true
 
 [[files]]
@@ -256,6 +291,11 @@ hash = "7853c06a90fb36d5518566ab5ae1f77bdba37eb0ffffc6c73b26d402db64c31f"
 metafile = true
 
 [[files]]
+file = "mods/modernfix.pw.toml"
+hash = "a53d3c53ddfdfb26bb6cecf0428ec4ade0daa8b4f49932acbc55d965817b0c6d"
+metafile = true
+
+[[files]]
 file = "mods/mouse-tweaks.pw.toml"
 hash = "679fa8f3b49b9ed3fbcb29d6ccdb99bce465faa01f9cec000464ac8d4fbe134f"
 metafile = true
@@ -273,6 +313,11 @@ metafile = true
 [[files]]
 file = "mods/not-enough-animations.pw.toml"
 hash = "1c3d52224f1f174fbcf2c308a70e3c34a736694b626992891404db32cbd69c7e"
+metafile = true
+
+[[files]]
+file = "mods/placebo.pw.toml"
+hash = "969078b157cd783f7c38ac33407abc4f532c244c973d52810d559f02be06db90"
 metafile = true
 
 [[files]]
@@ -318,6 +363,11 @@ metafile = true
 [[files]]
 file = "mods/serene-seasons.pw.toml"
 hash = "23ef0c67ed600fb75d47161cdbe43b860837afe9d1f3012c44f3e7eb13bdd1e5"
+metafile = true
+
+[[files]]
+file = "mods/servercore.pw.toml"
+hash = "874a064efc37398f5818a38666ea31263bd65ed0478b519b819f7a361bd0893e"
 metafile = true
 
 [[files]]

--- a/mods/chunky.pw.toml
+++ b/mods/chunky.pw.toml
@@ -1,0 +1,13 @@
+name = "Chunky"
+filename = "Chunky-1.3.146.jar"
+side = "both"
+
+[download]
+url = "https://cdn.modrinth.com/data/fALzjamp/versions/4FTDk9wv/Chunky-1.3.146.jar"
+hash-format = "sha512"
+hash = "13ef9d5bfea1895118eec45aa3071e2d79408241f29990624f67e157d4c525391753b0a1539ff3359dad79a6e5ab5e0b84fffbe528bdefcaaefd579ec794d9c9"
+
+[update]
+[update.modrinth]
+mod-id = "fALzjamp"
+version = "4FTDk9wv"

--- a/mods/clumps.pw.toml
+++ b/mods/clumps.pw.toml
@@ -1,0 +1,13 @@
+name = "Clumps"
+filename = "Clumps-forge-1.20.1-12.0.0.4.jar"
+side = "both"
+
+[download]
+url = "https://cdn.modrinth.com/data/Wnxd13zP/versions/nAHGB5ls/Clumps-forge-1.20.1-12.0.0.4.jar"
+hash-format = "sha512"
+hash = "ffd8ff2438e9f9d260d3926ccdd0cccc4772c6f99f29715690aed4f6e97a76035f3aeaa78168e2a458bc4cccf521e97ebdb6e0b61c819facb04af9ebb3638383"
+
+[update]
+[update.modrinth]
+mod-id = "Wnxd13zP"
+version = "nAHGB5ls"

--- a/mods/embeddium.pw.toml
+++ b/mods/embeddium.pw.toml
@@ -1,0 +1,13 @@
+name = "Embeddium"
+filename = "embeddium-0.3.31+mc1.20.1.jar"
+side = "client"
+
+[download]
+url = "https://cdn.modrinth.com/data/sk9rgfiA/versions/UTbfe5d1/embeddium-0.3.31%2Bmc1.20.1.jar"
+hash-format = "sha512"
+hash = "ffbf2da4685260a4d5c14c621708bd20722563f084f042d3dfb0a7b87f048e39299648c854a93939129da0d23a15a91ec628560d601e76074b08e275f6e132e9"
+
+[update]
+[update.modrinth]
+mod-id = "sk9rgfiA"
+version = "UTbfe5d1"

--- a/mods/entityculling.pw.toml
+++ b/mods/entityculling.pw.toml
@@ -1,0 +1,13 @@
+name = "Entity Culling"
+filename = "entityculling-forge-1.10.5-mc1.20.1.jar"
+side = "client"
+
+[download]
+url = "https://cdn.modrinth.com/data/NNAgCjsB/versions/MloBcsQQ/entityculling-forge-1.10.5-mc1.20.1.jar"
+hash-format = "sha512"
+hash = "00f4d6987a7902597e6e3f178f77308d795b2e1c46a2bfdad79f718e8a7417373971b83004cbbe491582d91d1658718187383a368a813af0266ba99804746814"
+
+[update]
+[update.modrinth]
+mod-id = "NNAgCjsB"
+version = "MloBcsQQ"

--- a/mods/fastsuite.pw.toml
+++ b/mods/fastsuite.pw.toml
@@ -1,0 +1,13 @@
+name = "FastSuite"
+filename = "FastSuite-1.20.1-5.1.2.jar"
+side = "both"
+
+[download]
+url = "https://cdn.modrinth.com/data/roccmqou/versions/nhk4VpGm/FastSuite-1.20.1-5.1.2.jar"
+hash-format = "sha512"
+hash = "5c41292a26c7a42ba462d92005afef0df80ce62714d3d47034be4a488c4632dcbf41d647a7825980008bf3970a14dd3cf181063f511231a8d55c235be0db1729"
+
+[update]
+[update.modrinth]
+mod-id = "roccmqou"
+version = "nhk4VpGm"

--- a/mods/ferrite-core.pw.toml
+++ b/mods/ferrite-core.pw.toml
@@ -1,0 +1,13 @@
+name = "FerriteCore"
+filename = "ferritecore-6.0.1-forge.jar"
+side = "both"
+
+[download]
+url = "https://cdn.modrinth.com/data/uXXizFIs/versions/DG5Fn9Sz/ferritecore-6.0.1-forge.jar"
+hash-format = "sha512"
+hash = "a1960a7c03dc32d4ccaccaf28afdd9b078758bbd62d15a91d4039a83fa9397a098e89b69591f6bd5190254d9ee97e502504154b9aec764adb8c65f000b75ba2c"
+
+[update]
+[update.modrinth]
+mod-id = "uXXizFIs"
+version = "DG5Fn9Sz"

--- a/mods/immediatelyfast.pw.toml
+++ b/mods/immediatelyfast.pw.toml
@@ -1,0 +1,13 @@
+name = "ImmediatelyFast"
+filename = "ImmediatelyFast-1.2.7+1.20.2.jar"
+side = "client"
+
+[download]
+url = "https://cdn.modrinth.com/data/5ZwdcRci/versions/yciHw2oP/ImmediatelyFast-1.2.7%2B1.20.2.jar"
+hash-format = "sha512"
+hash = "669a625894f175bc818062a194fb52b6163b2ddcb60cfb57a93efbb1c4e855b20200e175e225f86870cfde0846b80a50084088a2aefe6783cc2b49a6de59b2ba"
+
+[update]
+[update.modrinth]
+mod-id = "5ZwdcRci"
+version = "yciHw2oP"

--- a/mods/modernfix.pw.toml
+++ b/mods/modernfix.pw.toml
@@ -1,0 +1,13 @@
+name = "ModernFix"
+filename = "modernfix-forge-5.27.77+mc1.20.1.jar"
+side = "both"
+
+[download]
+url = "https://cdn.modrinth.com/data/nmDcB62a/versions/Za21t5GN/modernfix-forge-5.27.77%2Bmc1.20.1.jar"
+hash-format = "sha512"
+hash = "a8f1d38313524acf010c976550f25ea4b023fb2fc6a38e834ef821c0b3dfd11008bca74a9c9c114d7952a1bf0f1ca186628c5f321f396e994f67b1c19515d120"
+
+[update]
+[update.modrinth]
+mod-id = "nmDcB62a"
+version = "Za21t5GN"

--- a/mods/placebo.pw.toml
+++ b/mods/placebo.pw.toml
@@ -1,0 +1,13 @@
+name = "Placebo"
+filename = "Placebo-1.20.1-8.6.3.jar"
+side = "both"
+
+[download]
+url = "https://cdn.modrinth.com/data/tCkE8p2N/versions/6SkuAGoz/Placebo-1.20.1-8.6.3.jar"
+hash-format = "sha512"
+hash = "c23990465e26336f476c3b05a897bcf0c8660ae7338756b325f6bf81d0dee34b609474c62293f394acac818637ab03f92c776d104c8b8e86f3786395f5c4d623"
+
+[update]
+[update.modrinth]
+mod-id = "tCkE8p2N"
+version = "6SkuAGoz"

--- a/mods/servercore.pw.toml
+++ b/mods/servercore.pw.toml
@@ -1,0 +1,13 @@
+name = "ServerCore"
+filename = "servercore-forge-1.5.2+1.20.1.jar"
+side = "server"
+
+[download]
+url = "https://cdn.modrinth.com/data/4WWQxlQP/versions/rx1c7m6q/servercore-forge-1.5.2%2B1.20.1.jar"
+hash-format = "sha512"
+hash = "650f54dcf6d44e26cbc180ca5779857574692f02ff2a55146ed085db1665dde7fb578c75d655e3de064ed56599bc6d38dd547f5f123381c0a54867b98f805b0c"
+
+[update]
+[update.modrinth]
+mod-id = "4WWQxlQP"
+version = "rx1c7m6q"

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "d41d0c3d4b92c9c8463cfde602a72a73d1989501a138a5d71fe1abc849105b6c"
+hash = "0d3e02dca57d1fa3a5e5e492c306486bd6061f17649e4e264bd9fb65102b17e9"
 
 [versions]
 forge = "47.4.23"


### PR DESCRIPTION
Closes #13.

Nine mods plus Chunky, all from Modrinth. **93 metafiles** in the pack.

| | |
|---|---|
| Embeddium `0.3.31` · Entity Culling `1.10.5` · ImmediatelyFast `1.2.7` | CLIENT |
| ModernFix `5.27.77` · FerriteCore `6.0.1` · FastSuite `5.1.2` · Clumps `12.0.0.4` · Chunky `1.3.146` | COMMON |
| ServerCore `1.5.2` | SERVER |

## Two decisions the spec left to be resolved

**Chunky vs Chunk-Pregenerator** — §2 forbids both without a reason. No reason was needed: Chunk Pregenerator has a Modrinth project and **no 1.20.1 Forge build**.

**TaCZ: Accelerated is not added, and the spec contradicts itself.** §2 lists it as item 9 of the *Approved Core Performance Stack*. §19 gives its status as `CORE CANDIDATE / PROMOTE AFTER BENCHMARK`. I took the stricter reading — there is no benchmark baseline to promote it against, and §33 is explicit that measurement precedes tuning. Recorded in the matrix and the ledger so it is a decision, not an omission.

No §3 Experimental mod is in the pack.

## Verified by running it

**Boot 3** — same Forge 47.4.23 server, 83 jars after client-only filtering:

```
[06:05:52] Done (22.295s)! For help, type "help"
```

Green, and faster than the identical set without the stack — **27.452s → 22.295s**.

**That is an observation, not a benchmark**, and the matrix says so in those words. One cold start, one machine, no world cache, and startup time is not among the metrics §33–39 actually define (MSPT, TPS, entity tick time, client FPS across four scenarios).

## Matrix header corrected

It claimed every Tested cell was empty *"because nothing has been launched yet"*. A server has now booted three times. **The cells stay empty regardless** — §26 is the *client* protocol, and the client still has not run. The header now says which of the two it is, so nobody fills a Tested cell from a server result.

`node scripts/validate/verify.mjs` → passed (95 TOML files).

---

## สรุปภาษาไทย

Closes #13

เก้า mod บวก Chunky ทั้งหมดจาก Modrinth **93 metafile** ใน pack

| | |
|---|---|
| Embeddium `0.3.31` · Entity Culling `1.10.5` · ImmediatelyFast `1.2.7` | CLIENT |
| ModernFix `5.27.77` · FerriteCore `6.0.1` · FastSuite `5.1.2` · Clumps `12.0.0.4` · Chunky `1.3.146` | COMMON |
| ServerCore `1.5.2` | SERVER |

## สองการตัดสินใจที่เอกสารเปิดค้างไว้

**Chunky กับ Chunk-Pregenerator** — §2 ห้ามลงทั้งคู่โดยไม่มีเหตุผล ปรากฏว่าไม่ต้องใช้เหตุผลเลย: Chunk Pregenerator มีโปรเจกต์บน Modrinth แต่ **ไม่มี build 1.20.1 Forge**

**TaCZ: Accelerated ไม่ถูกเพิ่ม และเอกสารขัดกันเอง** §2 ใส่มันไว้เป็นลำดับ 9 ของ *Approved Core Performance Stack* ส่วน §19 ระบุสถานะเป็น `CORE CANDIDATE / PROMOTE AFTER BENCHMARK` ผมเลือกอ่านแบบเข้มกว่า — ยังไม่มี benchmark baseline ให้เลื่อนขั้นเทียบ และ §33 บอกชัดว่าการวัดมาก่อนการจูน บันทึกไว้ใน matrix และ ledger แล้ว เพื่อให้มันเป็นการตัดสินใจ ไม่ใช่การละเลย

ไม่มี mod จาก §3 Experimental อยู่ใน pack

## ยืนยันด้วยการรันจริง

**Boot 3** — Forge 47.4.23 server ตัวเดิม 83 jar หลังกรอง client-only:

```
[06:05:52] Done (22.295s)! For help, type "help"
```

เขียว และเร็วกว่าชุดเดียวกันที่ไม่มี stack นี้ — **27.452s → 22.295s**

**นั่นคือการสังเกต ไม่ใช่ benchmark** และ matrix เขียนไว้ด้วยคำนั้น มันคือ cold start ครั้งเดียว เครื่องเดียว ไม่มี world cache และเวลา startup ไม่ได้อยู่ในตัวชี้วัดที่ §33–39 กำหนดไว้จริง (MSPT, TPS, entity tick time, client FPS ข้ามสี่ scenario)

## แก้หัวของ matrix

มันเขียนว่าทุกช่อง Tested ว่างเปล่า *"เพราะยังไม่มีอะไรถูกเปิด"* ตอนนี้เซิร์ฟเวอร์ boot ไปแล้วสามครั้ง **ช่องเหล่านั้นยังคงว่างอยู่ดี** — §26 คือโปรโตคอลฝั่ง *client* และ client ยังไม่เคยรัน ตอนนี้หัวเอกสารระบุแล้วว่าอันไหนเป็นอันไหน เพื่อไม่ให้ใครเอาผลฝั่ง server ไปเติมช่อง Tested