### PR TITLE
docs: make the ledger preamble checkable against its own table

### DIFF
--- a/docs/OPEN-WORK-LEDGER.md
+++ b/docs/OPEN-WORK-LEDGER.md
@@ -27,13 +27,24 @@ population (W3/W6/W7), the Brimm-vs-TakKit comparison (§15), the JEI active-rec
 Spec §5) and the twelve-test release gate (Distribution Spec §16) are all **measurements**, and a
 dedicated server cannot produce any of them.
 
-**One exception that needs no client: the three Player Microchip textures**, which need an artist.
-That is the whole list.
+**Three rows need no client, and none of the three is actionable today** — which is a different
+statement from *"everything left needs a client"*, and the difference is the point. Search the table
+for 🟡 and check it:
 
-The other exception was the **Season 2 viability sweep**, and it is now done — ADR 0004. Both were
-the honest correction to an earlier claim that *everything* left was downstream of a client launch,
-which was wrong when it was written: seven Track 5 rows were buildable at the time and none of them
-had been touched.
+| Row | What it actually waits on |
+|---|---|
+| The three Player Microchip textures (**#35**) | an **artist** |
+| Re-add `cbc_firepower_components` | an **upstream release** supporting CBC ≥ 5.9 |
+| Re-evaluate `TaCZ: Accelerated` | a **benchmark baseline** — which does need a client to profile with |
+
+A fourth, the **Season 2 viability sweep**, needed neither and is now done — ADR 0004 (#44).
+
+**Why this is spelled out rather than summarised.** An earlier version of this paragraph claimed
+*everything* left was downstream of a client launch. That was false when it was written: seven Track
+5 rows were buildable and none had been touched. The correction then claimed the Microchip textures
+were *"the whole list"*, which was also false, by two rows (#48). A claim of completeness in this
+file is load-bearing — it is what a session reads instead of the table — so it is now written to be
+checkable against the table rather than trusted.
 
 Everything else in the pack is a design target derived from the documents until a client says
 otherwise.


### PR DESCRIPTION
## Summary

The ledger preamble asserted completeness and was wrong by two rows. Docs only —
`git diff --name-only` is `docs/OPEN-WORK-LEDGER.md`.

**Before:**

> **One exception that needs no client: the three Player Microchip textures**, which need an artist.
> That is the whole list.

Two 🟡 rows further down need no client either: `cbc_firepower_components` waits on an **upstream
release**, and `TaCZ: Accelerated` waits on a **benchmark baseline**.

**After** — a table the reader can check against the file:

| Row | What it actually waits on |
|---|---|
| The three Player Microchip textures (#35) | an **artist** |
| Re-add `cbc_firepower_components` | an **upstream release** supporting CBC ≥ 5.9 |
| Re-evaluate `TaCZ: Accelerated` | a **benchmark baseline** — which does need a client to profile with |

Plus the instruction to search the file for 🟡, so the claim is verifiable rather than trusted.

## Why this is worth a PR for one paragraph

**This paragraph has now been wrong twice, in the same shape.** The version before this one claimed
*everything* left was downstream of a client launch — false by **seven** Track 5 rows, all buildable
and none touched. The fix for that claimed the Microchip textures were "the whole list" — false by
**two**.

A claim of completeness in `OPEN-WORK-LEDGER.md` is load-bearing: it is what a session reads
*instead of* the table. The file exists to stop work vanishing into MD, and an over-broad summary at
the top is precisely how work vanishes from a ledger that technically still contains it.

## Testing

`node scripts/validate/verify.mjs` — green (96 JSON · 122 TOML · 157 indexed files · 5 KubeJS
scripts).

## Out of scope

**Doing any of the three.** No artist, no upstream release, no client to profile with. This changes
what the file claims, not what is done.

Closes #48

---

## สรุปภาษาไทย

### สรุป

ส่วนนำของ ledger ยืนยันว่าครบถ้วนและมันผิดไปสองแถว เป็น docs อย่างเดียว —
`git diff --name-only` มีแต่ `docs/OPEN-WORK-LEDGER.md`

**ก่อน:**

> **ข้อยกเว้นหนึ่งเดียวที่ไม่ต้องใช้ client: texture ของ Player Microchip สามไฟล์** ซึ่งต้องใช้คนทำงานศิลป์
> นั่นคือรายการทั้งหมด

มีอีกสองแถว 🟡 ที่อยู่ถัดลงไปซึ่งก็ไม่ต้องใช้ client เหมือนกัน: `cbc_firepower_components`
รอ **release จากต้นน้ำ** และ `TaCZ: Accelerated` รอ **benchmark baseline**

**หลัง** — เป็นตารางที่ผู้อ่านเอาไปเทียบกับไฟล์ได้:

| แถว | ตัวขวางจริง |
|---|---|
| texture ของ Player Microchip สามไฟล์ (#35) | **คนทำงานศิลป์** |
| เพิ่ม `cbc_firepower_components` กลับ | **release จากต้นน้ำ** ที่รองรับ CBC ≥ 5.9 |
| ประเมิน `TaCZ: Accelerated` ใหม่ | **benchmark baseline** — ซึ่งต้องใช้ client ในการ profile จริง |

บวกกับคำสั่งให้ค้นหา 🟡 ในไฟล์ เพื่อให้คำอ้างนั้นตรวจสอบได้แทนที่จะต้องเชื่อ

### ทำไมย่อหน้าเดียวถึงคุ้มกับการเปิด PR

**ย่อหน้านี้ผิดมาแล้วสองครั้ง ในรูปแบบเดียวกัน** เวอร์ชันก่อนหน้านี้อ้างว่า*ทุกอย่าง*ที่เหลือต้องรอ
การ launch client — ผิดไป **เจ็ด** แถวใน Track 5 ซึ่งทำได้ทั้งหมดและไม่มีใครแตะ
การแก้ครั้งนั้นอ้างว่า texture ของ Microchip คือ "รายการทั้งหมด" — ผิดไป **สอง** แถว

คำอ้างเรื่องความครบถ้วนใน `OPEN-WORK-LEDGER.md` เป็นสิ่งที่รับน้ำหนัก: มันคือสิ่งที่เซสชันหนึ่งอ่าน
*แทน*ตาราง ไฟล์นี้มีอยู่เพื่อกันไม่ให้งานหายไปใน MD และบทสรุปที่กว้างเกินไปที่ด้านบน
คือวิธีที่งานหายไปจาก ledger ที่ยังมีงานนั้นอยู่ทางเทคนิคพอดี

### การทดสอบ

`node scripts/validate/verify.mjs` — เขียว (JSON 96 · TOML 122 · ไฟล์ใน index 157 · KubeJS script 5)

### นอกขอบเขต

**การลงมือทำทั้งสามอย่าง** ไม่มีคนทำงานศิลป์ ไม่มี release จากต้นน้ำ ไม่มี client ให้ profile
PR นี้เปลี่ยนสิ่งที่ไฟล์อ้าง ไม่ได้เปลี่ยนสิ่งที่ทำเสร็จ

Closes #48
