### PR TITLE
feat(threat): first customization batch — HP curve, breach tag, Carry On blacklist

### DIFF
--- a/config/carryon-common.toml
+++ b/config/carryon-common.toml
@@ -1,0 +1,89 @@
+
+[settings]
+	#General Settings
+	#Maximum distance from where Blocks and Entities can be picked up
+	#Range: 0.0 ~ 1.7976931348623157E308
+	maxDistance = 2.5
+	#Max width of entities that can be picked up in survival mode
+	#Range: 0.0 ~ 10.0
+	maxEntityWidth = 1.5
+	#Max height of entities that can be picked up in survival mode
+	#Range: 0.0 ~ 10.0
+	maxEntityHeight = 2.5
+	#Slowness multiplier for blocks
+	#Range: 0.0 ~ 1.7976931348623157E308
+	blockSlownessMultiplier = 1.0
+	#Slowness multiplier for entities
+	#Range: 0.0 ~ 1.7976931348623157E308
+	entitySlownessMultiplier = 1.0
+	#Maximum stack limit for entities
+	#Range: > 1
+	maxEntityStackLimit = 10
+	#More complex Tile Entities slow down the player more
+	heavyTiles = true
+	#Allow all blocks to be picked up, not just Tile Entites. White/Blacklist will still be respected.
+	pickupAllBlocks = false
+	#Whether Blocks and Entities slow the creative player down when carried
+	slownessInCreative = true
+	#Whether hostile mobs should be able to picked up in survival mode
+	pickupHostileMobs = false
+	#Larger Entities slow down the player more
+	heavyEntities = true
+	#Allow babies to be carried even when adult mob is blacklisted (or not whitelisted)
+	allowBabies = false
+	#Use Whitelist instead of Blacklist for Blocks
+	useWhitelistBlocks = false
+	#Use Whitelist instead of Blacklist for Entities
+	useWhitelistEntities = false
+	#Use Whitelist instead of Blacklist for Stacking
+	useWhitelistStacking = false
+	#Whether the player can hit blocks and entities while carrying or not
+	hitWhileCarrying = false
+	#Whether the player drops the carried object when hit or not
+	dropCarriedWhenHit = false
+	#Use custom Pickup Scripts. Having this set to false, will not allow you to run scripts, but will increase your performance
+	useScripts = false
+	#Allows entities to be stacked on top of each other
+	stackableEntities = true
+	#Whether entities' size matters when stacking or not. This means that larger entities cannot be stacked on smaller ones
+	entitySizeMattersStacking = true
+	#Usually all the block state information is retained when placing a block that was picked up. But some information is changed to a modified property, like rotation or orientation. In this list, add additional properties that should NOT be saved and instead be updated when placed. Format: modid:block[propertyname]. Note: You don't need to add an entry for every subtype of a same block. For example, we only add an entry for one type of slab, but the change is applied to all slabs.
+	placementStateExceptions = ["minecraft:chest[type]", "minecraft:stone_button[face]", "minecraft:vine[north,east,south,west,up]", "minecraft:creeper_head[rotation]", "minecraft:glow_lichen[north,east,south,west,up,down]", "minecraft:oak_sign[rotation]", "minecraft:oak_trapdoor[half]"]
+	#Whether Players can be picked up. Creative players can't be picked up in Survival Mode
+	pickupPlayers = true
+	#Whether players in Survival Mode can pick up unbreakable blocks. Creative players always can.
+	pickupUnbreakableBlocks = false
+
+[whitelist]
+	#Whitelist. Read about the format here: https://github.com/Tschipp/CarryOn/wiki/Black---and-Whitelist-Config
+	#Entities that CAN be picked up (useWhitelistEntities must be true)
+	allowedEntities = []
+	#Blocks that CAN be picked up (useWhitelistBlocks must be true)
+	allowedBlocks = []
+	#Entities that CAN have other entities stacked on top of them (useWhitelistStacking must be true)
+	allowedStacking = []
+
+[blacklist]
+	#Blacklist. Read about the format here: https://github.com/Tschipp/CarryOn/wiki/Black---and-Whitelist-Config
+	#Blocks that cannot be picked up
+	# PACK CONTROLLED — Industrial Civilization Survival
+	# Main design document §3.9: Carry On must not become a way around logistics.
+	# The blacklist below already ships with create:*, minecolonies:*,
+	# immersiveengineering:*, iceandfire:*, securitycraft:*, ftbquests:* and
+	# framedblocks:* by default. Appended here are this pack's own bypass surface:
+	#   railways:*, createbigcannons:*, createaddition:*, createdieselgenerators:*, structurize:*, domum_ornamentum:*, sophisticatedbackpacks:*, sophisticatedcore:*
+	# Mod ids read from META-INF/mods.toml in each jar, not guessed from filenames —
+	# Steam 'n' Rails is "railways", which no filename would have told you.
+	forbiddenTiles = ["#forge:immovable", "#forge:relocation_not_supported", "minecraft:end_portal", "minecraft:piston_head", "minecraft:end_gateway", "minecraft:tall_grass", "minecraft:large_fern", "minecraft:peony", "minecraft:rose_bush", "minecraft:lilac", "minecraft:sunflower", "minecraft:*_bed", "minecraft:*_door", "minecraft:big_dripleaf_stem", "minecraft:waterlily", "minecraft:cake", "minecraft:nether_portal", "minecraft:tall_seagrass", "animania:block_trough", "animania:block_invisiblock", "colossalchests:*", "ic2:*", "bigreactors:*", "forestry:*", "tconstruct:*", "rustic:*", "botania:*", "astralsorcery:*", "quark:colored_bed_*", "immersiveengineering:*", "embers:block_furnace", "embers:ember_bore", "embers:ember_activator", "embers:mixer", "embers:heat_coil", "embers:large_tank", "embers:crystal_cell", "embers:alchemy_pedestal", "embers:boiler", "embers:combustor", "embers:catalzyer", "embers:field_chart", "embers:inferno_forge", "storagedrawers:framingtable", "skyresources:*", "lootbags:*", "exsartagine:*", "aquamunda:tank", "opencomputers:*", "malisisdoors:*", "industrialforegoing:*", "minecolonies:*", "thaumcraft:pillar*", "thaumcraft:infernal_furnace", "thaumcraft:placeholder*", "thaumcraft:infusion_matrix", "thaumcraft:golem_builder", "thaumcraft:thaumatorium*", "magneticraft:oil_heater", "magneticraft:solar_panel", "magneticraft:steam_engine", "magneticraft:shelving_unit", "magneticraft:grinder", "magneticraft:sieve", "magneticraft:solar_tower", "magneticraft:solar_mirror", "magneticraft:container", "magneticraft:pumpjack", "magneticraft:solar_panel", "magneticraft:refinery", "magneticraft:oil_heater", "magneticraft:hydraulic_press", "magneticraft:multiblock_gap", "refinedstorage:*", "mcmultipart:*", "enderstorage:*", "betterstorage:*", "practicallogistics2:*", "wearablebackpacks:*", "rftools:screen", "rftools:creative_screen", "create:*", "magic_doorknob:*", "iceandfire:*", "ftbquests:*", "waystones:*", "contact:*", "framedblocks:*", "securitycraft:*", "forgemultipartcbe:*", "integrateddynamics:cable", "mekanismgenerators:wind_generator", "cookingforblockheads:cabinet", "cookingforblockheads:corner", "cookingforblockheads:counter", "cookingforblockheads:oven", "cookingforblockheads:toaster", "cookingforblockheads:milk_jar", "cookingforblockheads:cow_jar", "cookingforblockheads:fruit_basket", "cookingforblockheads:cooking_table", "cookingforblockheads:fridge", "cookingforblockheads:sink", "powah:*", "advancementtrophies:trophy", "mekanismgenerators:heat_generator", "mna:filler_block", "railways:*", "createbigcannons:*", "createaddition:*", "createdieselgenerators:*", "structurize:*", "domum_ornamentum:*", "sophisticatedbackpacks:*", "sophisticatedcore:*"]
+	#Entities that cannot be picked up
+	forbiddenEntities = ["minecraft:end_crystal", "minecraft:ender_dragon", "minecraft:ghast", "minecraft:shulker", "minecraft:leash_knot", "minecraft:armor_stand", "minecraft:item_frame", "minecraft:painting", "minecraft:shulker_bullet", "animania:hamster", "animania:ferret*", "animania:hedgehog*", "animania:cart", "animania:wagon", "mynko:*", "pixelmon:*", "mocreatures:*", "quark:totem", "vehicle:*", "securitycraft:*", "taterzens:npc", "easy_npc:*", "bodiesbodies:dead_body"]
+	#Entities that cannot have other entities stacked on top of them
+	forbiddenStacking = ["minecraft:horse"]
+
+[customPickupConditions]
+	#Custom Pickup Conditions. Read about the format here: https://github.com/Tschipp/CarryOn/wiki/Custom-Pickup-Condition-Config
+	#Custom Pickup Conditions for Blocks
+	customPickupConditionsBlocks = []
+	#Custom Pickup Conditions for Entities
+	customPickupConditionsEntities = []
+

