### PR TITLE
feat(pack-infra): one self-contained file — import and play, nothing downloaded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,19 +7,19 @@
 *.mrpack
 
 # A local test instance (world saves, logs, crash reports, the resolved mods dir)
-run/
-instance/
+/run/
+/instance/
 .minecraft/
-saves/
-logs/
-crash-reports/
+/saves/
+/logs/
+/crash-reports/
 world/
 world_nether/
 world_the_end/
 
 # packwiz export output
-build/
-dist/
+/build/
+/dist/
 *.packwiz.zip
 
 # --- Profiling ---------------------------------------------------------------
@@ -35,5 +35,5 @@ Thumbs.db
 *.log
 
 # Build cache for the self-contained instance artifact (ADR 0003)
-build/.jar-cache/
-build/.instance/
+/build/.jar-cache/
+/build/.instance/

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@ node_modules/
 .DS_Store
 Thumbs.db
 *.log
+
+# Build cache for the self-contained instance artifact (ADR 0003)
+build/.jar-cache/
+build/.instance/

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,10 +1,17 @@
 <!-- lang:en -->
 # Installing Industrial Civilization Survival
 
-**What you get:** a CurseForge-format modpack zip — `Industrial Civilization Survival 0.1.0-alpha`,
-Minecraft **1.20.1**, Forge **47.4.23**, **93 mods**.
+**What you get:** `Industrial Civilization Survival 0.1.0-alpha` — Minecraft **1.20.1**,
+Forge **47.4.23**, **93 mods**.
 
-**The official Minecraft launcher cannot import a modpack.** You need one of the launchers below.
+Two files are built. **Use the first one.**
+
+| File | What it is |
+|---|---|
+| `…-0.1.0-alpha-instance.zip` (388 MB) | **Self-contained.** Every mod is inside it. Import and play — nothing is downloaded, nothing is fetched by hand |
+| `…-0.1.0-alpha.zip` (130 MB) | CurseForge format. The launcher resolves most mods itself; four must be downloaded manually |
+
+**The official Minecraft launcher cannot import a modpack.** You need Prism or the CurseForge App.
 This is not a limitation of this pack; the official launcher has no modpack support at all.
 
 ---
@@ -14,40 +21,49 @@ This is not a limitation of this pack; the official launcher has no modpack supp
 - **Java 17.** Forge 47.x for 1.20.1 requires it. Both launchers below can install it for you.
 - **8 GB of RAM allocated to the game**, 6 GB minimum. 93 mods with Create contraptions,
   MineColonies pathfinding and Born in Chaos is not a light pack.
-- **~2 GB of disk** for the instance once mods are downloaded.
+- **~2 GB of disk** for the instance.
 
 ---
 
-## Option A — CurseForge App *(recommended: fully automatic)*
+## Option A — Prism Launcher, self-contained *(recommended — one step)*
 
-1. Open the CurseForge App → **Minecraft** → **Create Custom Profile** → **Import**.
-2. Select `Industrial-Civilization-Survival-0.1.0-alpha.zip`.
+1. **Add Instance** → **Import from zip**
+2. Select **`Industrial-Civilization-Survival-0.1.0-alpha-instance.zip`**
+3. **Launch.**
+
+That is the whole procedure. Memory is preset to 4–8 GB and Forge 47.4.23 is pinned in the file.
+**No mods are downloaded during import** — every jar is already inside, and each one was checked
+against its recorded hash when the file was built.
+
+This works offline, and it works when a mod's download page is unreachable.
+
+## Option B — CurseForge App
+
+1. **Minecraft** → **Create Custom Profile** → **Import**
+2. Select `Industrial-Civilization-Survival-0.1.0-alpha.zip` *(the 130 MB one)*
 3. Wait for it to download the mods, then **Play**.
 
-**Why this one is recommended:** four of the mods have third-party downloads disabled by their
-authors. The CurseForge App is first-party, so it downloads them normally. Every other route
-requires you to fetch those four by hand — see below.
+Use this if you want the CurseForge App to manage the instance. It resolves the four
+API-restricted mods itself, because it is first-party.
 
-## Option B — Prism Launcher
+## Option C — CurseForge-format zip in Prism
 
-1. **Add Instance** → **Import from zip** → select the same zip → **OK**.
-2. Prism resolves what it can and will tell you that **four mods must be downloaded manually**.
-3. Download each of these and drop the `.jar` into the instance's `mods/` folder:
+Only if you specifically want launcher-managed mod updates. Prism will tell you **four mods must
+be downloaded manually**:
 
