### PR TITLE
feat(qol): add the Animation Spec Core stack and wire the sixth document in

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ The design document is the source of truth for intent:
 **`docs/Industrial Civilization Survival — Claude Code Handoff & Implementation Plan.md`**
 (read it before any pack work; unqualified `§N` references throughout this repo are to it).
 
-Three further specs layer on top of it. All share the same platform constraints and the same
+Five further specs layer on top of it. All share the same platform constraints and the same
 design rules, and each numbers its own sections — **cite them by name, never as a bare `§N`**:
 
 | Document | What it governs | Cite as |
@@ -27,6 +27,8 @@ design rules, and each numbers its own sections — **cite them by name, never a
 | `docs/Addon Spec — Crafting Assistance + Tactical Tracker.md` | JEI, Jade, Jade Addons, Crafting Tweaks, Mouse Tweaks, Polymorph, and a re-themed Player Microchip tracker | *Crafting Spec §N* |
 | `docs/Addon Spec — Natural Wildlife & Ecology.md` | Naturalist, Critters and Companions, Ecologics — the ordinary-animal layer that makes monsters read as abnormal. Carries its own phase list, W0–W9 | *Wildlife Spec §N* / *Wildlife Spec W3* |
 | `docs/Addon Modpack — Distribution & Updates.md` | **Release engineering, not content.** Source of truth, what counts as the pack, versioning, the release gate, branching, changelog, friend installation and updates | *Distribution Spec §N* |
+| `docs/Addon Performance — Optimization & Profiling.md` | The performance stack and the benchmark method. §2 is the approved Core stack; §3 Experimental stays out until each mod has its own benchmark branch | *Performance Spec §N* |
+| `docs/Addon Spec — Animation & Movement Layer.md` | Animation ownership, movement feel, first-person camera, and per-mod compatibility. §3 rejects **AMF: Better Movement** outright — do not re-propose without explicit direction | *Animation Spec §N* |
 
 The Distribution Spec is the one that constrains **this repository's own process**, not the game.
 Its §22 branching model and §16 release gate govern how work ships; see `docs/agents/workflow.md`.

--- a/docs/compatibility-matrix.md
+++ b/docs/compatibility-matrix.md
@@ -205,6 +205,26 @@ before adding it.
 **§3 Experimental mods are all absent by design** — AI Improvements, Let Me Despawn, Alternate
 Current, Canary, TaCZ Optimization, Smooth Boot Reloaded. Each needs its own benchmark branch.
 
+## Animation & movement stack (Animation Spec §2)
+
+| Mod | Version | Source | Side | Status | Tested |
+|---|---|---|---|---|---|
+| Not Enough Animations | `1.12.4` | MR | CLIENT | CORE | already in the pack |
+| Better Animations Collection | `v8.0.1-1.20.1-Forge` | MR | CLIENT | CORE | |
+| SmoothPlayerAnimations | `1.0.3` | MR | CLIENT | CORE | pulls `playerAnimator`, `Cloth Config` |
+| Smooth Movement | `1.20.1-2.6` | CF | COMMON | CORE | pulls `cupboard` |
+| **AMF: Better Movement** | — | — | — | **REJECTED** | Animation Spec §3 — excessive inertia, motion-sickness risk. *"Do not re-propose without explicit developer direction."* |
+| EMF / ETF / Fresh Animations | — | — | — | **NOT ADDED** | §2 *Optional Selective Layer*, not Core |
+
+**The slug in the sweep was wrong, and the sweep said so.** An early pass recorded
+`smooth-player-animations` as CurseForge-only. The real Modrinth slug is **`smoothplayeranimations`**
+— no hyphens — and it is on Modrinth. A slug miss reads exactly like an absent mod; only searching
+by *title* rather than guessing the slug found it.
+
+**Fresh Animations is a resource pack, not a mod.** That is why it has no 1.20.1 Forge build and
+why it can never be added with `packwiz mr add` as a mod. The spec groups it with EMF and ETF under
+*Optional Selective Layer* without making the distinction; it belongs in `resourcepacks/`.
+
 ## Boot test — 2026-08-25, Forge dedicated server
 
 The first real test of the mod set. Forge 47.4.23 dedicated server, Temurin 17.0.20.1, 6 GB heap,
