### PR TITLE
docs(pack-infra): reconcile the records after the single-file build

### DIFF
--- a/DONE.md
+++ b/DONE.md
@@ -6,6 +6,44 @@
 
 ---
 
+## One self-contained file — import and play (2026-08-25, branch `feat/16-single-file-artifact`)
+
+**Goal:** the pack exported as one file, but importing it was not one step — the manifest carried
+38 CurseForge references and four mods sent the user to click links by hand.
+
+**Shipped (#16):**
+- `scripts/build/build-instance.mjs` — reads every metafile, downloads each jar, **hash-verifies
+  it**, assembles a Prism Launcher instance and zips it. Refuses to emit on any mismatch.
+  This is Distribution Spec §14's `scripts/build/`, first entry.
+- **ADR 0003** — self-contained over the spec's reference profile, with the developer's stated
+  reason (patches authored here; no intent to track upstream updates) and the honest cost
+  (388 MB per release, every patch reships all of it).
+- `INSTALL.md` restructured: the self-contained file is Option A, one step, offline.
+
+**Validation:**
+- `all 93 jars verified — 93 downloaded, 0 from cache`
+- `archive verified — 93 jars under .minecraft/mods/, no backslash entries`
+- Independent check: extracted the finished artifact, SHA-256 over all 93 jars against the
+  verified cache — **93/93 byte-identical**.
+
+**Two defects caught before they shipped:**
+1. `Compress-Archive` writes ZIP entry names with **backslashes**, which the spec forbids. Prism
+   would have read `.minecraft\mods\create.jar` as one flat filename — 93 oddly-named files and no
+   mods directory, looking like a Prism bug. Found by a structural check counting **0** jars under
+   `*/mods/`.
+2. `build/` in `.gitignore` matched `scripts/build/` — an unanchored directory pattern matches at
+   any depth — so the build script **was never committed**. `git add -A` reported success and the
+   file was simply absent. All six directory patterns anchored.
+
+**Composition, stated so the "~60 mods" claim is checkable:** 93 metafiles = **66 mods named in
+the five design documents** + 27 libraries and dependencies packwiz resolved automatically.
+
+**Not claimed:** the artifact has **not** been imported into Prism. Prism has never been run, so it
+has no data directory, and driving its GUI unattended was out of scope. Verified instead: the
+archive matches Prism's documented instance format, and this jar set booted a Forge server green.
+
+---
+
 ## The pack exists and boots (2026-08-25, `/t4-afk` unattended run, branches `chore/9-*`, `feat/11-*`, `feat/13-*`)
 
 **Goal:** turn five design documents into a modpack a user can import into Minecraft.

--- a/docs/OPEN-WORK-LEDGER.md
+++ b/docs/OPEN-WORK-LEDGER.md
@@ -94,7 +94,8 @@ Folded into the operating layer under **#7**.
 | Item | Status | Gate | Next action |
 |---|---|---|---|
 | Create `develop`, with its own ruleset | 🟡 | deliberately deferred — nothing to integrate and nobody running `main` | Create it in the same change that cuts the first `v0.x.0-alpha` tag. Distribution Spec §22; reasoning in `docs/agents/workflow.md` |
-| `scripts/build/` — `build-client`, `build-server`, `validate-pack`, `generate-checksums` | 🔴 | needs `pack.toml` | Distribution Spec §14. One deterministic release command, not four remembered ones |
+| `scripts/build/build-instance.mjs` — the self-contained client artifact | ✅ | — | 93 jars, each hash-verified; Prism instance zip, one-step offline import (**#16**, ADR 0003) |
+| `scripts/build/` — `build-server`, `generate-checksums` | 🔴 | server pack needs side classification first | Distribution Spec §14. `build-instance` is the first of the set |
 | Grow `verify.mjs` into `validate-pack` | 🔴 | each check is gated on its own prerequisite | Distribution Spec §15 — the seven-item checklist is mapped against what exists in the script's own header |
 | COMMON / SERVER / CLIENT side classification | 🔴 | needs the mod list | Distribution Spec §11 — **read each mod's actual requirement, never guess** |
 | Server pack, version-locked to the client pack | 🔴 | needs a built client pack | Distribution Spec §12 |


### PR DESCRIPTION
Follow-up to #16 — ship log and ledger.

Records the pack composition so the *"~60 mods"* target is checkable rather than asserted:

**93 metafiles = 66 mods named in the five design documents + 27 libraries and dependencies packwiz resolved automatically.**

Track 5's build-script row is closed for `build-instance`; `build-server` and `generate-checksums` stay open behind side classification.

---

## สรุปภาษาไทย

ต่อจาก #16 — ship log และ ledger

บันทึกองค์ประกอบของ pack ไว้เพื่อให้เป้าหมาย *"ประมาณ 60 ตัว"* ตรวจสอบได้ ไม่ใช่แค่กล่าวอ้าง:

**93 metafile = mod ที่เอกสารออกแบบทั้งห้าใบระบุชื่อไว้ 66 ตัว + library และ dependency ที่ packwiz resolve ให้อัตโนมัติ 27 ตัว**

แถว build-script ของ Track 5 ปิดในส่วน `build-instance` ส่วน `build-server` และ `generate-checksums` ยังเปิดอยู่ รอการแยก side ก่อน