--- a/config/improvedmobs/common.toml
+++ b/config/improvedmobs/common.toml
@@ -1,0 +1,318 @@
+
+#Default difficulty caps at 250
+[general]
+	#Disable/Enables the whole difficulty scaling of this mod. Requires a mc restart
+	"Enable difficulty scaling" = true
+	#Time in ticks for which the difficulty shouldnt increase at the beginning. One full minecraft day is 24000 ticks
+	#Range: > 0
+	"Difficulty Delay" = 0
+	#If true ignores mobs from spawners
+	"Ignore Spawner" = false
+	#Handles increase in difficulty regarding current difficulty.
+	#Format is <minimum current difficulty>-<increase every 2400 ticks>
+	#Example ["0-0.01","10-0.1","30-0"]
+	#So the difficulty increases by 0.01 every 2400 ticks (->0.1 per mc day since a mc day has 24000 ticks) till it reaches a difficulty of 10.
+	#Then it increases by 1 per mc day till it reaches 30 and then stops.
+	#If you want to use negative values use | instead of - as the delimiter.
+	"Difficulty Increase" = ["0.0-0.1", "250.0-0.0"]
+	#Wether difficulty should only increase with at least one online players or not
+	"Ignore Players" = false
+	#If true will increase difficulty by the amount of time skipped. Else will only increase difficulty once.
+	"Punish Time Skip" = true
+	#Disable/Enable friendly fire for owned pets.
+	FriendlyFire = false
+	#Blacklist for pet you should't be able to give armor to. Pets from mods, which have custom armor already should be included here (for balancing reasons).
+	"Pet Blacklist" = []
+	#Treat pet blacklist as whitelist
+	"Pet Whitelist" = false
+	#Increase difficulty with time
+	#Here untill its back as a gamerule
+	"Difficulty toggle" = true
+	#How the difficulty at a position is calculated. Supported values are: 
+	#GLOBAL: Serverwide difficulty value
+	#PLAYERMAX: Maximum difficulty of players in a 256 radius around the position
+	#PLAYERMEAN: Average difficulty of players in a 256 radius around the position
+	#PLAYERSUM: Sum of difficulty of players in a 256 radius around the position. There is no upper limit for this so max difficulty can be higher than the limit! You crazy if you use this
+	#DISTANCE: Uses the distance to the position defined in Center Position to define the difficulty
+	#DISTANCESPAWN: Uses the distance to the world spawn to define the difficulty
+	#If the type is any of the distance types the functionality of Difficulty Increase is changed to the following where the 1. value is the minimum distance and the 2. is the difficulty that applies. 
+	#E.g. ["0-0","1000-5"] translates to 0 difficulty between 0-1000 distance and 5 difficulty for distance >= 1000
+	#You can also define it as a triple x-y-z instead where z is the increase per block in for that area.
+	#E.g. ["0-0-0.1","1000-5-1"] the difficulty increases between 0-1000 by 0.1 per block and >= 1000 by 1 per block with a starting value of 5
+	#Allowed Values: GLOBAL, PLAYERMAX, PLAYERMEAN, PLAYERSUM, DISTANCE, DISTANCESPAWN
+	"Difficulty type" = "GLOBAL"
+	#Position used for DISTANCE difficulty type
+	"Center Position" = "0-0"
+
+#Black/Whitelist for various stuff
+[list]
+	#Entities added here will be blacklisted from their assigned flags. Usage:
+	#<entity registry name> or <namespace> or <#tag> followed by any of:
+	#[ALL,ATTRIBUTES,ARMOR,HELDITEMS,BLOCKBREAK,USEITEM,LADDER,STEAL,GUARDIAN,PARROT,TARGETVILLAGER,NEUTRALAGGRO,PEHKUI,REVERSE].
+	#Having no flags is equal to ALL. Use REVERSE to reverse all flags. Some flags do nothing for certain mobs!
+	#Examples (without <>):
+	#<minecraft:sheep> (equal to minecraft:sheep|ALL) excludes sheeps from all modifications
+	#<minecraft:sheep|REVERSE|ATTRIBUTES will> add sheep to attributes modification only
+	#<#minecraft:raiders|ATTRIBUTES> will add all entities in the raiders tag to everything except attributes
+	#<minecraft:sheep|ATTRIBUTES> will add sheep to everything except attributes
+	#<minecraft> disables everything for all minecraft mobs
+	"Entity Configs" = ["minecraft:glow_squid", "minecraft:trader_llama", "naturalist:rhino", "iceandfire:dread_horse", "minecraft:horse", "minecraft:polar_bear", "iceandfire:lightning_dragon", "crittersandcompanions:weevil", "born_in_chaos_v1:riding_felsteed", "iceandfire:dragon_skull", "minecraft:llama", "minecraft:pig", "minecraft:turtle", "naturalist:rattlesnake", "minecraft:sheep", "naturalist:firefly", "born_in_chaos_v1:baby_spider_controlled", "crittersandcompanions:roly_poly", "minecraft:tadpole", "minecraft:goat", "minecraft:dolphin", "iceandfire:fire_dragon", "minecraft:cod", "naturalist:robin", "naturalist:tortoise", "minecolonies:visitor", "born_in_chaos_v1:controlled_baby_skeleton", "minecolonies:mercenary", "minecraft:donkey", "naturalist:bear", "crittersandcompanions:jumping_spider", "minecolonies:citizen", "minecraft:squid", "minecraft:skeleton_horse", "naturalist:vulture", "naturalist:zebra", "minecraft:cow", "naturalist:duck", "iceandfire:hippocampus", "minecraft:bee", "naturalist:giraffe", "iceandfire:pixie", "crittersandcompanions:snail", "minecraft:salmon", "naturalist:bluejay", "crittersandcompanions:dumbo_octopus", "crittersandcompanions:dragonfly", "minecraft:snow_golem", "born_in_chaos_v1:riding_lords_felsteed", "minecraft:mooshroom", "born_in_chaos_v1:pumpkin_spirit", "minecraft:villager", "naturalist:bass", "iceandfire:ice_dragon", "minecraft:rabbit", "minecraft:axolotl", "naturalist:deer", "ecologics:squirrel", "born_in_chaos_v1:infernal_spirit", "crittersandcompanions:ladybug", "naturalist:butterfly", "naturalist:moose", "minecraft:strider", "minecraft:parrot", "securitycraft:sentry", "naturalist:dragonfly", "naturalist:elephant", "crittersandcompanions:koi_fish", "minecraft:bat", "minecraft:wandering_trader", "naturalist:sparrow", "crittersandcompanions:otter", "iceandfire:amphithere", "iceandfire:sea_serpent", "naturalist:cardinal", "minecraft:frog", "minecraft:iron_golem", "crittersandcompanions:shima_enaga", "minecolonies:cavalry_horse", "crittersandcompanions:stag_beetle", "iceandfire:mob_skull", "naturalist:hippo", "naturalist:snake", "ecologics:coconut_crab", "railways:conductor", "naturalist:lion", "naturalist:alligator", "naturalist:lizard_tail", "born_in_chaos_v1:controlled_spiritual_assistant", "crittersandcompanions:sea_bunny", "crittersandcompanions:stick_bug", "naturalist:canary", "naturalist:caterpillar", "minecraft:mule", "minecraft:sniffer", "naturalist:catfish", "naturalist:boar", "crittersandcompanions:red_panda", "minecraft:zombie_horse", "iceandfire:cockatrice", "minecraft:camel", "crittersandcompanions:leaf_insect", "born_in_chaos_v1:thornshell_crab", "minecraft:cat", "minecraft:pufferfish", "naturalist:lizard", "crittersandcompanions:ferret", "minecraft:fox", "minecraft:allay", "ecologics:penguin", "minecraft:tropical_fish", "naturalist:coral_snake", "naturalist:snail", "iceandfire:hippogryph", "naturalist:finch", "minecraft:ocelot", "iceandfire:deathworm", "minecraft:chicken", "born_in_chaos_v1:mr_pumpkin_controlled", "minecraft:wolf", "minecraft:panda"]
+	#Any of the following 
+	#[ATTRIBUTES, ARMOR, HELDITEMS, BLOCKBREAK, USEITEM, LADDER, STEAL, GUARDIAN, PARROT, TARGETVILLAGER, NEUTRALAGGRO, PEHKUI]
+	#added here will disable that feature completely.
+	#E.g. ["GUARDIAN"] will disable the guardian feature
+	"Flag Blacklist" = []
+	#Treat ATTRIBUTES flags as whitelist
+	"Attribute Whitelist" = false
+	#Treat ARMOR flags as whitelist
+	"Armor Equip Whitelist" = false
+	#Treat HELDITEMS flags as whitelist
+	"Held Equip Whitelist" = false
+	#Treat BLOCKBREAK flags as whitelist
+	"Breaker Whitelist" = false
+	#Treat USEITEM flags as whitelist
+	"Use Flag Whitelist" = false
+	#Treat LADDER flags as whitelist
+	"Ladder Whitelist" = false
+	#Treat STEAL flags as whitelist
+	"Steal Whitelist" = false
+	#Treat GUARDIAN flags as whitelist
+	"Guardian Whitelist" = false
+	#Treat PARROT flags as whitelist
+	"Phantom Whitelist" = false
+	#Treat TARGETVILLAGER flags as whitelist
+	"Villager Whitelist" = false
+	#Treat NEUTRALAGGRO flags as whitelist
+	"Neutral Aggro Whitelist" = false
+	#Treat PEHKUI flags as whitelist (Needs pehkui installed)
+	"Pehkui Whitelist" = false
+
+#Settings for mod integration
+[integration]
+	#Whether vanillas clamped regional difficulty should be used. 
+	#See https://minecraft.wiki/w/Difficulty#Clamped_regional_difficulty
+	#Allowed Values: OFF, ON, ADD
+	"Use Vanilla Difficulty" = "OFF"
+	#The max value for vanilla difficulty scaling. As clamped regional difficulty returns a value between 0 and 1
+	#Thus difficulty will be regional difficulty * max
+	#Range: 0.0 ~ 1.7976931348623157E308
+	"Vanilla Max" = 250.0
+	#Should the scaling health mods difficulty system be used instead of this ones. (Requires scaling health mod)
+	#Allowed Values: OFF, ON, ADD
+	"Use Scaling Health Mod" = "ON"
+	#If true and playerEx is installed will use the level from playerEx as difficulty
+	#Allowed Values: OFF, ON, ADD
+	"Use Player EX Mod" = "ON"
+	#Scaling for playerEX integration
+	#Range: 0.0 ~ 1.7976931348623157E308
+	"PlayerEX Scaling" = 1.0
+	#If true and LevelZ is installed will use the the total skill level from LevelZ as difficulty
+	#Allowed Values: OFF, ON, ADD
+	"Use LevelZ Mod" = "ON"
+	#Scaling for LevelZ integration
+	#Range: 0.0 ~ 1.7976931348623157E308
+	"LevelZ Scaling" = 1.0
+	#Using pehkui to vary the size of mobs
+	"Use pehkui Mod" = false
+	#The Max scale of mobs. Range [1.0,10], default 2.0
+	#Range: 1.0 ~ 10.0
+	"Max size Multiplier" = 2.0
+	#The Minimum scale of mobs. Range (0,1.0), default 0.5
+	#Range: 0.0 ~ 1.0
+	"Minimum size Multiplier" = 0.5
+	#Chance that a mob will be affected by size changes
+	#Range: 0.0 ~ 1.0
+	"Size Chance" = 0.5
+
+#Settings regarding custom ai for mobs
+[ai]
+	#Whitelist for blocks, which can be actively broken. 
+	#Usage: id|namespace|#tag. Put "!" infront to exclude blocks. E.g. "minecraft", "minecraft:dirt" or "#minecraft:planks"
+	#Note: If you include common blocks (like grass blocks) the pathfinding can have undesirable results.
+	"Block Break Whitelist" = ["#forge:glass", "#forge:glass_panes", "#minecraft:fence_gates", "#forge:fence_gates", "#minecraft:wooden_doors"]
+	#Treat Block Whitelist as Blocklist
+	"Breaklist as Blacklist" = false
+	#Use the block breaking sound instead of a knocking sound
+	Sound = false
+	#Chance for a mob to be able to break blocks
+	#Range: 0.0 ~ 1.0
+	"Breaker Chance" = 0.30000001192092896
+	#Initial cooldown for block breaking mobs
+	#Range: > 0
+	"Breaker Initial Cooldown" = 120
+	#Cooldown for breaking blocks
+	#Range: > 0
+	"Breaker Cooldown" = 20
+	#By default mobs can only break the block they can harvest with the current tool they holding. Set this to true to disable that check (The block will not drop if they cant harvest it though!).
+	"Ignore Harvest Check" = false
+	#Blocks will be restored after x ticks being broken. If set to 0 will never restore
+	#This will not restore block entity data!
+	#Range: > 0
+	"Restore delay" = 0
+	#If mobs should break blocks when not chasing a target
+	"Idle Break" = false
+	#Chance a breaker mob to ignore line of sight
+	#Range: 0.0 ~ 1.0
+	"Breaker Sight Ignore" = 0.5
+	#A modifier to the breaking speed
+	#Range: 0.0 ~ 1.7976931348623157E308
+	"Breaking Speed Base" = 1.0
+	#Addition to breaking speed modifier based on difficulty.
+	#Final modifier is base + addition * difficulty
+	#Range: 0.0 ~ 1.7976931348623157E308
+	"Breaking Speed Add" = 0.0
+	#Chance for a mob to be able to steal items from inventory blocks
+	#Range: 0.0 ~ 1.0
+	"Stealer Chance" = 0.30000001192092896
+	#List of blocks mobs shouldn't steal from. You can also add a modid to blacklist whole mods
+	"Steal Block Blacklist" = []
+	#Items which will be given to mobs who can break blocks. Empty list = no items. Syntax: id;weight
+	#Note: Mobs can only break blocks if the tool they are holding can break the blocks
+	"Breaking items" = ["minecraft:diamond_pickaxe;1", "minecraft:iron_axe;2"]
+	#Should mobs be able to break block entities? Evaluated before the break list
+	"Break BlockEntities" = true
+	#Chance for neutral mobs to be aggressive
+	#Range: 0.0 ~ 1.0
+	"Neutral Aggressive Chance" = 0.05000000074505806
+	#List for of pairs containing which mobs auto target others. Syntax is [mob id]-[mob id] where second value is the target.
+	# e.g. minecraft:zombie-minecraft:skeleton makes all zombies target skeletons
+	"Auto Target List" = []
+	#Difficulty at which mobs are able to break blocks
+	#Range: 0.0 ~ 1.7976931348623157E308
+	"Difficulty Break AI" = 0.0
+	#Difficulty at which mobs are able to steal items
+	#Range: 0.0 ~ 1.7976931348623157E308
+	"Difficulty Steal AI" = 0.0
+	#Chance for mobs to be able to summon an aquatic mount
+	#Range: 0.0 ~ 1.0
+	"Guardian Chance" = 0.5
+	#Chance for mobs to be able to summon a flying mount
+	#Range: 0.0 ~ 1.0
+	"Phantom Chance" = 0.5
+	#Set this to true to allow tnt thrown by mobs to destroy blocks
+	"TNT Block Destruction" = false
+	#Chance for a mob to ignore line of sight
+	#This config ONLY affects villager target, neutral aggressive and auto targeting feature
+	#Range: 0.0 ~ 1.0
+	"Generic Sight Ignore" = 0.5
+
+#Configs regarding mobs spawning with equipment
+[equipment]
+	#Blacklist items from whole mods. Add modid to prevent items from that mod being equipped. (For individual items use the equipment.json)
+	"Item Blacklist" = []
+	#Use blacklist as whitelist
+	"Item Whitelist" = false
+	#Blacklist for items mobs should never be able to use.
+	#Use as in using the item similar to players (e.g. shooting bows)
+	"Item Use Blacklist" = ["bigbrain:buckler"]
+	#Turn the use blacklist into a whitelist
+	"Item Use Whitelist" = false
+	#Blacklist for specific mobs and items they shouldnt use (e.g. skeletons already use bows)
+	#<entity registry name-item>
+	#For different items but same entity use multiple lines
+	#Some special names are BOW, TRIDEN, CROSSBOW refering to every bow/trident/crossbow item (So you dont need to type e.g. every bow item)
+	"Entity Item Use Blacklist" = ["minecraft:drowned;TRIDENT", "minecraft:illusioner;BOW", "minecraft:piglin;CROSSBOW", "minecraft:pillager;CROSSBOW", "minecraft:skeleton;BOW", "minecraft:snow_golem;minecraft:snowball", "minecraft:stray;BOW", "minecraft:wither_skeleton;BOW"]
+	#Base chance that a mob can have one piece of armor
+	#Range: 0.0 ~ 1.0
+	"Equipment Chance" = 0.10000000149011612
+	#Base chance for each additional armor pieces
+	#Range: 0.0 ~ 1.0
+	"Additional Equipment Chance" = 0.30000001192092896
+	#Adds additional x*difficulty% to base equip chance
+	#Range: 0.0 ~ 1.7976931348623157E308
+	"Equipment Addition" = 0.30000001192092896
+	#Chance for an equipment to have a random armor trim
+	#Range: 0.0 ~ 1.0
+	"Armor Trim Chance" = 0.05000000074505806
+	#Chance for mobs to have a weapon
+	#Range: 0.0 ~ 1.0
+	"Weapon Chance" = 0.5
+	#Adds additional x*difficulty% to base weapon chance
+	#Range: 0.0 ~ 1.7976931348623157E308
+	"Weapon Chance Add" = 0.30000001192092896
+	#Base chance for each armor pieces to get enchanted
+	#Range: 0.0 ~ 1.0
+	"Enchanting Chance" = 0.20000000298023224
+	#Adds additional x*difficulty% to base enchanting chance
+	#Range: 0.0 ~ 1.7976931348623157E308
+	"Enchanting Addition" = 0.20000000298023224
+	#Specify min and max enchanting levels according to difficulty. difficulty-minLevel-maxLevel
+	"Enchanting Calc" = ["0.0-5-10", "25.0-5-15", "50.0-10-17", "100.0-15-25", "200.0-20-30", "250.0-30-35"]
+	#Blacklist enchantments from being applied to equipments
+	"Enchanting Blacklist" = []
+	#Turn the enchant blacklist to a whitelist
+	"Enchanting Whitelist" = false
+	#Chance for mobs to have an item in offhand
+	#Range: 0.0 ~ 1.0
+	"Item Equip Chance" = 0.5
+	#Adds additional x*difficulty% to base item chance
+	#Range: 0.0 ~ 1.7976931348623157E308
+	"Item Chance add" = 0.20000000298023224
+	#Should mobs drop the armor equipped through this mod? Will not change drops if the mob obtained the armor through other means (e.g. vanilla)
+	"Should drop equipment" = false
+
+#Settings for attribute modifiers
+[attributes]
+	# PACK CONTROLLED — Industrial Civilization Survival
+	# Target, Main design document §3.4:
+	#   Day 1 ~20 HP · Day 100 ~28-32 · Day 200 ~35-40 · cap ~40-50
+	#   "ห้าม HP scaling ไม่มีเพดาน"
+	#
+	# "Difficulty Increase" above is ["0.0-0.1", ...] = +0.1 difficulty per MC day,
+	# so difficulty = day/10. Health multiplier = 1 + difficulty*0.016*M.
+	# Against a 20 HP vanilla zombie:
+	#
+	#   Day 100  difficulty 10  ->  1 + 10*0.016*2.75 = 1.44  ->  28.8 HP   (target 28-32)
+	#   Day 200  difficulty 20  ->  1 + 20*0.016*2.75 = 1.88  ->  37.6 HP   (target 35-40)
+	#   ceiling  multiplier 2.5                                ->  50.0 HP   (target cap 40-50)
+	#
+	# The default 5.0 ceiling would allow 100 HP - twice the documented cap, and
+	# exactly the unbounded scaling §3 Rule 3 forbids. Difficulty is capped at 250
+	# by "Difficulty Increase", so without this ceiling the curve keeps climbing.
+	#
+	#Health will be multiplied by 1 + difficulty*0.016*x. Set to 0 to disable
+	#Range: 0.0 ~ 1.7976931348623157E308
+	"Health Increase Multiplier" = 2.75
+	#Health will be multiplied by at maximum this. Set to 0 means no limit
+	#Range: 0.0 ~ 1.7976931348623157E308
+	"Max Health Increase" = 2.5
+	#Round health to the nearest x. Set to 0 to disable
+	#Range: 0.0 ~ 1.7976931348623157E308
+	"Round HP" = 0.5
+	#Damage will be multiplied by 1 + difficulty*0.008*x. Set to 0 to disable
+	#Range: 0.0 ~ 1.7976931348623157E308
+	"Damage Increase Multiplier" = 1.0
+	#Damage will be multiplied by at maximum this. Set to 0 means no limit
+	#Range: 0.0 ~ 1.7976931348623157E308
+	"Max Damage Increase" = 3.0
+	#Speed will be increased by difficulty*0.0008*x. Set to 0 to disable
+	#Range: 0.0 ~ 1.7976931348623157E308
+	"Speed Increase" = 1.0
+	#Maximum increase in speed
+	#Range: 0.0 ~ 1.0
+	"Max Speed" = 0.1
+	#Knockback will be increased by difficulty*0.002*x. Set to 0 to disable
+	#Range: 0.0 ~ 1.7976931348623157E308
+	"Knockback Increase" = 1.0
+	#Maximum increase in knockback
+	#Range: 0.0 ~ 1.0
+	"Max Knockback" = 0.5
+	#Magic resistance will be increased by difficulty*0.0016*x. Set to 0 to disable
+	#Range: 0.0 ~ 1.7976931348623157E308
+	"Magic Resistance Increase" = 1.0
+	#Maximum increase in magic resistance. Magic reduction is percentage
+	#Range: 0.0 ~ 1.0
+	"Max Magic Resistance" = 0.4000000059604645
+	#Projectile Damage will be multiplied by 1 + difficulty*0.008*x. Set to 0 to disable
+	#Range: 0.0 ~ 1.7976931348623157E308
+	"Projectile Damage Increase" = 1.0
+	#Projectile damage will be multiplied by maximum of this
+	#Range: 0.0 ~ 1.7976931348623157E308
+	"Max Projectile Damage" = 2.0
+	#Explosion Damage will be multiplied by 1 + difficulty*0.003*x. Set to 0 to disable
+	#Range: 0.0 ~ 1.7976931348623157E308
+	"Explosion Damage Increase" = 1.0
+	#Explosion damage will be multiplied by maximum of this
+	#Range: 0.0 ~ 1.7976931348623157E308
+	"Max Explosion Damage" = 1.75
+

