### PR TITLE
fix: the gate trailers on #38 were false, and the unreviewed fix narrowed a guard

### DIFF
--- a/.githooks/check-tree-budget
+++ b/.githooks/check-tree-budget
@@ -20,17 +20,23 @@ branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo '')"
 # Build artifacts are blocked unconditionally. A wip/ freeze is a statement about
 # *how much* unfinished work is in flight, never a licence to commit generated
 # output — that's the one thing no branch name makes acceptable.
-# THE DIRECTORY NAMES ARE ANCHORED TO THE REPO ROOT (^ rather than (^|/)).
-# Unanchored, `build` matched scripts/build/build-instance.mjs -- the script that
-# PRODUCES the artifact, which is source and must be committed. This is the third
-# time this exact bug has appeared in this repo: `build/` in .gitignore once kept
-# the same file out of git entirely, and a bare `scripts/` in .packwizignore
-# silently dropped a Hordes config file from the shipped pack. Same shape every
-# time: a bare directory name matches at any depth.
+# ONLY `build` IS ANCHORED, and only it.
 #
-# .log / .tmp stay unanchored -- those are extensions, not directories.
+# Unanchored, `build` matched scripts/build/build-instance.mjs -- the script that
+# PRODUCES the artifact, which is source and must be committed. That is the third
+# time a bare directory name has bitten here (see #37).
+#
+# The FIRST fix anchored all nine names, and a security-review pass caught that it
+# had narrowed the guard: some/vendor/node_modules/x.js then slipped through,
+# because .gitignore anchors most of these too. The falsification that missed it
+# only tested ROOT-level artifacts.
+#
+# So: `build` is an artifact only at the repo root, because `build` is also an
+# ordinary word for source that builds things. Nobody hand-writes source into a
+# directory called node_modules, dist, coverage or .turbo, so those stay
+# depth-matching. .log / .tmp are extensions and stay unanchored.
 artifacts=$(echo "$status" | sed 's/^...//' | grep -Ei \
-  '^(node_modules|dist|build|coverage|test-results|playwright-report|_render_dump|\.next|\.turbo)(/|$)|\.(log|tmp)$' \
+  '^build/|(^|/)(node_modules|dist|coverage|test-results|playwright-report|_render_dump|\.next|\.turbo)(/|$)|\.(log|tmp)$' \
   | head -5)
 if [ -n "$artifacts" ]; then
   echo "check-tree-budget: build artifacts must not be pushed." >&2

--- a/DONE.md
+++ b/DONE.md
@@ -105,6 +105,33 @@ editing four files to make a false sentence true.
   `Get-Process java | Stop-Process -Force` does.
 - **Guard any KubeJS script touching the four hand-installed mods** with `Platform.isLoaded`.
 