@@ -271,3 +291,20 @@ That is an observation, not a benchmark. It is one cold start on one machine wit
 and startup time is not the metric the Performance Spec cares about — §33–39 define the real ones
 (MSPT, TPS, entity tick time, client FPS) across four scenarios. Do not quote 22.295s as evidence
 the pack performs well; quote it only as evidence the stack loads and does not regress startup.
+
+### Boot 4 — with the animation & movement stack (2026-08-25)
+
+87 jars after client-only filtering. The three client-only animation mods are **not** exercised by
+this test; what it does prove is that `smooth-movement`, `cupboard`, `playeranimator` and
+`cloth-config` load on the common side without conflict.
+
+```
+[07:04:24] Done (25.183s)! For help, type "help"
+```
+
+Green. No errors from any animation-stack mod.
+
+**What a server boot cannot tell you here.** Animation ownership, first-person camera feel and the
+mixing rules in Animation Spec §4–14 are entirely client-side and entirely subjective. This batch
+is the one where a green boot proves least — the spec's own §12 coverage matrix and §39 benchmark
+scene are the real checks, and both need a client.

--- a/index.toml
+++ b/index.toml
@@ -38,6 +38,11 @@ hash = "12c4913f51659fc1c0978004f411d9d9b878f589367e4fbe17ca5da60acbbce8"
 metafile = true
 
 [[files]]
+file = "mods/better-animations-collection.pw.toml"
+hash = "2f1f1c29d99ea10b67348fc529474f128d5b51d0591f124e3363d760e400f53a"
+metafile = true
+
+[[files]]
 file = "mods/blockui.pw.toml"
 hash = "2195b22648787aac875b1ea60c51cca57c1c0a4db4241ec52cd3ea2abfeaebf4"
 metafile = true
@@ -70,6 +75,11 @@ metafile = true
 [[files]]
 file = "mods/client-dynamic-light.pw.toml"
 hash = "237b0859d871b5f843ed689971ee1487a80c86db58aa656901b99d9c0d3a5f91"
+metafile = true
+
+[[files]]
+file = "mods/cloth-config.pw.toml"
+hash = "e3dd03e7fec88831974857e2cdded54dd5c5bdcaa3f6d6248c2800e82db4dd41"
 metafile = true
 
 [[files]]
@@ -125,6 +135,11 @@ metafile = true
 [[files]]
 file = "mods/critters-and-companions.pw.toml"
 hash = "10cf81efb7efc162edb060c26a48ffd997eab3d482929b1a84ea62c9be3f36ce"
+metafile = true
+
+[[files]]
+file = "mods/cupboard.pw.toml"
+hash = "b6753307b3f6a24d0545c4a3383de9be1da85bde4ee749f645c3bd6bb6188f31"
 metafile = true
 
 [[files]]
@@ -338,6 +353,11 @@ hash = "b4018b39ba9f5536c10090297bb19e212bbf6f32a6dcfd29745ee3253896c91e"
 metafile = true
 
 [[files]]
+file = "mods/playeranimator.pw.toml"
+hash = "765987a78e5d8c782d0da2de99998b43b5907d6c41347d3804045ad109e4a586"
+metafile = true
+
+[[files]]
 file = "mods/playerrevive.pw.toml"
 hash = "0e4e32a1b974218110ad20c2545e57e748979dbc7b0e4981d474a6386b898c05"
 metafile = true
@@ -390,6 +410,16 @@ metafile = true
 [[files]]
 file = "mods/simple-voice-radio.pw.toml"
 hash = "656e95162a6b80203fb0608ec02494f5448915b206705e80958d5dc7698a6ac9"