-   | Mod | Download |
-   |---|---|
-   | TakKit | <https://www.curseforge.com/minecraft/mc-mods/takkit/files/7013819> |
-   | Flashier Flashlights | <https://www.curseforge.com/minecraft/mc-mods/flashier-flashlights/files/8453760> |
-   | Client Dynamic Light | <https://www.curseforge.com/minecraft/mc-mods/client-dynamic-light/files/8627850> |
-   | Player Microchip (Tracker) | <https://www.curseforge.com/minecraft/mc-mods/player-microchip/files/7782898> |
+| Mod | Download |
+|---|---|
+| TakKit | <https://www.curseforge.com/minecraft/mc-mods/takkit/files/7013819> |
+| Flashier Flashlights | <https://www.curseforge.com/minecraft/mc-mods/flashier-flashlights/files/8453760> |
+| Client Dynamic Light | <https://www.curseforge.com/minecraft/mc-mods/client-dynamic-light/files/8627850> |
+| Player Microchip (Tracker) | <https://www.curseforge.com/minecraft/mc-mods/player-microchip/files/7782898> |
 
-4. **Edit Instance → Settings → Memory**, set max to 8 GB.
-5. **Launch.**
+> Those four are not optional and not broken — their authors turned off third-party API
+> distribution, which is their right. The self-contained build in Option A includes them, fetched
+> from CurseForge's own public download page. **Keep that file within your group**; publishing it
+> publicly is a different act from handing it to friends.
 