--- a/docs/Addon Spec — Animation & Movement Layer.md
+++ b/docs/Addon Spec — Animation & Movement Layer.md
@@ -1,0 +1,1375 @@
+# Addon Spec — Animation & Movement Layer
+## Claude Code CLI Implementation Handoff
+
+> **Project:** Industrial Civilization Survival  
+> **Repository:** `xenodeve/minecraft-100day`  
+> **Platform:** Minecraft 1.20.1 / Forge / Java 17  
+> **Purpose:** Add a smooth, expressive and comfortable animation/movement layer for player, Vanilla mobs/animals and modded entities while preserving Minecraft-like controls and avoiding excessive realism or motion sickness.
+>
+> This document is standalone implementation context for Claude Code CLI.
+
+---
+
+# 1. Design Goal
+
+Target:
+
+```text
+Minecraft movement
+        ↓
+Smoother
+More expressive
+More readable
+More immersive
+        ↓
+Still feels like Minecraft
+```
+
+Do **not** turn the pack into:
+
+```text
+real-world inertia simulation
+camera-heavy realism
+Arma-like movement
+constant acceleration/deceleration
+```
+
+Core principle:
+
+> **Improve visual motion without making long 100–300+ day sessions tiring.**
+
+---
+
+# 2. Approved Stack
+
+## Core / Core Candidates
+
+```text
+Smooth Player Animations
+Not Enough Animations
+Better Animations Collection
+Smooth Movement
+```
+
+## Optional Selective Layer
+
+```text
+Entity Model Features (EMF)
+Entity Texture Features (ETF)
+Fresh Animations
+```
+
+Fresh Animations is a **selective Vanilla-entity gap filler**, not a default global replacement.
+
+---
+
+# 3. Rejected
+
+## AMF: Better Movement
+
+```text
+Status: REJECTED
+```
+
+Reasons:
+
+- excessive real-life inertia
+- changes control feel too much
+- potential motion sickness / fatigue
+- not needed for pack identity
+
+Do not re-propose without explicit developer direction.
+
+---
+
+# 4. Hard Rule — Animation Ownership
+
+> **One entity, one primary animation owner.**
+
+Examples:
+
+```text
+Player → Smooth Player Animations
+Zombie → Better Animations Collection
+Wolf → Fresh Animations
+Naturalist Bear → Naturalist native animation
+Ice & Fire Dragon → Ice & Fire native animation
+```
+
+Do not blindly let BAC and Fresh Animations control the same entity.
+
+---
+
+# 5. Architecture
+
+```text
+                    ENTITY MOVEMENT
+                          │
+                          ▼
+                  Smooth Movement
+             visual position interpolation
+                          │
+          ┌───────────────┼────────────────┐
+          │               │                │
+          ▼               ▼                ▼
+       PLAYER       VANILLA ENTITY    MODDED ENTITY
+          │               │                │
+          ▼               ▼                ▼
+ Smooth Player       Better Anim.         Native
+ Animations           Collection        Animation
+      +                   │
+ Not Enough               ▼
+ Animations          Missing / weak?
+                          │
+                         YES
+                          │
+                          ▼
+                Fresh Animations
+                    EMF + ETF
+```
+
+---
+
+# 6. Player Ownership
+
+Primary:
+
+```text
+Smooth Player Animations
+```
+
+Secondary action layer:
+
+```text
+Not Enough Animations
+```
+
+Smooth Player Animations should own locomotion such as:
+
+```text
+walking
+running
+sprinting
+swimming
+crawling
+climbing
+idle
+body transitions
+upper/lower body movement
+```
+
+Not Enough Animations should complement missing third-person/action animations.
+
+---
+
+# 7. Player Compatibility Targets
+
+Must test with:
+
+```text
+TaCZ
+TaCZ Additions
+TaCZ Durability
+TakKit
+Brimm Armors
+CAPS_Awim
+Sophisticated Backpacks
+Curios
+PlayerRevive
+Create contraptions
+Minecarts / trains
+Swimming
+Ladders / crawling
+```
+
+Critical TaCZ checks:
+
+```text
+ADS
+reload
+fire
+sprint
+crouch
+weapon swap
+remote-player pose
+```
+
+---
+
+# 8. Fresh Animations Player Extension
+
+Initial status:
+
+```text
+DISABLED
+```
+
+Player already has:
+
+```text
+Smooth Player Animations
++
+Not Enough Animations
+```
+
+Do not add a third player animation owner unless testing reveals a real gap.
+
+---
+
+# 9. Vanilla Mob / Animal Default
+
+Primary default:
+
+```text
+Better Animations Collection
+```
+
+Fresh Animations is only considered where BAC is:
+
+```text
+missing
+visibly weaker
+aesthetic mismatch
+or otherwise not satisfactory
+```
+
+Selection must be made per entity.
+
+---
+
+# 10. Fresh Animations Role
+
+Use Fresh Animations through:
+
+```text
+EMF
++
+ETF
++
+Fresh Animations Resource Pack
+```
+
+Do not use OptiFine.
+
+Fresh Animations should fill **entity-level gaps**, not automatically replace BAC everywhere.
+
+---
+
+# 11. Entity-Level, Not Animation-Level Mixing
+
+Do not start with:
+
+```text
+Cow walk → BAC
+Cow idle → FA
+Cow eat → BAC
+Cow sleep → FA
+```
+
+Prefer:
+
+```text
+Cow → BAC
+Wolf → FA
+```
+
+Animation-by-animation merging is a future custom compatibility task only.
+
+---
+
+# 12. Animation Coverage Matrix
+
+Create:
+
+```text
+docs/animation-coverage.md
+```
+
+Recommended columns:
+
+```text
+Entity
+Category
+Native Animation
+BAC Coverage
+FA Coverage
+Selected Owner
+Reason
+Conflict
+Performance Notes
+Tested
+```
+
+Example only:
+
+| Entity | BAC | FA | Owner | Reason |
+|---|---:|---:|---|---|
+| Zombie | Yes | Yes | BAC | good default |
+| Cow | Yes | Yes | BAC | good default |
+| Wolf | Partial | Strong | FA | richer movement |
+| Naturalist Bear | — | — | Native | mod owns animation |
+| Dragon | — | — | Native | Ice & Fire owns animation |
+
+Do not treat the example as final truth.
+
+---
+
+# 13. Modded Entity Rule
+
+Default:
+
+```text
+Modded entity → native mod animation
+```
+
+Includes:
+
+```text
+Naturalist
+Critters and Companions
+Born in Chaos
+Ice & Fire
+MineColonies NPCs
+```
+
+Do not force BAC/FA onto modded entities unless explicitly supported and tested.
+
+---
+
+# 14. Ownership Priority
+
+```text
+1. Native mod animation
+2. Explicit compatibility layer
+3. BAC / FA for Vanilla entities
+4. Vanilla fallback
+```
+
+---
+
+# 15. Smooth Movement Role
+
+Smooth Movement is **not** an animation owner.
+
+It is a:
+
+> **Visual interpolation layer**
+
+Purpose:
+
+```text
+smooth position transitions
+reduce visible entity jerk
+reduce perceived multiplayer/TPS stutter
+improve motion continuity
+```
+
+It may improve perceived smoothness without increasing raw TPS/FPS.
+
+---
+
+# 16. Smooth Movement Initial Policy
+
+Conceptual initial state:
+
+```text
+Players             ON / TEST
+Living Entities     ON / TEST
+Items                ON / TEST
+Minecarts            TEST
+Falling Blocks       TEST
+Projectiles          OFF
+```
+
+Read the actual installed config before implementing. Do not invent option names.
+
+---
+
+# 17. Projectile Smoothing
+
+Initial status:
+
+```text
+OFF
+```
+
+Because the pack uses or may use:
+
+```text
+TaCZ bullets
+Create Big Cannons
+Warium projectiles
+Historical Anti Air
+Aircraft weapons
+```
+
+Do not risk visual/server ballistic disagreement.
+
+---
+
+# 18. Projectile Smoothing Gate
+
+Only consider enabling after:
+
+```text
+TaCZ semi-auto test
+TaCZ full-auto test
+CBC shell test
+multiplayer latency test
+Warium test later
+```
+
+Required:
+
+```text
+no hit-registration mismatch
+no visual trajectory mismatch
+no projectile teleport artifacts
+no damage regression
+```
+
+---
+
+# 19. Better Animations Collection Configuration
+
+Inspect real generated config.
+
+Possible actions:
+
+```text
+disable conflicting features
+disable weak/unwanted features
+disable ownership for entities handed to FA
+```
+
+Do not assume per-entity/per-animation toggles exist until verified.
+
+---
+
+# 20. Fresh Animations Selection Criteria
+
+For each Vanilla entity evaluate:
+
+```text
+1. Is BAC coverage present?
+2. Does BAC look good?
+3. Is FA meaningfully better?
+4. What is the render cost?
+5. Is this entity common enough that cost matters?
+6. Does FA conflict with other model/resource packs?
+```
+
+Then assign:
+
+```text
+BAC
+FA
+VANILLA
+```
+
+---
+
+# 21. Custom Animation Compatibility Pack
+
+If an entity later needs a custom hybrid:
+
+```text
+resourcepacks/
+└── industrial-civilization-animation-compat/
+```
+
+Only build after understanding:
+
+```text
+EMF model definitions
+animation expressions
+resource-pack priority
+license constraints
+```
+
+Do not immediately fork BAC or Fresh Animations.
+
+---
+
+# 22. Licensing / Redistribution
+
+Before shipping Fresh Animations:
+
+```text
+read current license
+record attribution requirements
+record redistribution permission
+avoid copying upstream assets unnecessarily
+```
+
+Preferred model:
+
+```text
+Original Fresh Animations pack
++
+Industrial Civilization compatibility override pack
+```
+
+Update:
+
+```text
+docs/distribution-licenses.md
+```
+
+---
+
+# 23. Movement Comfort Rule
+
+Hard UX requirement:
+
+> Avoid systems that add continuous inertia, excessive camera motion, heavy body sway or motion that can cause motion sickness in long sessions.
+
+This is a permanent pack-level design constraint unless explicitly changed.
+
+---
+
+# 24. First-Person Camera Policy
+
+Do not add by default:
+
+```text
+excessive head bob
+dynamic camera inertia
+strong sprint shake
+forced breathing sway
+```
+
+TaCZ already provides weapon feedback.
+
+---
+
+# 25. Tactical Readability
+
+Animation must preserve:
+
+```text
+fast reaction
+sprint-stop-shoot
+crouch
+ADS
+reload
+weapon switch
+revive
+climb / escape
+```
+
+Aesthetic polish must not reduce combat readability.
+
+---
+
+# 26. PlayerRevive Compatibility
+
+Test:
+
+```text
+downed pose
+crawl/incapacitated state
+revive interaction
+standing recovery
+```
+
+Look for:
+
+```text
+pose fighting
+T-pose
+snapping
+stuck animation
+```
+
+---
+
+# 27. TaCZ Compatibility Matrix
+
+Test:
+
+```text
+Idle with gun
+Walk
+Sprint
+Crouch
+ADS
+Fire
+Reload
+Weapon swap
+Attachment interaction
+```
+
+Observe:
+
+```text
+first person
+third person
+remote multiplayer player
+```
+
+---
+
+# 28. Tactical Gear Compatibility
+
+Test:
+
+```text
+TakKit NVG
+Brimm armor
+CAPS_Awim
+Sophisticated Backpacks
+Curios
+```
+
+Watch for:
+
+```text
+clipping
+floating equipment
+body desync
+headgear/NVG pose conflict
+```
+
+---
+
+# 29. Create Compatibility
+
+Test player animation while:
+
+```text
+standing on contraption
+moving on contraption
+riding train
+using seats
+using elevator
+climbing Create structures
+```
+
+Document any unavoidable foot sliding or orientation issue.
+
+---
+
+# 30. MineColonies Compatibility
+
+MineColonies NPCs remain native-owned.
+
+Performance test:
+
+```text
+10 citizens
+25 citizens
+50 citizens
+```
+
+Do not force Vanilla animation replacements onto citizens without evidence.
+
+---
+
+# 31. Hordes Compatibility
+
+Test:
+
+```text
+50 mobs
+100 mobs
+150 mobs
+```
+
+with:
+
+```text
+BAC
+Smooth Movement
+Entity Culling
+ImmediatelyFast
+Embeddium
+```
+
+Measure:
+
+```text
+FPS
+1% low
+frame time
+entity render cost
+```
+
+---
+
+# 32. Naturalist Compatibility
+
+Naturalist entities keep native animations.
+
+Verify:
+
+```text
+walk
+run
+idle
+attack
+swim
+special animations
+```
+
+Smooth Movement may interpolate position only.
+
+---
+
+# 33. Born in Chaos Compatibility
+
+Born in Chaos remains native-owned.
+
+Test:
+
+```text
+movement
+attack animation
+special abilities
+death
+Smooth Movement interpolation
+```
+
+Reject interpolation settings that create hitbox/visual mismatch.
+
+---
+
+# 34. Ice & Fire Compatibility
+
+Critical entities:
+
+```text
+Dragon
+Cyclops
+Troll
+Hydra
+Sea Serpent
+Death Worm
+```
+
+retain native animation.
+
+Test Smooth Movement especially for:
+
+```text
+dragon flight
+takeoff
+landing
+charge
+attack
+```
+
+Exclude problematic entities if supported and necessary.
+
+---
+
+# 35. Combat Readability
+
+Hostile animation must not obscure:
+
+```text
+attack windup
+facing direction
+hit reaction
+special ability cue
+```
+
+Combat readability outranks animation smoothness.
+
+---
+
+# 36. Animal Style Goal
+
+Animals should feel:
+
+```text
+alive
+cute
+natural
+ambient
+```
+
+while preserving Minecraft's visual language.
+
+The contrast must remain:
+
+```text
+normal wildlife
+vs
+abnormal hostile creatures
+```
+
+---
+
+# 37. Performance Layer Integration
+
+Test with:
+
+```text
+Embeddium
+ModernFix
+FerriteCore
+Entity Culling
+ImmediatelyFast
+ServerCore
+```
+
+If Fresh Animations is enabled, explicitly test:
+
+```text
+EMF
++
+ETF
++
+Fresh Animations
++
+Entity Culling
+```
+
+---
+
+# 38. Performance Documentation
+
+Create:
+
+```text
+docs/animation-performance.md
+```
+
+Compare:
+
+```text
+Baseline
+NEA only
+SPA + NEA
+BAC
+BAC + Smooth Movement
+BAC + EMF/ETF + selective FA
+```
+
+Metrics:
+
+```text
+Average FPS
+1% low
+frame time
+CPU
+GPU
+RAM
+VRAM
+entity count
+```
+
+---
+
+# 39. Benchmark Scene — Player
+
+```text
+tactical armor
+TaCZ rifle
+walk
+sprint
+crouch
+ADS
+reload
+fire
+```
+
+Primary goal:
+
+```text
+animation correctness
+```
+
+---
+
+# 40. Benchmark Scene — Vanilla Entities
+
+Spawn controlled groups:
+
+```text
+20
+50
+100
+```
+
+Compare BAC vs selected FA ownership.
+
+---
+
+# 41. Benchmark Scene — Horde
+
+Test:
+
+```text
+50
+100
+150
+```
+
+Look for:
+
+```text
+frame pacing
+render bottleneck
+interpolation artifacts
+```
+
+---
+
+# 42. Benchmark Scene — Colony
+
+Use mixed load:
+
+```text
+MineColonies
++
+wildlife
++
+player animation
++
+Create activity
+```
+
+This represents real gameplay better than an empty benchmark arena.
+
+---
+
+# 43. Multiplayer Test
+
+Test at least:
+
+```text
+2 players
+4 players
+```
+
+Check:
+
+```text
+remote player SPA/NEA
+TaCZ remote pose
+Smooth Movement
+equipment sync
+```
+
+---
+
+# 44. Smooth Movement Network Test
+
+Observe:
+
+```text
+normal ping
+moderate ping
+TPS fluctuation
+packet jitter
+```
+
+Goal:
+
+reduce visual jerk without:
+
+```text
+ghost positions
+rubber-band-looking interpolation
+server/client mismatch
+```
+
+---
+
+# 45. Conflict Log
+
+Create:
+
+```text
+docs/animation-conflicts.md
+```
+
+Record:
+
+```text
+Entity
+Owner A
+Owner B
+Observed issue
+Resolution
+Version
+```
+
+---
+
+# 46. Repository Structure
+
+Recommended:
+
+```text
+docs/
+├── animation-coverage.md
+├── animation-performance.md
+├── animation-conflicts.md
+└── animation-test-plan.md
+
+resourcepacks/
+└── industrial-civilization-animation-compat/
+```
+
+Actual config file paths must come from first launch.
+
+---
+
+# 47. Phase A0 — Version Sweep
+
+Verify exact Forge 1.20.1 builds for:
+
+```text
+Smooth Player Animations
+Better Animations Collection
+Smooth Movement
+EMF
+ETF
+Fresh Animations
+```
+
+Record:
+
+```text
+version
+source
+dependencies
+loader
+side
+license
+```
+
+---
+
+# 48. Phase A1 — Player Baseline
+
+Install:
+
+```text
+Smooth Player Animations
+```
+
+alongside existing:
+
+```text
+Not Enough Animations
+```
+
+Do not add FA/EMF/ETF yet.
+
+---
+
+# 49. Phase A2 — Player Combat Test
+
+Test:
+
+```text
+TaCZ
+TakKit
+PlayerRevive
+Backpacks
+Curios
+```
+
+Resolve player conflicts before adding more animation layers.
+
+---
+
+# 50. Phase A3 — BAC Baseline
+
+Install Better Animations Collection.
+
+Audit Vanilla entities.
+
+Create:
+
+```text
+docs/animation-coverage.md
+```
+
+---
+
+# 51. Phase A4 — Smooth Movement
+
+Install Smooth Movement.
+
+Initial principle:
+
+```text
+living movement enabled
+projectile smoothing disabled
+```
+
+Test Vanilla + modded mobs + multiplayer.
+
+---
+
+# 52. Phase A5 — Fresh Animations Evaluation
+
+On a test branch/profile install:
+
+```text
+EMF
+ETF
+Fresh Animations
+```
+
+Compare entity-by-entity against BAC.
+
+Do not make FA global owner automatically.
+
+---
+
+# 53. Phase A6 — Ownership Matrix
+
+Assign every relevant Vanilla entity:
+
+```text
+BAC
+FA
+VANILLA
+```
+
+with documented reason.
+
+---
+
+# 54. Phase A7 — Selective FA Layer
+
+Build resource-pack priority / selective ownership strategy.
+
+Goal:
+
+```text
+FA owns only approved entities
+```
+
+Do not blindly delete or copy upstream assets.
+
+---
+
+# 55. Phase A8 — Performance Test
+
+Run:
+
+```text
+Vanilla entity density
+Horde
+MineColonies
+Wildlife
+```
+
+Compare:
+
+```text
+BAC-only
+vs
+BAC + selective FA
+```
+
+---
+
+# 56. Phase A9 — Multiplayer Test
+
+Test:
+
+```text
+remote SPA/NEA player
+Smooth Movement
+TaCZ
+Horde
+```
+
+---
+
+# 57. Phase A10 — Release Gate
+
+Animation layer may merge only when:
+
+```text
+no major player pose conflict
+no TaCZ ADS/reload conflict
+no PlayerRevive stuck pose
+no Vanilla model corruption
+no severe Horde render regression
+projectile smoothing still OFF unless separately validated
+no redistribution/license issue
+```
+
+---
+
+# 58. Optional Profiles
+
+If selective Fresh Animations is measurably heavier:
+
+## Standard
+
+```text
+Smooth Player Animations
+Not Enough Animations
+Better Animations Collection
+Smooth Movement
+```
+
+## Enhanced Animation
+
+```text
+Standard
++
+EMF
++
+ETF
++
+Selective Fresh Animations
+```
+
+Gameplay must remain identical.
+
+---
+
+# 59. Success Criteria — Player
+
+Player should:
+
+```text
+walk smoothly
+sprint naturally
+transition smoothly
+look good with tactical gear
+use TaCZ correctly
+recover correctly after revive
+```
+
+while staying responsive.
+
+---
+
+# 60. Success Criteria — Vanilla Entities
+
+Vanilla mobs/animals should:
+
+```text
+look more alive
+remain combat-readable
+fit Minecraft's style
+not clash badly with modded entities
+```
+
+---
+
+# 61. Success Criteria — Modded Entities
+
+Modded entities should:
+
+```text
+retain native animation
+avoid accidental model override
+interpolate cleanly where Smooth Movement is used
+```
+
+---
+
+# 62. Failure Conditions
+
+Reject/disable a component if it causes:
+
+```text
+T-pose
+weapon pose corruption
+player snapping
+camera discomfort
+broken revive pose
+entity model distortion
+attack animation mismatch
+projectile visual/hit mismatch
+severe FPS regression
+```
+
+---
+
+# 63. Claude Code Hard Rules
+
+## DO
+
+1. Keep one primary animation owner per entity.
+2. Prefer native animation for modded entities.
+3. Use Smooth Player Animations + NEA for Player.
+4. Use BAC as Vanilla default.
+5. Use Fresh Animations selectively.
+6. Keep Smooth Movement separate from animation ownership.
+7. Keep projectile smoothing OFF initially.
+8. Test TaCZ before declaring player animation stable.
+9. Benchmark Horde/entity-heavy scenes.
+10. Audit Fresh Animations licensing before redistribution.
+11. Document ownership decisions.
+12. Preserve Minecraft-like responsiveness.
+13. Prioritize motion comfort for long sessions.
+
+## DO NOT
+
+1. Do not add AMF: Better Movement.
+2. Do not use OptiFine.
+3. Do not enable Fresh Animations Player Extension initially.
+4. Do not blindly stack BAC and FA on the same entity.
+5. Do not assume animation-level mixing is trivial.
+6. Do not enable projectile smoothing before ballistic testing.
+7. Do not force BAC/FA onto modded entities.
+8. Do not add heavy camera sway/inertia.
+9. Do not sacrifice combat readability for smoothness.
+10. Do not claim compatibility without launching the game.
+
+---
+
+# 64. Final Architecture
+
+```text
+PLAYER
+────────────────────────
+Smooth Player Animations
++
+Not Enough Animations
+
+VANILLA MONSTERS / ANIMALS
+────────────────────────
+Better Animations Collection
+        │
+        └─ Fresh Animations
+           only where approved
+           through EMF + ETF
+
+MODDED MONSTERS / ANIMALS
+────────────────────────
+Native mod animations
+
+GLOBAL VISUAL MOVEMENT
+────────────────────────
+Smooth Movement
+(projectiles OFF initially)
+```
+
+---
+
+# 65. Final Feature Definition
+
+> **The Animation & Movement Layer makes Industrial Civilization Survival smoother, more alive and more expressive without turning Minecraft into a real-world movement simulator. Player animation remains responsive and tactical, Vanilla creatures gain improved motion, modded creatures retain their native identity, and Smooth Movement improves visual continuity during multiplayer or server-load fluctuations.**
+
+Target:
+
+```text
+More life
++
+More smoothness
++
+Better tactical presentation
++
+No motion sickness
++
+No unnecessary realism tax
+```
+
+Guiding sentence:
+
+> **Smooth like a modern game, readable like Minecraft, comfortable enough to play for hundreds of days.**