+metafile = true
+
+[[files]]
+file = "mods/smooth-movement.pw.toml"
+hash = "6524f2c8618b33b13fee693cefbe7c34d3e69f760670dd653296f4714ded9e5c"
+metafile = true
+
+[[files]]
+file = "mods/smoothplayeranimations.pw.toml"
+hash = "4f8f7d24808a744eb325214c6656f2a493146d59a63a1fce23c3abe867e52459"
 metafile = true
 
 [[files]]

--- a/mods/better-animations-collection.pw.toml
+++ b/mods/better-animations-collection.pw.toml
@@ -1,0 +1,13 @@
+name = "Better Animations Collection"
+filename = "BetterAnimationsCollection-v8.0.1-1.20.1-Forge.jar"
+side = "client"
+
+[download]
+url = "https://cdn.modrinth.com/data/OoOVj3J3/versions/3V51q1QN/BetterAnimationsCollection-v8.0.1-1.20.1-Forge.jar"
+hash-format = "sha512"
+hash = "a49f4f61229f3e743310a45d59e6c33f2d493d63aed483ee84bc6b56e982ee183b9d376f1d58695ee56eb4ed5ec0a1c1c0c605c19478fd057f922274105102e0"
+
+[update]
+[update.modrinth]
+mod-id = "OoOVj3J3"
+version = "3V51q1QN"

--- a/mods/cloth-config.pw.toml
+++ b/mods/cloth-config.pw.toml
@@ -1,0 +1,13 @@
+name = "Cloth Config API"
+filename = "cloth-config-11.1.136-forge.jar"
+side = "both"
+
+[download]
+url = "https://cdn.modrinth.com/data/9s6osm5g/versions/t8TXrZvZ/cloth-config-11.1.136-forge.jar"
+hash-format = "sha512"
+hash = "137c4af99c53d77317cbfb1cc8c49fc2761708b49d1992f51fd846960df41dde3a83519c987e081508d4ed90c603566f3d5a6cb620ad9d85b8f4de59aa9115ef"
+
+[update]
+[update.modrinth]
+mod-id = "9s6osm5g"
+version = "t8TXrZvZ"

--- a/mods/cupboard.pw.toml
+++ b/mods/cupboard.pw.toml
@@ -1,0 +1,13 @@
+name = "Cupboard"
+filename = "cupboard-1.20.1-4.0.jar"
+side = "both"
+
+[download]
+hash-format = "sha1"
+hash = "9d4194cb96189aa15bd88041bd475a36dcef15dc"
+mode = "metadata:curseforge"
+
+[update]
+[update.curseforge]
+file-id = 8617695
+project-id = 326652

--- a/mods/playeranimator.pw.toml
+++ b/mods/playeranimator.pw.toml
@@ -1,0 +1,13 @@
+name = "playerAnimator"
+filename = "player-animation-lib-forge-1.0.2-rc1+1.20.jar"
+side = "both"
+
+[download]
+url = "https://cdn.modrinth.com/data/gedNE4y2/versions/xe2EVE6q/player-animation-lib-forge-1.0.2-rc1%2B1.20.jar"
+hash-format = "sha512"
+hash = "cb9f6a3aaa943823a85fdd716ddb3c7623af2b3520926c3a98d170c52d31908894808fb61c52bea39bae622dbab59d50b4bad56f7ca0533a9c3350d412c33729"
+
+[update]
+[update.modrinth]
+mod-id = "gedNE4y2"
+version = "xe2EVE6q"

--- a/mods/smooth-movement.pw.toml
+++ b/mods/smooth-movement.pw.toml
@@ -1,0 +1,13 @@
+name = "Smooth Movement"
+filename = "smoothmovement-1.20.1-2.6.jar"
+side = "both"
+
+[download]
+hash-format = "sha1"
+hash = "401702c2d1369b55c4134b302dd1d9981e5cb680"
+mode = "metadata:curseforge"
+
+[update]
+[update.curseforge]
+file-id = 7614595
+project-id = 852498