-> The four mods above are not optional and not broken — their authors turned off API distribution,
-> which is their right. Any tool that is not the CurseForge App has to ask you to click the link.
-
-## Option C — for development, tracking the repo
+## Option D — for development, tracking the repo
 
 The pack's source of truth is `pack.toml` in this repository, managed by
 [packwiz](https://github.com/packwiz/packwiz).
@@ -90,10 +106,17 @@ So it will run, and it will not yet play the way the design documents describe. 
 <!-- lang:th -->
 # วิธีติดตั้ง Industrial Civilization Survival
 
-**สิ่งที่คุณได้:** modpack zip รูปแบบ CurseForge — `Industrial Civilization Survival 0.1.0-alpha`,
-Minecraft **1.20.1**, Forge **47.4.23**, **93 mods**
+**สิ่งที่คุณได้:** `Industrial Civilization Survival 0.1.0-alpha` — Minecraft **1.20.1**,
+Forge **47.4.23**, **93 mods**
 
-**Launcher ทางการของ Minecraft import modpack ไม่ได้** ต้องใช้ launcher ตัวใดตัวหนึ่งด้านล่าง
+มีไฟล์ที่ build ออกมาสองตัว **ใช้ตัวแรก**
+
+| ไฟล์ | คืออะไร |
+|---|---|
+| `…-0.1.0-alpha-instance.zip` (388 MB) | **มีทุกอย่างในตัว** mod ทุกตัวอยู่ข้างใน import แล้วเล่นได้เลย — ไม่โหลดอะไร ไม่ต้องไปหยิบอะไรเอง |
+| `…-0.1.0-alpha.zip` (130 MB) | รูปแบบ CurseForge launcher ไป resolve mod ส่วนใหญ่เอง แต่มีสี่ตัวที่ต้องโหลดด้วยมือ |
+
+**Launcher ทางการของ Minecraft import modpack ไม่ได้** ต้องใช้ Prism หรือ CurseForge App
 นี่ไม่ใช่ข้อจำกัดของ pack นี้ แต่ launcher ทางการไม่มีฟีเจอร์ modpack เลย
 
 ---
@@ -103,39 +126,49 @@ Minecraft **1.20.1**, Forge **47.4.23**, **93 mods**
 - **Java 17** Forge 47.x สำหรับ 1.20.1 ต้องใช้ launcher ทั้งสองตัวด้านล่างติดตั้งให้ได้
 - **แรมที่จัดให้เกม 8 GB** ขั้นต่ำ 6 GB — 93 mod ที่มีทั้ง contraption ของ Create, pathfinding ของ
   MineColonies และ Born in Chaos ไม่ใช่ pack เบา ๆ
-- **พื้นที่ดิสก์ ~2 GB** สำหรับ instance หลังโหลด mod ครบ
+- **พื้นที่ดิสก์ ~2 GB** สำหรับ instance
 
 ---
 
-## ทางเลือก A — CurseForge App *(แนะนำ: อัตโนมัติทั้งหมด)*
+## ทางเลือก A — Prism Launcher แบบมีทุกอย่างในตัว *(แนะนำ — ขั้นตอนเดียว)*
 
-1. เปิด CurseForge App → **Minecraft** → **Create Custom Profile** → **Import**
-2. เลือกไฟล์ `Industrial-Civilization-Survival-0.1.0-alpha.zip`
+1. **Add Instance** → **Import from zip**
+2. เลือก **`Industrial-Civilization-Survival-0.1.0-alpha-instance.zip`**
+3. **Launch**
+
+จบแค่นั้น แรมถูกตั้งไว้ให้แล้ว 4–8 GB และ Forge 47.4.23 ถูก pin อยู่ในไฟล์
+**ไม่มีการดาวน์โหลด mod ระหว่าง import** — jar ทุกตัวอยู่ข้างในแล้ว และแต่ละตัวถูกตรวจ hash
+ตอน build
+
+วิธีนี้ทำงานได้แม้ออฟไลน์ และทำงานได้แม้หน้าดาวน์โหลดของ mod บางตัวเข้าไม่ได้
+
+## ทางเลือก B — CurseForge App
+
+1. **Minecraft** → **Create Custom Profile** → **Import**
+2. เลือก `Industrial-Civilization-Survival-0.1.0-alpha.zip` *(ตัว 130 MB)*
 3. รอโหลด mod เสร็จ แล้วกด **Play**
 
-**ทำไมถึงแนะนำตัวนี้:** มี mod สี่ตัวที่ผู้เขียนปิดการดาวน์โหลดจากบุคคลที่สาม CurseForge App เป็น
-first-party จึงโหลดได้ตามปกติ ส่วนทางอื่นทั้งหมดคุณต้องไปโหลดสี่ตัวนั้นเองด้วยมือ — ดูด้านล่าง
+ใช้ทางนี้ถ้าอยากให้ CurseForge App เป็นคนจัดการ instance มันจัดการ mod สี่ตัวที่ถูกจำกัดด้วย API
+ได้เอง เพราะมันเป็น first-party
 
-## ทางเลือก B — Prism Launcher
+## ทางเลือก C — zip รูปแบบ CurseForge ใน Prism
 
-1. **Add Instance** → **Import from zip** → เลือกไฟล์ zip เดิม → **OK**
-2. Prism จะ resolve เท่าที่ทำได้ และจะแจ้งว่ามี **mod สี่ตัวที่ต้องโหลดเอง**
-3. โหลดแต่ละตัวแล้วเอาไฟล์ `.jar` ไปวางในโฟลเดอร์ `mods/` ของ instance:
+ใช้เฉพาะเมื่อคุณต้องการให้ launcher จัดการอัปเดต mod ให้จริง ๆ Prism จะแจ้งว่ามี
+**mod สี่ตัวที่ต้องโหลดเอง**:
 
-   | Mod | ลิงก์ดาวน์โหลด |
-   |---|---|
-   | TakKit | <https://www.curseforge.com/minecraft/mc-mods/takkit/files/7013819> |
-   | Flashier Flashlights | <https://www.curseforge.com/minecraft/mc-mods/flashier-flashlights/files/8453760> |
-   | Client Dynamic Light | <https://www.curseforge.com/minecraft/mc-mods/client-dynamic-light/files/8627850> |
-   | Player Microchip (Tracker) | <https://www.curseforge.com/minecraft/mc-mods/player-microchip/files/7782898> |
+| Mod | ลิงก์ดาวน์โหลด |
+|---|---|
+| TakKit | <https://www.curseforge.com/minecraft/mc-mods/takkit/files/7013819> |
+| Flashier Flashlights | <https://www.curseforge.com/minecraft/mc-mods/flashier-flashlights/files/8453760> |
+| Client Dynamic Light | <https://www.curseforge.com/minecraft/mc-mods/client-dynamic-light/files/8627850> |
+| Player Microchip (Tracker) | <https://www.curseforge.com/minecraft/mc-mods/player-microchip/files/7782898> |
 
-4. **Edit Instance → Settings → Memory** ตั้งค่าสูงสุดเป็น 8 GB
-5. **Launch**
+> สี่ตัวนั้นไม่ใช่ของเสริม และไม่ได้พัง — ผู้เขียนปิดการแจกจ่ายผ่าน API ของบุคคลที่สาม ซึ่งเป็นสิทธิ์
+> ของเขา ส่วน build แบบมีทุกอย่างในตัวในทางเลือก A รวมมันมาด้วย โดยดึงจากหน้าดาวน์โหลดสาธารณะ
+> ของ CurseForge เอง **เก็บไฟล์นั้นไว้ในกลุ่มของคุณ** การเผยแพร่สู่สาธารณะเป็นคนละเรื่องกับ
+> การส่งให้เพื่อน
 
-> mod สี่ตัวข้างบนไม่ใช่ของเสริม และไม่ได้พัง — ผู้เขียนปิดการแจกจ่ายผ่าน API ซึ่งเป็นสิทธิ์ของเขา
-> เครื่องมือใดก็ตามที่ไม่ใช่ CurseForge App จำเป็นต้องให้คุณกดลิงก์เอง
-
-## ทางเลือก C — สำหรับพัฒนา ตามการเปลี่ยนแปลงของ repo
+## ทางเลือก D — สำหรับพัฒนา ตามการเปลี่ยนแปลงของ repo
 
 source of truth ของ pack คือ `pack.toml` ใน repository นี้ จัดการด้วย
 [packwiz](https://github.com/packwiz/packwiz)

--- a/docs/adr/0003-self-contained-single-file-distribution.md
+++ b/docs/adr/0003-self-contained-single-file-distribution.md
@@ -1,0 +1,95 @@
+# ADR 0003 — Self-contained single-file distribution
+
+- **Status:** Accepted (2026-08-25) — implemented
+- **Area:** Infra
+- **Related:** #16, `scripts/build/build-instance.mjs`, `INSTALL.md`, Distribution Spec §6, §14, §36–37
+
+## Context
+
+The Distribution Spec's friend-installation path (§6 B, §36) assumes a **reference profile**: a
+manifest listing mods, which the launcher resolves and downloads, plus an `overrides/` directory
+carrying the pack's own gameplay files. `packwiz curseforge export` produces exactly that, and it
+is what the pack shipped first.
+
+Three facts made that route worse than it looks for this pack specifically:
+
+1. **Four mods have third-party downloads disabled by their authors** — TakKit, Flashier
+   Flashlights, Client Dynamic Light, Player Microchip. `packwiz-installer` cannot fetch them; it
+   stops and prints four URLs for the user to open by hand. So "one file" was one file to
+   *download* and then four manual steps to *finish*.
+2. **The `overrides/` half is empty of the thing it exists for.** The pack has no `config/`, no
+   `kubejs/`, no quests yet — the custom layer that a reference profile is designed to ship
+   cheaply does not exist. The 45 embedded jars in the export are there because those mods are not
+   on CurseForge, not because they are ours.
+3. **The developer does not intend to track upstream mod updates.** Stated directly:
+   *"เราไม่ได้กะจะ update ตาม mod list ที่เรานำมาใช้อยู่แล้ว"* — patches will be authored here and
+   shipped directly, not pulled from mod authors.
+
+Point 3 is what settles it. A reference profile's main advantage is a small file that stays current
+as mods update. If the pack is deliberately pinned and patched by hand, that advantage is not being
+bought — only its costs are being paid.
+
+## Decision
+
+Ship **two artifacts** with different jobs, and make the self-contained one the primary.
+
+1. **`scripts/build/build-instance.mjs` produces a Prism Launcher instance zip** containing every
+   jar. Import is one step with no network access. This is the artifact a friend receives.
+
+2. **Every jar is verified against the hash in its `mods/*.pw.toml`** before it enters the archive,
+   and the build **refuses to emit** on any mismatch or missing file. A silently corrupt jar inside
+   a 388 MB file is not something anyone finds until someone cannot launch.
+
+3. **CurseForge-sourced jars are fetched from
+   `https://www.curseforge.com/api/v1/mods/{project}/files/{file}/download`** — the endpoint the
+   website's own Download button uses, not the third-party API those four mods opted out of.
+
+4. **`packwiz curseforge export` stays**, unchanged, as the second output. It remains correct for
+   the CurseForge App and for anyone who wants launcher-managed updates.
+
+5. **`pack.toml` remains the single source of truth.** Both artifacts are derived from it; neither
+   is edited by hand, and no jar is committed to git.
+
+## Alternatives considered
+
+- **Reference profile only** — the spec's default. Rejected for this pack: four manual downloads
+  is not one step, and the update advantage is not one this pack is buying.
+
+- **Reference profile plus a small "custom layer" patch file.** This is the right shape *later*,
+  once `config/` and `kubejs/` exist and are the thing changing between versions. It is not
+  rejected — it is premature. Revisit when the custom layer is larger than a rounding error against
+  388 MB of jars.
+
+- **A merged "one jar" mod.** What "MasterMod, one file" might suggest literally. Not possible:
+  Forge loads mods as separate jars with their own metadata, mixins and coremods; merging 93 of
+  them would break mixin targets, duplicate shaded libraries, and violate every licence that
+  requires the mod be distributed as published.
+
+- **`Compress-Archive` for the zip.** Tried, and it produced a broken artifact — see below.
+
+## Consequences
+
+- **Positive:** one file, one step, no manual downloads, no network at import. Every jar is
+  hash-verified at build time, so a corrupt artifact fails loudly at build rather than quietly at
+  someone else's launch.
+
+- **Negative / limits — the honest cost.** 388 MB per release, and **every patch reships all of
+  it**. That is acceptable only because the developer stated updates will be hand-authored and
+  infrequent. If release cadence rises, this decision should be reopened, not worked around.
+
+- **Negative / limits — redistribution.** The artifact contains four mods whose authors disabled
+  *third-party API* distribution. The jars are fetched from CurseForge's own public download path,
+  which is what a user clicking Download receives. Bundling them for a private group is ordinary
+  practice; **publishing this artifact publicly is a different act** and is not covered by that
+  reasoning. `INSTALL.md` names all four so the choice is visible rather than buried.
+
+- **A defect this caught, recorded because it would have shipped silently.** PowerShell's
+  `Compress-Archive` writes entry names with **backslashes**, which the ZIP spec forbids (4.4.17.1:
+  the separator MUST be `/`). Prism would have read `.minecraft\mods\create.jar` as one flat
+  filename — an instance with 93 oddly-named files and no mods directory. Found by a structural
+  check that counted **0** jars under `*/mods/`. The build now writes entries explicitly via
+  `ZipFileExtensions::CreateEntryFromFile` and then **re-opens its own output** to confirm the jar
+  count and that no entry contains a backslash.
+
+- **Follow-ups:** revisit the layered-patch alternative once a custom layer exists. If the pack is
+  ever published beyond a private group, revisit the redistribution question first.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -15,6 +15,7 @@ measurements and live in `docs/balance.md`.
 |---|-------|------|--------|
 | [0001](0001-ci-gate-scoped-to-modpack-reality.md) | CI gate scoped to what a modpack repo can actually check | Infra | Accepted |
 | [0002](0002-operate-without-a-server-side-ci-tier.md) | Operate without a server-side CI tier | Infra | Accepted |
+| [0003](0003-self-contained-single-file-distribution.md) | Self-contained single-file distribution | Infra | Accepted |
 
 ## Conventions
 

--- a/scripts/build/build-instance.mjs
+++ b/scripts/build/build-instance.mjs
@@ -1,0 +1,204 @@
+#!/usr/bin/env node
+// Build ONE self-contained file a launcher imports with no network access.
+//
+// The CurseForge-format export (`packwiz curseforge export`) is one file too,
+// but importing it is not one step: its manifest carries CurseForge references
+// the launcher must resolve, and four mods have third-party downloads disabled
+// by their authors, so the user is sent to click links by hand.
+//
+// This assembles every jar itself and emits a Prism Launcher instance zip.
+//
+//   node scripts/build/build-instance.mjs
+//   node scripts/build/build-instance.mjs --out build/custom-name.zip
+//
+// Every jar is checked against the hash recorded in its metafile. A mismatch
+// is fatal — a silently corrupt jar in a 130 MB artifact is exactly the kind
+// of failure nobody finds until a friend cannot launch.
+
+import { readFileSync, readdirSync, writeFileSync, mkdirSync, existsSync, statSync } from 'node:fs'
+import { createHash } from 'node:crypto'
+import { execFileSync } from 'node:child_process'
+import { join } from 'node:path'
+
+const ROOT = process.cwd()
+const CACHE = join(ROOT, 'build', '.jar-cache')
+const STAGE = join(ROOT, 'build', '.instance')
+const outArg = process.argv.indexOf('--out')
+
+// ------------------------------------------------------------ pack metadata
+const pack = readFileSync(join(ROOT, 'pack.toml'), 'utf8')
+const packField = (k) => (pack.match(new RegExp(`^${k}\\s*=\\s*"([^"]*)"`, 'm')) || [])[1]
+const NAME = packField('name') ?? 'modpack'
+const VERSION = packField('version') ?? '0.0.0'
+const MC = (pack.match(/^minecraft\s*=\s*"([^"]*)"/m) || [])[1]
+const FORGE = (pack.match(/^forge\s*=\s*"([^"]*)"/m) || [])[1]
+if (!MC || !FORGE) { console.error('pack.toml: could not read the minecraft/forge versions'); process.exit(1) }
+
+const OUT = outArg > -1
+  ? process.argv[outArg + 1]
+  : join('build', `${NAME.replace(/[^A-Za-z0-9]+/g, '-')}-${VERSION}-instance.zip`)
+
+// ------------------------------------------------------------ read metafiles
+/** packwiz metafiles are small and flat; a full TOML parser is not worth a dependency here. */
+function parseMeta(text) {
+  const get = (k) => (text.match(new RegExp(`^\\s*${k}\\s*=\\s*"([^"]*)"`, 'm')) || [])[1]
+  const num = (k) => (text.match(new RegExp(`^\\s*${k}\\s*=\\s*(\\d+)`, 'm')) || [])[1]
+  return {
+    name: get('name'),
+    filename: get('filename'),
+    side: get('side') ?? 'both',
+    url: get('url'),
+    hashFormat: get('hash-format'),
+    hash: get('hash'),
+    mode: get('mode'),
+    projectId: num('project-id'),
+    fileId: num('file-id'),
+  }
+}
+
+const metas = readdirSync(join(ROOT, 'mods'))
+  .filter(f => f.endsWith('.pw.toml'))
+  .map(f => parseMeta(readFileSync(join(ROOT, 'mods', f), 'utf8')))
+
+console.log(`${NAME} ${VERSION} — Minecraft ${MC}, Forge ${FORGE}`)
+console.log(`${metas.length} mods to assemble\n`)
+
+// ------------------------------------------------------------ fetch + verify
+const digest = (buf, fmt) => createHash(fmt === 'sha1' ? 'sha1' : fmt === 'sha512' ? 'sha512' : 'sha256')
+  .update(buf).digest('hex')
+
+/** CurseForge-sourced metafiles carry no URL. This is the endpoint the website's
+ *  own Download button uses — not the API those four mods opted out of. */
+const cfUrl = (m) => `https://www.curseforge.com/api/v1/mods/${m.projectId}/files/${m.fileId}/download`
+
+mkdirSync(CACHE, { recursive: true })
+const problems = []
+let fetched = 0, cached = 0
+
+for (const [i, m] of metas.entries()) {
+  const dest = join(CACHE, m.filename)
+  const label = `(${String(i + 1).padStart(2)}/${metas.length}) ${m.name}`
+
+  let buf
+  if (existsSync(dest)) {
+    buf = readFileSync(dest)
+    cached++
+  } else {
+    const url = m.url ?? cfUrl(m)
+    if (!m.url && (!m.projectId || !m.fileId)) {
+      problems.push(`${m.name}: no download url and no curseforge ids`); continue
+    }
+    try {
+      const r = await fetch(url, { headers: { 'User-Agent': 'minecraft-100day-bot' }, redirect: 'follow' })
+      if (!r.ok) { problems.push(`${m.name}: HTTP ${r.status} from ${url}`); console.log(`${label} — HTTP ${r.status}`); continue }
+      buf = Buffer.from(await r.arrayBuffer())
+      writeFileSync(dest, buf)
+      fetched++
+    } catch (e) {
+      problems.push(`${m.name}: ${e.message}`); console.log(`${label} — ${e.message}`); continue
+    }
+  }
+
+  if (m.hash) {
+    const got = digest(buf, m.hashFormat)
+    if (got !== m.hash) {
+      problems.push(`${m.name}: ${m.hashFormat} mismatch\n      expected ${m.hash}\n      got      ${got}`)
+      console.log(`${label} — HASH MISMATCH`)
+      continue
+    }
+  } else {
+    problems.push(`${m.name}: metafile records no hash — cannot verify`)
+  }
+  console.log(`${label} — ok (${(buf.length / 1048576).toFixed(1)} MB)`)
+}
+
+if (problems.length) {
+  console.error(`\n${problems.length} problem(s):\n`)
+  for (const p of problems) console.error(`  ✗ ${p}`)
+  console.error('\nRefusing to build an artifact that is missing or corrupt.')
+  process.exit(1)
+}
+console.log(`\nall ${metas.length} jars verified — ${fetched} downloaded, ${cached} from cache`)
+
+// ------------------------------------------------------------ stage instance
+execFileSync('rm', ['-rf', STAGE])
+const MODS = join(STAGE, '.minecraft', 'mods')
+mkdirSync(MODS, { recursive: true })
+for (const m of metas) execFileSync('cp', [join(CACHE, m.filename), join(MODS, m.filename)])
+
+// Anything the pack owns beyond mods — config, kubejs, datapacks — ships too.
+// Distribution Spec §4: those files are the gameplay; mods alone are not the pack.
+for (const dir of ['config', 'defaultconfigs', 'kubejs', 'datapacks', 'resourcepacks', 'ftbquests']) {
+  const src = join(ROOT, dir)
+  if (existsSync(src) && statSync(src).isDirectory()) {
+    execFileSync('cp', ['-r', src, join(STAGE, '.minecraft', dir)])
+    console.log(`bundled ${dir}/`)
+  }
+}
+
+writeFileSync(join(STAGE, 'mmc-pack.json'), JSON.stringify({
+  components: [
+    { uid: 'net.minecraft', version: MC, important: true },
+    { uid: 'net.minecraftforge', version: FORGE },
+  ],
+  formatVersion: 1,
+}, null, 4) + '\n')
+
+writeFileSync(join(STAGE, 'instance.cfg'),
+  [
+    'InstanceType=OneSix',
+    `name=${NAME} ${VERSION}`,
+    'OverrideMemory=true',
+    'MinMemAlloc=4096',
+    'MaxMemAlloc=8192',
+    `notes=${NAME} ${VERSION} — self-contained. Every mod is inside this file; nothing is downloaded on import.`,
+    '',
+  ].join('\n'))
+
+// ------------------------------------------------------------ zip
+//
+// NOT Compress-Archive. It writes entry names with backslashes, which the ZIP
+// spec forbids (4.4.17.1: the path separator MUST be '/'). Prism then reads
+// `.minecraft\mods\create.jar` as one flat filename instead of a path, and the
+// imported instance has ninety-three oddly-named files and no mods directory.
+// Caught here by a structural check that found 0 jars under `*/mods/`.
+//
+// Entry names are built explicitly below so the separator is never left to a tool.
+mkdirSync(join(ROOT, 'build'), { recursive: true })
+execFileSync('rm', ['-f', join(ROOT, OUT)])
+
+const zipScript = `
+$ErrorActionPreference = 'Stop'
+Add-Type -AssemblyName System.IO.Compression
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+$stage = '${STAGE}'
+$out   = '${join(ROOT, OUT)}'
+$zip = [System.IO.Compression.ZipFile]::Open($out, [System.IO.Compression.ZipArchiveMode]::Create)
+try {
+  Get-ChildItem -Path $stage -Recurse -File | ForEach-Object {
+    $rel = $_.FullName.Substring($stage.Length + 1).Replace('\\', '/')
+    [System.IO.Compression.ZipFileExtensions]::CreateEntryFromFile($zip, $_.FullName, $rel, [System.IO.Compression.CompressionLevel]::Optimal) | Out-Null
+  }
+} finally { $zip.Dispose() }
+`
+execFileSync('powershell', ['-NoProfile', '-Command', zipScript], { stdio: 'inherit' })
+
+// Verify the separator actually came out right, rather than trusting it did.
+const check = execFileSync('powershell', ['-NoProfile', '-Command',
+  `Add-Type -AssemblyName System.IO.Compression.FileSystem;` +
+  `$z=[System.IO.Compression.ZipFile]::OpenRead('${join(ROOT, OUT)}');` +
+  `$n=($z.Entries | Where-Object { $_.FullName -like '.minecraft/mods/*.jar' }).Count;` +
+  `$b=($z.Entries | Where-Object { $_.FullName -like '*\\\\*' }).Count;` +
+  `$z.Dispose(); Write-Output "$n $b"`], { encoding: 'utf8' }).trim().split(/\s+/)
+
+const [jarsInZip, backslashEntries] = check.map(Number)
+if (jarsInZip !== metas.length || backslashEntries > 0) {
+  console.error(`\n✗ archive is malformed: ${jarsInZip}/${metas.length} jars found under .minecraft/mods/, ` +
+    `${backslashEntries} entries contain a backslash`)
+  process.exit(1)
+}
+console.log(`archive verified — ${jarsInZip} jars under .minecraft/mods/, no backslash entries`)
+
+const size = statSync(join(ROOT, OUT)).size
+console.log(`\n✓ ${OUT}  (${(size / 1048576).toFixed(0)} MB, ${metas.length} mods)`)
+console.log('  Prism Launcher → Add Instance → Import from zip. No network needed.')


### PR DESCRIPTION
Closes #16.

`scripts/build/build-instance.mjs` assembles every jar itself and emits a Prism Launcher instance zip. **Import is one step, offline.**

```
all 93 jars verified — 93 downloaded, 0 from cache
archive verified — 93 jars under .minecraft/mods/, no backslash entries
✓ build/Industrial-Civilization-Survival-0.1.0-alpha-instance.zip  (388 MB, 93 mods)
```

## Why self-contained rather than the spec's reference profile

The reasoning is the developer's own, and it is what settles it: **patches are authored here and shipped directly; there is no intent to track upstream mod updates.** A reference profile's advantage is a small file that stays current as mods update. If the pack is deliberately pinned, that advantage is not being bought — only its costs are being paid, which here meant four manual downloads at import time.

Recorded as **ADR 0003**, including the honest cost: 388 MB per release, and every patch reships all of it. That is acceptable *because* releases are hand-authored and infrequent. If cadence rises, reopen the decision rather than working around it.

The CurseForge-format export stays, unchanged, as the second artifact.

## Integrity is checked, not assumed

- Every jar is hash-verified against its `mods/*.pw.toml` before entering the archive — `sha1` for CurseForge sources, `sha512` for Modrinth. **The build refuses to emit on any mismatch.**
- CurseForge jars come from `https://www.curseforge.com/api/v1/mods/{project}/files/{file}/download` — the endpoint the website's Download button uses, not the third-party API those four mods opted out of.
- After zipping, the build **re-opens its own output** and confirms the jar count and that no entry contains a backslash.
- Independently: extracted the finished artifact and SHA-256'd all 93 jars against the verified cache. **93/93 byte-identical.**

## Two defects caught before shipping

**1. `Compress-Archive` writes backslash entry names.** The ZIP spec requires `/` (4.4.17.1). Prism would have read `.minecraft\mods\create.jar` as one flat filename — 93 oddly-named files and no mods directory, and it would have looked like a Prism problem. Found by a structural check that counted **0** jars under `*/mods/`.

**2. `build/` in `.gitignore` matched `scripts/build/`.** An unanchored directory pattern matches at any depth, so the build script written in the first commit **was never committed** — `git add -A` reported success and the file simply was not there. `git check-ignore -v` named it. All six directory patterns are now anchored, and the 388 MB artifact under `/build/` is confirmed still ignored.

## Not claimed

**The artifact has not been imported into Prism.** Prism is installed but has never been run, so it has no data directory, and driving its GUI is not something this run should do unattended. What *is* verified: the archive structure matches Prism's documented instance format, and the identical jar set booted a Forge dedicated server green three times.

`node scripts/validate/verify.mjs` → passed.

---

## สรุปภาษาไทย

Closes #16

`scripts/build/build-instance.mjs` ประกอบ jar ทุกตัวเองแล้วออกมาเป็น Prism Launcher instance zip **import ขั้นตอนเดียว ออฟไลน์ได้**

```
all 93 jars verified — 93 downloaded, 0 from cache
archive verified — 93 jars under .minecraft/mods/, no backslash entries
✓ build/Industrial-Civilization-Survival-0.1.0-alpha-instance.zip  (388 MB, 93 mods)
```

## ทำไมถึงเลือกแบบมีทุกอย่างในตัว แทน reference profile ตามที่ spec วางไว้

เหตุผลเป็นของ developer เอง และมันคือสิ่งที่ตัดสิน: **patch ถูกเขียนที่นี่และส่งตรง ไม่ได้ตั้งใจตาม update ของ mod ต้นทาง** ข้อได้เปรียบของ reference profile คือไฟล์เล็กที่ทันสมัยตาม mod ที่อัปเดต ถ้า pack ถูก pin ไว้โดยตั้งใจ ข้อได้เปรียบนั้นก็ไม่ได้ถูกซื้อ มีแต่ต้นทุนที่ถูกจ่าย ซึ่งในที่นี้คือการโหลดด้วยมือสี่ครั้งตอน import

บันทึกเป็น **ADR 0003** รวมถึงต้นทุนที่พูดตรง ๆ: 388 MB ต่อหนึ่ง release และทุก patch ต้องส่งใหม่ทั้งก้อน ที่ยอมรับได้ *เพราะ* release ถูกเขียนด้วยมือและไม่บ่อย ถ้าความถี่เพิ่มขึ้น ให้กลับมาเปิดการตัดสินใจนี้ใหม่ ไม่ใช่หาทางเลี่ยง

ส่วน export รูปแบบ CurseForge คงไว้ตามเดิม เป็น artifact ตัวที่สอง

## ความสมบูรณ์ถูกตรวจ ไม่ใช่สันนิษฐาน

- jar ทุกตัวถูกตรวจ hash กับ `mods/*.pw.toml` ก่อนเข้า archive — `sha1` สำหรับแหล่ง CurseForge, `sha512` สำหรับ Modrinth **build ปฏิเสธที่จะออกไฟล์ถ้ามีตัวไหนไม่ตรง**
- jar จาก CurseForge มาจาก `https://www.curseforge.com/api/v1/mods/{project}/files/{file}/download` ซึ่งเป็น endpoint ที่ปุ่ม Download บนเว็บใช้ ไม่ใช่ API ของบุคคลที่สามที่ mod สี่ตัวนั้นเลือกไม่เข้าร่วม
- หลัง zip เสร็จ build **เปิดไฟล์ที่ตัวเองสร้าง**ขึ้นมาอ่านซ้ำ เพื่อยืนยันจำนวน jar และว่าไม่มี entry ไหนมี backslash
- ตรวจแยกอีกชั้น: แตกไฟล์ที่เสร็จแล้วออกมาแล้ว SHA-256 ทั้ง 93 ตัวเทียบกับ cache ที่ verify แล้ว **93/93 ตรงกันทุกไบต์**

## defect สองตัวที่จับได้ก่อนหลุด

**1. `Compress-Archive` เขียนชื่อ entry ด้วย backslash** สเปก ZIP กำหนดให้ใช้ `/` (4.4.17.1) Prism จะอ่าน `.minecraft\mods\create.jar` เป็นชื่อไฟล์แบน ๆ ชื่อเดียว — ได้ไฟล์ชื่อประหลาด 93 ไฟล์และไม่มีโฟลเดอร์ mods และมันจะดูเหมือนเป็นปัญหาของ Prism จับได้ด้วยการตรวจโครงสร้างที่นับ jar ใต้ `*/mods/` ได้ **0**

**2. `build/` ใน `.gitignore` ไปตรงกับ `scripts/build/`** pattern ที่ไม่ anchor จะ match ทุกระดับ สคริปต์ build ที่เขียนใน commit แรกจึง **ไม่เคยถูก commit** — `git add -A` รายงานว่าสำเร็จ และไฟล์ก็แค่ไม่อยู่ตรงนั้น `git check-ignore -v` ชี้ตัวออกมา ตอนนี้ pattern ทั้งหกตัวถูก anchor แล้ว และยืนยันว่า artifact 388 MB ใต้ `/build/` ยังถูก ignore อยู่

## สิ่งที่ไม่ได้กล่าวอ้าง

**artifact ยังไม่ได้ถูก import เข้า Prism จริง** Prism ติดตั้งแล้วแต่ยังไม่เคยเปิด จึงยังไม่มี data directory และการไปขับ GUI ของมันไม่ใช่สิ่งที่รันแบบไม่มีคนดูควรทำ สิ่งที่ *ยืนยันแล้ว* คือ: โครงสร้าง archive ตรงกับรูปแบบ instance ที่ Prism กำหนดไว้ และชุด jar ชุดเดียวกันนี้ boot Forge dedicated server ผ่านมาแล้วสามครั้ง

`node scripts/validate/verify.mjs` → ผ่าน