--- a/docs/customization-map.md
+++ b/docs/customization-map.md
@@ -32,12 +32,12 @@ them**, never all at once.
 | **Attract to Sound** | `HEAVY CUSTOM` | The noise ladder: `suppressed pistol < pistol < rifle < shotgun < HMG < cannon`. Gunfire attracts **existing** mobs — it must not spawn them. Watch MSPT under automatic fire; coalesce events if profiling demands it | Main §3.3, §11 |
 | **IceAndFire CE** | `HEAVY WORLDGEN CUSTOMIZATION` | Spawn-safe radius **~2000–2500 blocks**; roost and den separation far above default. Tune IceAndFire's own worldgen — **not** In Control | Main §3.4, §10 |
 | **The Hordes** | `HEAVY CUSTOM WAVES` | Tier I–IV composition, and the shape `Calm → Tension → Crisis → Recovery`. Dragons are never Horde mobs. Build Tier I and II first | Main §3.4, §12, §24 Phase 6 |
-| **Enhanced AI** | `HEAVY CONFIG` | Which materials breach easily (wood, dirt, cobble) and which must actually hold (fortified stone, industrial defences) | Main §3.4 |
-| **Improved Mobs** | `HEAVY NERF FROM DEFAULT` | HP curve: **Day 1 ~20 → Day 100 ~28–32 → Day 200 ~35–40 → cap ~40–50**. Scaling must have a ceiling | Main §3.4 |
+| **Enhanced AI** | `HEAVY CONFIG` | ✅ **DONE (#21)** — it is a **tag**, not a config: `kubejs/data/enhancedai/tags/blocks/miner_blacklist.json`. Wood/dirt/cobble deliberately absent so they stay breachable | Main §3.4 |
+| **Improved Mobs** | `HEAVY NERF FROM DEFAULT` | ✅ **DONE (#21)** — `Health Increase Multiplier = 2.75`, `Max Health Increase = 2.5` in `config/improvedmobs/common.toml`, derivation recorded in the file | Main §3.4 |
 | **In Control!** | `HEAVY CUSTOM` | Spawn density, day-based threat tier, biome rules, distance rules, enemy restrictions | Main §3.4 |
 | **SecurityCraft** | `HEAVY CUSTOM` | Disable or limit anything that makes a base unbreachable — reinforced blocks, sentries, mines | Main §3.10, §14 |
 | **Immersive Engineering** | `HEAVY CUSTOM SCOPE` | It owns **electrical infrastructure**, not manufacturing. Disable or gate IE machinery that bypasses Create | Main §3.11 |
-| **Carry On** | `HEAVY BLACKLIST` | Blacklist Create machinery, MineColonies blocks, large storage, industrial machines — anything that bypasses logistics | Main §3.9 |
+| **Carry On** | `HEAVY BLACKLIST` | ✅ **DONE (#21)** — most of it ships by default; appended `railways:*`, the three Create addons, `structurize:*`, `domum_ornamentum:*`, `sophisticatedbackpacks:*`, `sophisticatedcore:*` | Main §3.9 |
 
 ## Custom — scoped, smaller
 

--- a/index.toml
+++ b/index.toml
@@ -1,6 +1,18 @@
 hash-format = "sha256"
 
 [[files]]
+file = "config/carryon-common.toml"
+hash = "2d6325c0faf202f663ecd24fba288893bc9894950be9ab7459e40b406bdde19d"
+
+[[files]]
+file = "config/improvedmobs/common.toml"
+hash = "bd28d94f50a98de35da0e606349680a3f8a8f1402d25758024d9dbc7924964d4"
+
+[[files]]
+file = "kubejs/data/enhancedai/tags/blocks/miner_blacklist.json"
+hash = "6993c08462884c38a5c8ff7a39b2b287f0e2e1fa521239b479ac4badb031b7cf"
+
+[[files]]
 file = "mods/ambientsounds.pw.toml"
 hash = "fa96526cc55c9fbac742aea245930f1a2db2e68b50765f1bdbaf85477e1631bf"
 metafile = true

--- a/index.toml
+++ b/index.toml
@@ -2,11 +2,11 @@ hash-format = "sha256"
 
 [[files]]
 file = "config/carryon-common.toml"
-hash = "2d6325c0faf202f663ecd24fba288893bc9894950be9ab7459e40b406bdde19d"
+hash = "9549d1d5bbf54277b92b4f8e68e61f8736b327bb0cb15d0a68c51615a98f79fc"
 
 [[files]]
 file = "config/improvedmobs/common.toml"
-hash = "bd28d94f50a98de35da0e606349680a3f8a8f1402d25758024d9dbc7924964d4"
+hash = "a8364ac6a95a957c0a83fa0b7a4f1782cff594969e1e709339f6c55478ff6fb6"
 
 [[files]]
 file = "kubejs/data/enhancedai/tags/blocks/miner_blacklist.json"

--- a/kubejs/README.md
+++ b/kubejs/README.md
@@ -1,0 +1,67 @@
+# kubejs/ — the pack's global data layer
+
+**What is here right now:** `data/enhancedai/tags/blocks/miner_blacklist.json` — the blocks a
+breaching mob **cannot** mine.
+
+## Why this lives under `kubejs/data/` and not `datapacks/`
+
+The design document's §7 repo layout lists a `datapacks/` directory, and that is where a datapack
+*file* belongs — but Minecraft does not load a `datapacks/` folder at the pack root. Vanilla only
+reads `<world>/datapacks/`, which is **per-world**: a datapack placed there applies to the world it
+sits in and to no world the player creates afterwards. For a pack rule that must hold in every
+world, that is the wrong place.
+
+KubeJS — CORE in this pack — loads `kubejs/data/<namespace>/…` as a global datapack for every
+world. So that is where a pack-wide tag goes.
+
+If a `datapacks/` directory appears later it should hold things that are genuinely per-world, or a
+mod that provides global datapack loading should be added deliberately and recorded.
+
+## Why the tag is a datapack and not a config
+
+Enhanced AI's generated `common.toml` says so itself:
+
+> Mobs can mine blocks to reach the target. Uses offhand item to mine. Only mobs in the entity type
+> tag `enhancedai:mobs/can_mine` can spawn with the ability to mine and blocks in the tag
+> `enhancedai:miner_blacklist` cannot be mined.
+
+The mod exposes the behaviour through tags, so the customization the design document files under
+`HEAVY CONFIG` (Main §3.4) is really a datapack. Read from the generated config, not assumed —
+§31 rule 11.
+
+## The design intent this encodes
+
+Main §3.4:
+
+> Wood/Dirt/Cobblestone สามารถ breach ได้ง่ายกว่า
+> Fortified Stone / Industrial defenses ต้องดีขึ้นจริง
+
+So wood, dirt, cobblestone and ordinary stone are **deliberately absent** from the blacklist — a
+mob is supposed to get through them. What is listed is the tier a player has to actually build
+toward: obsidian, netherite, steel, and Immersive Engineering's concrete and steel scaffolding.
+
+**SecurityCraft's reinforced blocks are deliberately NOT here.** §14 says the opposite for them:
+*"SecurityCraft ต้องถูก nerf หากมี block ที่ทำให้ enemy ไม่สามารถ breach ได้เลย"* — making them
+unmineable is the failure this pack is avoiding, not the goal.
+
+## `"required": false`
+
+Every mod-provided entry is wrapped as `{ "id": "...", "required": false }`. A tag entry that names
+a block which does not exist is a **hard datapack error** in 1.20.1 — it fails the whole tag and
+takes the reload with it. `required: false` makes a missing entry a no-op instead.
+
+That matters here because the Immersive Engineering block ids have **not** been verified against
+the registry. They are the mod's conventional names; if one is wrong, this file degrades to
+ignoring that line rather than breaking the world load. Verify them against `/data get` or a
+registry dump before relying on any single one.
+
+## Verifying it took effect
+
+```
+/datapack list
+```
+should show `file/ics-threat` under enabled packs. Then, in game, have a breaching mob path at a
+wall of one of the listed blocks and confirm it does not mine through.
+
+**Not yet verified in game.** The server boots with this datapack loaded; that proves it parses,
+not that the behaviour is what the design wants.

--- a/kubejs/data/enhancedai/tags/blocks/miner_blacklist.json
+++ b/kubejs/data/enhancedai/tags/blocks/miner_blacklist.json
@@ -1,0 +1,26 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:obsidian",
+    "minecraft:crying_obsidian",
+    "minecraft:reinforced_deepslate",
+    "minecraft:ancient_debris",
+    "minecraft:netherite_block",
+    "minecraft:bedrock",
+
+    { "id": "#forge:storage_blocks/steel", "required": false },
+    { "id": "#forge:storage_blocks/netherite", "required": false },
+
+    { "id": "immersiveengineering:concrete", "required": false },
+    { "id": "immersiveengineering:concrete_tile", "required": false },
+    { "id": "immersiveengineering:concrete_leaded", "required": false },
+    { "id": "immersiveengineering:concrete_sheet", "required": false },
+    { "id": "immersiveengineering:concrete_quarter", "required": false },
+    { "id": "immersiveengineering:concrete_three_quarter", "required": false },
+    { "id": "immersiveengineering:steel_scaffolding_standard", "required": false },
+    { "id": "immersiveengineering:steel_scaffolding_grate_top", "required": false },
+    { "id": "immersiveengineering:steel_scaffolding_wooden_top", "required": false },
+    { "id": "immersiveengineering:sheetmetal_steel", "required": false },
+    { "id": "immersiveengineering:sheetmetal_iron", "required": false }
+  ]
+}

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "0d3e02dca57d1fa3a5e5e492c306486bd6061f17649e4e264bd9fb65102b17e9"
+hash = "2c4684ce0f65a6ccf89287a07432c8bad9d8b5744982b47f6eac8f1e94f52741"
 
 [versions]
 forge = "47.4.23"

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "2c4684ce0f65a6ccf89287a07432c8bad9d8b5744982b47f6eac8f1e94f52741"
+hash = "3464e78961325e2e91745b32c8df3765e38e8b35ecbff0e7215d1a5a223ecadc"
 
 [versions]
 forge = "47.4.23"


### PR DESCRIPTION
Closes #21.

The first real tuning. The 88 configs the server boot generated satisfy §31 rule 11 — every key
below was **read out of a generated file**, not recalled.

## Improved Mobs — the HP curve

```
Health Increase Multiplier   1.0 → 2.75
Max Health Increase          5.0 → 2.5
```

Difficulty rises 0.1 per MC day and health is `base × (1 + difficulty×0.016×M)`. Against a 20 HP
zombie:

| | difficulty | HP | target (Main §3.4) |
|---|---|---|---|
| Day 100 | 10 | **28.8** | 28–32 ✅ |
| Day 200 | 20 | **37.6** | 35–40 ✅ |
| ceiling | — | **50** | cap 40–50 ✅ |

**The default ceiling of `5.0` allowed 100 HP** — twice the documented cap, and precisely the
unbounded scaling §3 Rule 3 forbids. The derivation is written into the file beside the values, so
the next person changing them can see what they are trading against.

## Enhanced AI — breach materials

Filed under `HEAVY CONFIG`, and **it is not a config**. The generated comment says mining is gated
by the block tag `enhancedai:miner_blacklist`. So this is a datapack.

Wood, dirt and cobblestone are **deliberately absent** — a mob is supposed to get through them.
Obsidian, netherite, steel and IE concrete are listed. **SecurityCraft is deliberately excluded**:
§14 wants those nerfed, and making them unmineable is the failure the pack is avoiding.

**It lives in `kubejs/data/`, not `datapacks/`.** Minecraft does not load a `datapacks/` folder at
the pack root — vanilla reads `<world>/datapacks/`, which is *per-world*, so a world created later
would never get the rule. KubeJS is CORE here and loads `kubejs/data/` globally.

Every mod-provided entry is `{"id": …, "required": false}`. A tag entry naming a block that does
not exist is a **hard error** in 1.20.1 and takes the whole reload with it. **The IE block ids are
conventional and not registry-verified** — that is stated in the file's README rather than glossed.

## Carry On — the blacklist

Reading the generated `forbiddenTiles` **first**: `create:*`, `minecolonies:*`,
`immersiveengineering:*`, `iceandfire:*`, `securitycraft:*`, `ftbquests:*`, `framedblocks:*` are
already there by default. The document's `HEAVY BLACKLIST` was mostly satisfied out of the box.

Appended this pack's own bypass surface: `railways:*`, `createbigcannons:*`, `createaddition:*`,
`createdieselgenerators:*`, `structurize:*`, `domum_ornamentum:*`, `sophisticatedbackpacks:*`,
`sophisticatedcore:*`.

Mod ids were read from `META-INF/mods.toml` in each jar. **Steam 'n' Rails is `railways`** — no
filename would have told you that.

## Validated

```
Done (14.012s)! For help, type "help"
KubeJS Server: Server resource reload complete!
```

Zero tag or datapack errors. The two mixin `minVersion` ERRORs in the log are **pre-existing** —
counted 2 in the previous boot's log as well, so not introduced here. Checked rather than assumed.

## A hash bug this caught

Forge writes configs with **CRLF** on Windows; `.gitattributes` stores text as **LF**. So the
working-tree file and the committed blob were different bytes, and packwiz had hashed the CRLF one
into `index.toml`.

Invisible until someone else clones — they get the LF file, the hash does not match, and packwiz
calls a correct config corrupt.

```
config/carryon-common.toml        wt=2d6325c0  blob=9549d1d5  DIFFER
config/improvedmobs/common.toml   wt=bd28d94f  blob=a8364ac6  DIFFER
                                  → after normalising, both MATCH
```

Any config copied in from a generated instance needs the same treatment.

## Not claimed

**No in-game behaviour was observed.** The boot proves the files parse and load. It does not prove
a mob fails to mine obsidian, or that a day-100 zombie has 28.8 HP. Those are client-launch checks.

## Not in this batch

TaCZ balance, the Hordes tiers, In Control spawn rules, dragon worldgen — §26 forbids changing
everything at once.

---

## สรุปภาษาไทย

Closes #21

การจูนจริงชุดแรก config 88 ไฟล์ที่การ boot server สร้างขึ้นทำให้ §31 ข้อ 11 ผ่านแล้ว — ทุกคีย์ด้านล่าง
**อ่านมาจากไฟล์ที่ถูกสร้างจริง** ไม่ใช่จำมา

## Improved Mobs — เส้นโค้ง HP

```
Health Increase Multiplier   1.0 → 2.75
Max Health Increase          5.0 → 2.5
```

ความยากเพิ่ม 0.1 ต่อวันในเกม และ health = `base × (1 + difficulty×0.016×M)` เทียบกับซอมบี้ 20 HP:

| | difficulty | HP | เป้า (Main §3.4) |
|---|---|---|---|
| Day 100 | 10 | **28.8** | 28–32 ✅ |
| Day 200 | 20 | **37.6** | 35–40 ✅ |
| เพดาน | — | **50** | cap 40–50 ✅ |

**เพดาน default ที่ `5.0` เปิดให้ถึง 100 HP** — สองเท่าของเพดานที่เอกสารกำหนด และตรงกับ scaling
ที่ไม่มีเพดานซึ่ง §3 Rule 3 ห้ามไว้พอดี ที่มาของตัวเลขถูกเขียนไว้ในไฟล์ข้าง ๆ ค่า เพื่อให้คนที่มาแก้
ทีหลังเห็นว่ากำลังแลกอะไรอยู่

## Enhanced AI — วัสดุที่ breach ได้

ถูกจัดไว้ใต้ `HEAVY CONFIG` และ **มันไม่ใช่ config** คอมเมนต์ที่ถูกสร้างมาบอกว่าการขุดถูกคุมด้วย
block tag `enhancedai:miner_blacklist` ดังนั้นนี่คือ datapack

ไม้ ดิน และ cobblestone **จงใจไม่ใส่** — mob ควรจะทะลุมันได้ ส่วนที่ใส่คือ obsidian, netherite,
steel และ concrete ของ IE **SecurityCraft จงใจไม่ใส่**: §14 ต้องการให้ nerf มัน และการทำให้ขุด
ไม่ได้คือความล้มเหลวที่ pack นี้พยายามเลี่ยง

**มันอยู่ใน `kubejs/data/` ไม่ใช่ `datapacks/`** Minecraft ไม่โหลดโฟลเดอร์ `datapacks/` ที่ราก pack —
vanilla อ่านจาก `<world>/datapacks/` ซึ่งเป็น *ต่อ world* ดังนั้น world ที่สร้างทีหลังจะไม่ได้กฎนี้เลย
KubeJS เป็น CORE ที่นี่และโหลด `kubejs/data/` ให้ทุก world

ทุก entry ที่มาจากมอดเขียนเป็น `{"id": …, "required": false}` เพราะ tag entry ที่ระบุบล็อกซึ่งไม่มีจริง
เป็น **hard error** ใน 1.20.1 และจะพาการ reload ล่มไปด้วย **block id ของ IE เป็นชื่อตามธรรมเนียม
และยังไม่ได้ตรวจกับ registry** — ระบุไว้ใน README ของไฟล์ ไม่ได้กลบ

## Carry On — blacklist

อ่าน `forbiddenTiles` ที่ถูกสร้างมา**ก่อน**: `create:*`, `minecolonies:*`, `immersiveengineering:*`,
`iceandfire:*`, `securitycraft:*`, `ftbquests:*`, `framedblocks:*` มีอยู่แล้วโดย default คำสั่ง
`HEAVY BLACKLIST` ในเอกสารถูกทำให้เกือบครบตั้งแต่แกะกล่อง

เพิ่มพื้นที่ที่ข้ามระบบของ pack นี้เอง: `railways:*`, `createbigcannons:*`, `createaddition:*`,
`createdieselgenerators:*`, `structurize:*`, `domum_ornamentum:*`, `sophisticatedbackpacks:*`,
`sophisticatedcore:*`

modid อ่านมาจาก `META-INF/mods.toml` ในแต่ละ jar **Steam 'n' Rails คือ `railways`** ซึ่งไม่มีทาง
รู้จากชื่อไฟล์

## ยืนยันแล้ว

```
Done (14.012s)! For help, type "help"
KubeJS Server: Server resource reload complete!
```

ไม่มี tag หรือ datapack error เลย ส่วน mixin `minVersion` ERROR สองตัวใน log **มีมาก่อนแล้ว** —
นับได้ 2 ใน log ของ boot ครั้งก่อนเช่นกัน จึงไม่ได้เกิดจากการแก้นี้ ตรวจแล้วไม่ได้สันนิษฐาน

## บั๊กเรื่อง hash ที่จับได้จากงานนี้

Forge เขียน config เป็น **CRLF** บน Windows ส่วน `.gitattributes` เก็บ text เป็น **LF** ไฟล์ใน
working tree กับ blob ที่ commit จึงเป็นคนละไบต์ และ packwiz ได้ hash ตัว CRLF ลง `index.toml` ไปแล้ว

มองไม่เห็นจนกว่าจะมีคนอื่น clone — เขาจะได้ไฟล์ LF, hash ไม่ตรง, และ packwiz จะบอกว่า config
ที่ถูกต้องนั้นเสีย

```
config/carryon-common.toml        wt=2d6325c0  blob=9549d1d5  DIFFER
config/improvedmobs/common.toml   wt=bd28d94f  blob=a8364ac6  DIFFER
                                  → หลัง normalise ทั้งคู่ MATCH
```

config ใด ๆ ที่คัดลอกมาจาก instance ที่ถูกสร้างขึ้น ต้องทำแบบเดียวกัน

## สิ่งที่ไม่ได้กล่าวอ้าง

**ยังไม่ได้สังเกตพฤติกรรมในเกมเลย** การ boot พิสูจน์ว่าไฟล์ parse และโหลดได้ ไม่ได้พิสูจน์ว่า mob
ขุด obsidian ไม่ได้ หรือซอมบี้วันที่ 100 มี 28.8 HP พวกนั้นเป็นการตรวจที่ต้องเปิด client

## ไม่อยู่ใน batch นี้

balance ของ TaCZ, tier ของ Hordes, กฎ spawn ของ In Control, worldgen มังกร — §26 ห้ามเปลี่ยน
ทุกอย่างพร้อมกัน