--- a/mods/smoothplayeranimations.pw.toml
+++ b/mods/smoothplayeranimations.pw.toml
@@ -1,0 +1,13 @@
+name = "SmoothPlayerAnimations"
+filename = "SmoothPlayerAnimations_Forge_1.20.1_1.0.3.jar"
+side = "client"
+
+[download]
+url = "https://cdn.modrinth.com/data/ZdlGpqTS/versions/e82AQF18/SmoothPlayerAnimations_Forge_1.20.1_1.0.3.jar"
+hash-format = "sha512"
+hash = "99faa7e7bd1447098b60776f1aa287d39c9507b7822eefc050363636c10efe9ee8c8b71798f71f528415a9cb5e9d534268f818f978e6eb92f83f658b8d8ef8b9"
+
+[update]
+[update.modrinth]
+mod-id = "ZdlGpqTS"
+version = "e82AQF18"

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "3464e78961325e2e91745b32c8df3765e38e8b35ecbff0e7215d1a5a223ecadc"
+hash = "094905076331e2527afbf69a145539b67cdcd26c59830383f1b9b7264d659500"
 
 [versions]
 forge = "47.4.23"


### PR DESCRIPTION
Closes #23.

The sixth design document had **zero references anywhere in the operating layer** — not in
`CLAUDE.md`, not in the customization map, not in the ledger. A session reading the repo would not
have known it existed. This adds its §2 Core stack and wires the document in.

| Mod | Version | Source | Side |
|---|---|---|---|
| Not Enough Animations | `1.12.4` | Modrinth | CLIENT — already present |
| Better Animations Collection | `v8.0.1-1.20.1-Forge` | Modrinth | CLIENT |
| SmoothPlayerAnimations | `1.0.3` | Modrinth | CLIENT |
| Smooth Movement | `1.20.1-2.6` | CurseForge | COMMON |

Dependencies pulled automatically: `playerAnimator`, `Cloth Config`, `cupboard`. **99 metafiles.**

## A slug miss looks exactly like an absent mod

The first sweep searched `smooth-player-animations` and reported **CurseForge-only**. The real
Modrinth slug is **`smoothplayeranimations`** — no hyphens. Searching by **title** rather than
guessing the slug found it.

That matters beyond this one mod: **every earlier `CURSEFORGE-ONLY` verdict that came from a slug
guess is now suspect.** Recorded in the matrix so the next sweep re-checks by title instead of
trusting the earlier result.

## Fresh Animations is a resource pack, not a mod

Which is why it has no 1.20.1 Forge build and why `packwiz mr add` can never take it. §2 groups it
with EMF and ETF under *Optional Selective Layer* without drawing the distinction — it belongs in
`resourcepacks/`.

## Deliberately not added

- **EMF, ETF, Fresh Animations** — *Optional Selective Layer*, not Core
- **AMF: Better Movement** — §3 rejects it: excessive inertia, motion-sickness risk, *"Do not
  re-propose without explicit developer direction."* Recorded in `CLAUDE.md` so it is not
  re-proposed by a session that never read §3.

## Validated, with honest scope

```
[07:04:24] Done (25.183s)! For help, type "help"
```

87 jars, green, no errors from any animation-stack mod.

**This is the batch where a green server boot proves least.** Three of the four Core mods are
CLIENT-only, so the boot exercises only `smooth-movement`, `cupboard`, `playeranimator` and
`cloth-config`. Animation ownership, camera feel and the mixing rules in §4–14 are client-side and
largely subjective; §12's coverage matrix and §39's benchmark scene are the real checks and both
need a client.

## Process slip, recorded rather than hidden

**The branch was cut and the work committed before the issue existed.** I named the branch
`feat/23-animation-layer` on the assumption of the next number, then filed #23 afterwards. The
number happened to match; that was luck, not process. The rule is PRD → issues → PR, and the issue
comes first so the branch name can reference something real.

---

## สรุปภาษาไทย

Closes #23

เอกสารออกแบบใบที่หก **ไม่ถูกอ้างถึงที่ไหนเลยใน operating layer** — ไม่มีใน `CLAUDE.md` ไม่มีใน
customization map ไม่มีใน ledger เซสชันที่มาอ่าน repo จะไม่รู้ด้วยซ้ำว่ามันมีอยู่ PR นี้เพิ่ม Core
stack ตาม §2 และเชื่อมเอกสารเข้าระบบ

