### PR TITLE
chore(pack-infra): end the AFK run, restore the destructive-command guard

### DIFF
--- a/.claude/t4.json
+++ b/.claude/t4.json
@@ -4,5 +4,5 @@
   "autoMerge": false,
   "requireGreenCI": false,
   "note": "Marker that flags this as a T4 repo — the hooks fire only when this file is present, so they never touch a non-T4 repo. Set \"verify\" to a FAST test command (unit+build+lint; leave e2e to CI) to arm the local ship gate: t4-gate RUNS it before `gh pr merge` and blocks on failure. Empty = off; keep it in sync with .github/workflows/t4-verify.yml. Set \"requireGreenCI\" true to also block `gh pr merge` while any server-side check is failing or still pending (`gh pr checks`) — the fallback for repos that can't make checks required in branch protection; see references/ci-cd-layer.md. Set \"autoMerge\" (or \"afk\") true during an unattended run so `gh pr merge` doesn't stop to ask for review confirmation — the verify and CI denies still apply. \"afk\": true additionally lets the gate permit `git reset --hard`/`git clean` for reverting a parked item to green (force-push and `branch -D` stay blocked).",
-  "afk": true
+  "afk": false
 }


### PR DESCRIPTION
Housekeeping for #13.

`.claude/t4.json` `"afk": true` was set at the start of the unattended run so `t4-gate` would
permit the two destructive-revert commands — the revert-to-green path `t4-afk` requires for parking
an item. The run is over, so the guard goes back on.

Force-push and branch deletion were blocked throughout either way.

**Noted in passing:** writing this PR body tripped the gate, because the body quoted one of those
command names as prose. The hook's own troubleshooting table documents exactly this — detection is
anchored to a command position, but "a genuine invocation reached another way can still be caught".
A `--body` string reached it another way. Passing the body as a file works.

---

## สรุปภาษาไทย

งานเก็บกวาดของ #13

`.claude/t4.json` `"afk": true` ถูกตั้งไว้ตอนเริ่มรันแบบไม่มีคนดู เพื่อให้ `t4-gate` ยอมให้ใช้คำสั่ง
revert แบบทำลายสองตัว ซึ่งเป็นเส้นทาง revert-to-green ที่ `t4-afk` ต้องใช้ตอน park งาน ตอนนี้รันจบ
แล้ว guard จึงกลับมาทำงาน

ส่วน force-push และการลบ branch ถูกบล็อกตลอดอยู่แล้วไม่ว่ากรณีใด

**บันทึกไว้ระหว่างทาง:** การเขียน body ของ PR นี้ไปสะดุด gate เข้า เพราะ body อ้างชื่อคำสั่งหนึ่งใน
นั้นเป็นข้อความธรรมดา ตารางแก้ปัญหาของ hook เองระบุกรณีนี้ไว้ตรง ๆ — การตรวจจับยึดกับตำแหน่งของ
คำสั่ง แต่ "การเรียกใช้จริงที่มาถึงด้วยเส้นทางอื่นก็ยังถูกจับได้" ส่วน string ที่ส่งผ่าน `--body` ก็มาถึง
ด้วยเส้นทางอื่น การส่ง body เป็นไฟล์แก้ปัญหานี้ได้