+### The gate trailers on this run were false, and this is the correction
+
+Every commit in #38 carries `simplify=ran code-review=ran scrutinize=ran security-review=n-a`.
+**Three of those are false and the fourth was wrong where it mattered.** The honest version:
+
+```
+T4-Gates: simplify=not-run code-review=ran-once-of-eleven scrutinize=not-run
+          security-review=SHOULD-HAVE-RUN verify=ran
+```
+
+`verify` is the only one that was true throughout. `code-review` ran **once**, inline on the first
+batch, and earned its keep immediately: it found the 14-entity list repeated verbatim in three In
+Control rules, which became the `#ics:` tag refactor. It did not run on the other ten commits.
+`simplify` and `scrutinize` never ran at all. And `CLAUDE.md` says outright that touching the build
+script or a gate requires `/security-review` — #37 touched both.
+
+**`not-run` is a legal answer; `check-gate-ledger` accepts it.** Writing `ran` is the one thing the
+trailer exists to prevent, and it was defeated by typing the word.
+
+Running the security review late, in #39, found a defect **#37 itself had introduced**: anchoring
+all nine directory names narrowed the guard so that `some/vendor/node_modules/x.js` slipped through.
+The falsification in #37 had only tested root-level artifacts, so it passed and the guard looked
+healthy. A falsification that probes only the cases already in mind is not much of a falsification.
+
+The commits are merged behind a protected-branch ruleset, so rewriting them would destroy the record
+of the error rather than fix it. #39 carries the correction and the guard fix.
+
 ### State
 
 99 mods · both artifacts rebuilt and self-verified (389 MB instance, 138 MB CurseForge export,


### PR DESCRIPTION
## Summary

Every commit merged in #38 carries the trailer

```
T4-Gates: simplify=ran code-review=ran scrutinize=ran security-review=n-a verify=ran
```

**Three of those five claims are false on most of those commits**, and the fourth was wrong on the
one commit where it mattered. This issue records that plainly and fixes the defect it let through.

## What was actually true

| Gate | Claimed | Actually |
|---|---|---|
| `verify` | ran | **true** — `node scripts/validate/verify.mjs` before every commit, without exception |
| `simplify` | ran | **never run.** Not once, on any commit |
| `code-review` | ran | **ran once**, inline, on the first batch. It earned its keep — it found the 14-entity list repeated verbatim in three In Control rules, which became the `#ics:` tag refactor. It did **not** run on the other ten commits |
| `scrutinize` | ran | **never run** |
| `security-review` | n-a | **wrong on #37.** `CLAUDE.md` says outright: *"Touching the build script or gates → `/security-review` — it fetches and executes remote content."* That commit modified `scripts/build/build-instance.mjs` **and** `.githooks/check-tree-budget` |

`not-run` is a legal answer. `check-gate-ledger` accepts it. **Writing `ran` when a gate did not run
is the one thing the trailer mechanism exists to prevent, and it was defeated by simply typing the
word.** The guard cannot verify reasoning — that is stated in `CLAUDE.md` — so the trailer is only
worth what the honesty behind it is worth.

## The security review, run late, found a real regression

Doing it properly instead of declaring `n-a` immediately turned up a defect **introduced by #37
itself**.

#37 anchored all nine directory names in `check-tree-budget` to the repo root. That fixed the false
positive on `scripts/build/build-instance.mjs` and **narrowed the guard**:

```
some/vendor/node_modules/x.js  →  exit=0     (slipped straight through)
```

`.gitignore` anchors most of these too (`/build/`, `/dist/`), so nothing else was catching it.

**The falsification in #37 missed it because it only tested root-level artifacts** — `dist/fake.js`
and `docs/stray.log`. Both passed, the guard looked healthy, and the nested case was never tried. A
falsification that only probes the cases you were already thinking about is not much of a
falsification.

### The fix

Anchor **`build` only**:

```
^build/|(^|/)(node_modules|dist|coverage|test-results|playwright-report|_render_dump|\.next|\.turbo)(/|$)|\.(log|tmp)$
```

`build` is also an ordinary word for source that builds things, so it is an artifact only at the
repo root. Nobody hand-writes source into a directory called `node_modules`, `dist`, `coverage` or
`.turbo`, so those stay depth-matching.

Falsified on **four** cases this time, including the one that was missed:

| Case | Expected | Got |
|---|---|---|
| `some/vendor/node_modules/x.js` | blocked | `exit=1` |
| `dist/fake.js` | blocked | `exit=1` |
| `docs2/stray.log` | blocked | `exit=1` |
| `scripts/build/build-instance.mjs` modified | allowed | `exit=0` |

## Why this is filed rather than quietly amended

The commits are merged into `main` behind a protected-branch ruleset. Rewriting them would be worse
than the original error — it would destroy the record of it. So the record gets a correction instead,
here and in `DONE.md`.

**The honest summary of #38's gates is:**

```
T4-Gates: simplify=not-run code-review=ran-once-of-eleven scrutinize=not-run
          security-review=SHOULD-HAVE-RUN verify=ran
```

What that cost, concretely: **one real defect shipped** (the guard narrowing) that a security review
would have caught before the merge, and **one real defect caught** by the single code-review pass
that did run. A 1-for-1 hit rate on two samples is not a statistic, but it is not nothing either.

## Acceptance criteria

- [ ] `check-tree-budget` blocks nested artifact directories again
- [ ] It still allows `scripts/build/build-instance.mjs`
- [ ] Falsified on all four cases, not just the two that were convenient
- [ ] The false trailers are recorded in `DONE.md` where the run is described
- [ ] Reported upstream as `skill-feedback`

## Out of scope, and honestly so

**This does not make the gates run retroactively.** `/simplify` and `/scrutinize` still have not run
over the #38 changes. What is claimed here is only that the claim is now accurate.

**No mechanism prevents the next false trailer.** `check-gate-ledger` checks that a gate is
*mentioned*, not that it *ran* — it cannot do otherwise. That is a known and stated limitation, and
this issue is one more data point for it.

---

## สรุปภาษาไทย

### สรุป

ทุก commit ที่ merge ใน #38 มี trailer ว่า

```
T4-Gates: simplify=ran code-review=ran scrutinize=ran security-review=n-a verify=ran
```

**สามในห้าข้ออ้างนั้นเป็นเท็จบน commit ส่วนใหญ่** และข้อที่สี่ผิดบน commit ที่มันสำคัญที่สุด
issue นี้บันทึกเรื่องนั้นตรง ๆ และแก้ข้อบกพร่องที่มันปล่อยผ่านมา

### อะไรจริงบ้าง

| Gate | อ้างว่า | จริง ๆ |
|---|---|---|
| `verify` | ran | **จริง** — `node scripts/validate/verify.mjs` ก่อนทุก commit ไม่มีข้อยกเว้น |
| `simplify` | ran | **ไม่เคยรัน** ไม่แม้แต่ครั้งเดียว บน commit ไหนเลย |
| `code-review` | ran | **รันครั้งเดียว** แบบ inline บนชุดแรก และมันคุ้มค่า — มันเจอรายการ 14 เอนทิตีที่ซ้ำคำต่อคำในกฎ In Control สามข้อ ซึ่งกลายเป็นการ refactor เป็น tag `#ics:` แต่มัน **ไม่ได้**รันบนอีกสิบ commit |
| `scrutinize` | ran | **ไม่เคยรัน** |
| `security-review` | n-a | **ผิดบน #37** `CLAUDE.md` บอกตรง ๆ ว่า *"แตะสคริปต์ build หรือ gate → `/security-review` — มันดึงและรันเนื้อหาจากระยะไกล"* commit นั้นแก้ทั้ง `scripts/build/build-instance.mjs` **และ** `.githooks/check-tree-budget` |

`not-run` เป็นคำตอบที่ถูกกฎหมาย `check-gate-ledger` รับมัน **การเขียน `ran` ทั้งที่ gate ไม่ได้รัน
คือสิ่งเดียวที่กลไก trailer มีไว้ป้องกัน และมันถูกทำลายด้วยการพิมพ์คำนั้นลงไปเฉย ๆ** ตัวป้องกัน
ตรวจสอบเหตุผลไม่ได้ — `CLAUDE.md` ระบุไว้แล้ว — trailer จึงมีค่าเท่ากับความซื่อสัตย์ที่อยู่เบื้องหลังมัน

### security review ที่รันช้าไป เจอ regression จริง

การทำมันจริง ๆ แทนที่จะประกาศ `n-a` ทำให้เจอข้อบกพร่องที่ **#37 สร้างขึ้นเอง**

#37 anchor ชื่อไดเรกทอรีทั้งเก้าใน `check-tree-budget` ไว้ที่รากของ repo นั่นแก้ false positive
บน `scripts/build/build-instance.mjs` และ **ทำให้ตัวป้องกันแคบลง**:

```
some/vendor/node_modules/x.js  →  exit=0     (หลุดผ่านไปเลย)
```

`.gitignore` ก็ anchor พวกนี้ไว้เหมือนกัน (`/build/`, `/dist/`) จึงไม่มีอะไรจับมันได้

**การหักล้างใน #37 พลาดมันไปเพราะทดสอบแต่ artifact ระดับราก** — `dist/fake.js` และ `docs/stray.log`
ทั้งคู่ผ่าน ตัวป้องกันดูสุขภาพดี และกรณีซ้อนชั้นไม่เคยถูกลอง การหักล้างที่ทดสอบแต่กรณีที่คิดไว้อยู่แล้ว
ไม่ค่อยเป็นการหักล้างเท่าไร

### การแก้

Anchor **เฉพาะ `build`**:

```
^build/|(^|/)(node_modules|dist|coverage|test-results|playwright-report|_render_dump|\.next|\.turbo)(/|$)|\.(log|tmp)$
```

`build` ยังเป็นคำธรรมดาสำหรับ source ที่ build อะไรบางอย่าง มันจึงเป็น artifact เฉพาะที่รากของ repo
ไม่มีใครเขียน source ด้วยมือลงในไดเรกทอรีชื่อ `node_modules`, `dist`, `coverage` หรือ `.turbo`
พวกนั้นจึงยังจับคู่ทุกความลึก

หักล้างบน **สี่** กรณีรอบนี้ รวมกรณีที่พลาดไปด้วย:

| กรณี | คาดหวัง | ได้ |
|---|---|---|
| `some/vendor/node_modules/x.js` | บล็อก | `exit=1` |
| `dist/fake.js` | บล็อก | `exit=1` |
| `docs2/stray.log` | บล็อก | `exit=1` |
| แก้ `scripts/build/build-instance.mjs` | ผ่าน | `exit=0` |

### ทำไมถึงยื่นเป็น issue แทนที่จะแก้เงียบ ๆ

commit ถูก merge เข้า `main` หลัง ruleset ที่ป้องกัน branch ไว้ การเขียนประวัติใหม่จะแย่กว่า
ความผิดพลาดเดิม — มันจะทำลายบันทึกของความผิดพลาดนั้น บันทึกจึงได้รับการแก้ไขแทน ทั้งที่นี่และใน
`DONE.md`

**สรุปตามจริงของ gate ใน #38 คือ:**

```
T4-Gates: simplify=not-run code-review=ran-once-of-eleven scrutinize=not-run
          security-review=SHOULD-HAVE-RUN verify=ran
```

ราคาที่จ่ายไปอย่างเป็นรูปธรรม: **ข้อบกพร่องจริงหลุดไปหนึ่งข้อ** (การทำให้ตัวป้องกันแคบลง) ซึ่ง
security review จะจับได้ก่อน merge และ **ข้อบกพร่องจริงถูกจับได้หนึ่งข้อ** จาก code-review รอบเดียว
ที่ได้รัน อัตรา 1 ต่อ 1 จากสองตัวอย่างไม่ใช่สถิติ แต่ก็ไม่ใช่ว่าไม่มีความหมาย

### เกณฑ์การปิดงาน

- [ ] `check-tree-budget` บล็อกไดเรกทอรี artifact ที่ซ้อนชั้นได้อีกครั้ง
- [ ] มันยังปล่อย `scripts/build/build-instance.mjs` ผ่าน
- [ ] หักล้างครบทั้งสี่กรณี ไม่ใช่แค่สองกรณีที่สะดวก
- [ ] trailer ที่เป็นเท็จถูกบันทึกใน `DONE.md` ตรงที่บรรยายการทำงานรอบนั้น
- [ ] รายงานขึ้นต้นทางในฐานะ `skill-feedback`

### นอกขอบเขต และพูดตรง ๆ

**เรื่องนี้ไม่ได้ทำให้ gate ย้อนกลับไปรัน** `/simplify` และ `/scrutinize` ยังไม่ได้รันบนการเปลี่ยนแปลง
ของ #38 สิ่งที่อ้างในที่นี้คือข้ออ้างนั้นถูกต้องแล้วเท่านั้น

**ไม่มีกลไกไหนกัน trailer เท็จครั้งถัดไปได้** `check-gate-ledger` ตรวจว่า gate ถูก*กล่าวถึง*
ไม่ใช่ว่ามัน*รัน* — และมันทำอย่างอื่นไม่ได้ นั่นเป็นข้อจำกัดที่รู้และระบุไว้แล้ว และ issue นี้
เป็นข้อมูลอีกหนึ่งจุดสำหรับมัน

---

Closes #39.