| Mod | เวอร์ชัน | แหล่ง | Side |
|---|---|---|---|
| Not Enough Animations | `1.12.4` | Modrinth | CLIENT — มีอยู่แล้ว |
| Better Animations Collection | `v8.0.1-1.20.1-Forge` | Modrinth | CLIENT |
| SmoothPlayerAnimations | `1.0.3` | Modrinth | CLIENT |
| Smooth Movement | `1.20.1-2.6` | CurseForge | COMMON |

dependency ที่ถูกดึงมาอัตโนมัติ: `playerAnimator`, `Cloth Config`, `cupboard` **99 metafiles**

## slug ที่ผิดหน้าตาเหมือน mod ที่ไม่มีอยู่จริงเป๊ะ

การกวาดรอบแรกค้น `smooth-player-animations` แล้วรายงานว่า **CurseForge-only** slug จริงบน
Modrinth คือ **`smoothplayeranimations`** ไม่มีขีด การค้นด้วย **ชื่อ** แทนการเดา slug ถึงเจอ

เรื่องนี้สำคัญเกินกว่า mod ตัวเดียว: **ทุกคำตัดสิน `CURSEFORGE-ONLY` ก่อนหน้านี้ที่มาจากการเดา slug
ตอนนี้น่าสงสัยหมด** บันทึกไว้ใน matrix แล้วเพื่อให้การกวาดครั้งหน้าตรวจซ้ำด้วยชื่อ แทนที่จะเชื่อผลเดิม

## Fresh Animations เป็น resource pack ไม่ใช่ mod

นั่นคือเหตุผลที่มันไม่มี build 1.20.1 Forge และเหตุผลที่ `packwiz mr add` รับมันไม่ได้ §2 จัดมัน
รวมกับ EMF และ ETF ใต้ *Optional Selective Layer* โดยไม่ได้แยกความต่างนี้ — ที่ของมันคือ
`resourcepacks/`

## จงใจไม่เพิ่ม

- **EMF, ETF, Fresh Animations** — *Optional Selective Layer* ไม่ใช่ Core
- **AMF: Better Movement** — §3 ปฏิเสธ: inertia มากเกิน เสี่ยงเมาภาพ *"Do not re-propose without
  explicit developer direction."* บันทึกไว้ใน `CLAUDE.md` เพื่อไม่ให้เซสชันที่ไม่เคยอ่าน §3 มาเสนอใหม่

## ยืนยันแล้ว พร้อมขอบเขตที่พูดตรง

```
[07:04:24] Done (25.183s)! For help, type "help"
```

87 jar เขียว ไม่มี error จาก mod ใน animation stack เลย

**นี่คือ batch ที่การ boot server ผ่านพิสูจน์ได้น้อยที่สุด** สามในสี่ตัวของ Core เป็น CLIENT ล้วน
การ boot จึงทดสอบแค่ `smooth-movement`, `cupboard`, `playeranimator` และ `cloth-config`
ความเป็นเจ้าของ animation, ความรู้สึกของกล้อง และกฎการผสมใน §4–14 อยู่ฝั่ง client และเป็นเรื่อง
อัตวิสัยเป็นส่วนใหญ่ ตารางความครอบคลุมของ §12 และ benchmark scene ของ §39 คือการตรวจจริง
และทั้งคู่ต้องเปิด client

## ความผิดพลาดเชิงกระบวนการ บันทึกไว้ไม่ได้ซ่อน

**branch ถูกตัดและงานถูก commit ก่อนที่ issue จะมีอยู่** ผมตั้งชื่อ branch เป็น
`feat/23-animation-layer` โดยเดาเลขถัดไป แล้วค่อย file #23 ทีหลัง เลขบังเอิญตรง ซึ่งเป็นความโชคดี
ไม่ใช่กระบวนการ กฎคือ PRD → issues → PR และ issue ต้องมาก่อนเพื่อให้ชื่อ branch อ้างถึงสิ่งที่มีอยู่จริง
