### PR TITLE
feat(pack-infra): a generated mod roster with resolved source URLs, shipped with the pack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ no entry, no tag, and is never handed to a friend as if it were a release.
   version. It carries the four mods CurseForge's API will not serve, so a host does not have to
   hunt them down by hand.
 - **`SHA256SUMS.txt`** next to the downloads, so you can check that what you got is what was built.
+- **A mod list you can actually read.** `MODLIST.md` sits at the top of both the client and the
+  server download: all 99 mods, the exact jar filename of each, whether it runs on the client, the
+  server or both, and a link to the page it came from. Every mod in this pack is somebody else's
+  work and this is where they are credited.
 
 ### Changed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,7 @@ node scripts/validate/verify.mjs test     # node --check over every kubejs/**/*.
 node scripts/build/build-instance.mjs     # the self-contained client instance (389 MB, 99 mods)
 node scripts/build/build-server.mjs       # the server pack (332 MB, 89 mods — Distribution Spec §12)
 node scripts/build/generate-checksums.mjs # build/SHA256SUMS.txt, and refuses a stale artifact
+node scripts/build/generate-modlist.mjs   # docs/MODLIST.md — 99 mods, source URLs resolved from ids
 
 node scripts/validate/config-drift.mjs <install>   # "friend A works, friend B doesn't" (§38)
 
@@ -177,6 +178,8 @@ docs/
   Addon Spec — Natural Wildlife ….md         Naturalist / Critters / Ecologics, phases W0–W9
   Addon Modpack — Distribution & Updates.md  release engineering — governs THIS repo's process
   OPEN-WORK-LEDGER.md         open work, tracked and untracked — read at session start
+  MODLIST.md                  GENERATED — the roster a downloader reads. Ships inside both
+                              artifacts. `verify` refuses one that disagrees with mods/
   customization-map.md        WHAT STILL HAS TO BE BUILT — the 22 mods the design docs
                               tag for custom work, with their concrete targets
   compatibility-matrix.md     what has been OBSERVED — versions, sources, boot results

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -91,16 +91,22 @@ hundred lines name the mod. `crash-reports/` has the same information formatted 
 
 ## What is in the pack, and what is not
 
-This is `0.1.0-alpha`. It is **the mod set, resolved and pinned** — and nothing else yet.
+This is `0.1.0-alpha`.
 
-- ✅ 93 mods at exact, verified versions; Create pinned to `6.0.8`
-- ❌ **No balance work.** Gun damage, mob health, spawn rates and ammunition costs are all at their
-  mod defaults. The design intent — ammunition as an industrial resource, monsters that are
-  dangerous through AI rather than health — is **not implemented yet**.
-- ❌ No KubeJS recipes, no quests, no custom configs.
+- ✅ **99 mods** at exact, verified versions; Create pinned to `6.0.8`. **`MODLIST.md`, at the top
+  of this download, lists every one of them with a link to where it came from.**
+- ✅ **The balance work is done.** Guns are gated behind four tiers of factory output, ammunition is
+  an industrial product, hordes arrive roughly every twelve days and grow, monsters fade in over
+  time rather than all at once, and undead do not burn at dawn.
+- ✅ **A twelve-chapter quest campaign**, 48 quests, written around objectives rather than a
+  crafting checklist.
+- ⚠️ **None of it has been verified in a running game.** Every check so far has been a dedicated
+  server boot: configs parse, recipes register, quests load. That is not the same as playing it, and
+  numbers may be wrong in ways only play reveals.
+- ❌ **One known problem, unfixed:** Improved Mobs cannot read the defence values of Brimm Armors,
+  so no Brimm armour will ever be worn by a mob.
 
-So it will run, and it will not yet play the way the design documents describe. See
-`docs/OPEN-WORK-LEDGER.md` for what is next.
+See `docs/OPEN-WORK-LEDGER.md` for what is next, and `CHANGELOG.md` for what changed.
 <!-- lang:end -->
 
 <!-- lang:th -->
@@ -196,13 +202,19 @@ java -jar packwiz-installer-bootstrap.jar http://localhost:8080/pack.toml
 
 ## ใน pack มีอะไร และยังไม่มีอะไร
 
-นี่คือ `0.1.0-alpha` มันคือ **ชุด mod ที่ resolve และ pin เรียบร้อยแล้ว** — และยังไม่มีอย่างอื่น
+นี่คือ `0.1.0-alpha`
 
-- ✅ 93 mod ที่เวอร์ชันเป๊ะและตรวจสอบแล้ว Create pin ที่ `6.0.8`
-- ❌ **ยังไม่มีงาน balance เลย** ดาเมจปืน เลือดม็อบ อัตรา spawn และต้นทุนกระสุน ยังเป็นค่า default
-  ของแต่ละ mod ทั้งหมด เจตนาการออกแบบ — กระสุนเป็นทรัพยากรอุตสาหกรรม, สัตว์ประหลาดอันตราย
-  เพราะ AI ไม่ใช่เพราะเลือดเยอะ — **ยังไม่ได้ถูกทำ**
-- ❌ ยังไม่มี KubeJS recipe ไม่มี quest ไม่มี config ที่ปรับเอง
+- ✅ **99 mod** ที่เวอร์ชันเป๊ะและตรวจสอบแล้ว Create pin ที่ `6.0.8`
+  **`MODLIST.md` ที่อยู่บนสุดของไฟล์ที่โหลดมา ลงชื่อทุกตัวพร้อมลิงก์ไปยังที่มาของมัน**
+- ✅ **งาน balance ทำเสร็จแล้ว** ปืนถูกกั้นด้วยสี่ขั้นของกำลังการผลิต กระสุนเป็นของที่ต้องผลิต
+  ในโรงงาน horde มาทุก ๆ สิบสองวันโดยประมาณและใหญ่ขึ้นเรื่อย ๆ สัตว์ประหลาดโผล่มาทีละนิด
+  แทนที่จะมาพร้อมกัน และผีดิบไม่ไหม้ตอนเช้า
+- ✅ **แคมเปญ quest สิบสองบท** 48 quest เขียนรอบเป้าหมาย ไม่ใช่ checklist การคราฟต์
+- ⚠️ **ยังไม่มีอะไรถูกตรวจสอบในเกมจริง** การตรวจทุกอย่างที่ผ่านมาเป็นการ boot
+  บน dedicated server: config parse ได้ recipe ลงทะเบียนได้ quest โหลดได้ นั่นไม่เท่ากับการเล่นจริง
+  และตัวเลขอาจผิดในแบบที่มีแต่การเล่นเท่านั้นที่จะเผย
+- ❌ **ปัญหาที่รู้แล้วหนึ่งข้อ ยังไม่ได้แก้:** Improved Mobs อ่านค่าป้องกันของ Brimm Armors ไม่ได้
+  ดังนั้นจะไม่มีมอบตัวไหนสวมเกราะ Brimm เลย
 
 ดังนั้นมันรันได้ แต่ยังไม่ได้เล่นแบบที่เอกสารออกแบบบรรยายไว้ ดูสิ่งที่จะทำต่อได้ที่
 `docs/OPEN-WORK-LEDGER.md`

--- a/docs/MODLIST.md
+++ b/docs/MODLIST.md
@@ -1,0 +1,196 @@
+<!-- roster-digest: effcececefa99a752909f369b67a5d4022cea2090286d311c0805cbdd4cb4e57 -->
+<!-- GENERATED FILE — do not edit by hand.
+     Run: node scripts/build/generate-modlist.mjs
+     `verify` refuses a roster that disagrees with mods/. -->
+
+# What is in this pack · ในแพ็กนี้มีอะไรบ้าง
+
+**Industrial Civilization Survival 0.1.0-alpha** — **99 mods** on Minecraft `1.20.1`,
+Forge `47.4.23`.
+
+Every mod here is somebody else's work. This file exists so you can see whose, and go and find
+the original.
+
+**Where you will find this file.** It ships at the top of the client instance zip and at the top of
+the server zip. The CurseForge-format zip instead carries packwiz's own `modlist.html`, which lists
+97 names — the client-side set — with no versions, sides or links. This
+file is the complete one.
+
+**ไฟล์นี้อยู่ตรงไหน** มันอยู่บนสุดของ zip ตัว client instance และบนสุดของ zip ตัว server
+ส่วน zip รูปแบบ CurseForge จะมี `modlist.html` ของ packwiz เองแทน ซึ่งลงชื่อไว้ 97 ชื่อ —
+ชุดฝั่ง client — โดยไม่มีเวอร์ชัน ไม่มี side ไม่มีลิงก์ ไฟล์นี้คือตัวที่ครบ
+
+## Reading the table
+
+**The File column is the exact jar filename**, not a tidied-up version number. That is deliberate:
+99 mods use 99 filename conventions, and parsing a version out of them would mean guessing. The
+filename is what is actually on your disk, so it is also what you can match against your `mods/`
+folder when something goes wrong.
+
+**Source links are resolved, not guessed.** packwiz records a project *id*, never a slug, so this
+script follows the id to whatever page it lands on and links that. It never assembles a URL out of a
+mod's name — twice now, a guessed slug in this repo has pointed at the wrong project entirely, once
+at a modpack rather than the mod.
+
+**Client / Server** tells you where a mod runs. If you are hosting a server, you need the
+87 in *Both* and the 2 in *Server only*; the 10 client-only
+mods are not installed on a server and are not missing when they are absent.
+
+## อ่านตารางยังไง
+
+**คอลัมน์ File คือชื่อไฟล์ jar จริง ๆ** ไม่ใช่เลขเวอร์ชันที่จัดให้สวย ตั้งใจให้เป็นแบบนั้น เพราะมอด 99 ตัว
+ใช้รูปแบบการตั้งชื่อไฟล์ 99 แบบ การพยายามแกะเวอร์ชันออกมาคือการเดา ชื่อไฟล์คือสิ่งที่อยู่บนเครื่องคุณจริง ๆ
+ดังนั้นมันจึงเป็นสิ่งที่คุณเอาไปเทียบกับโฟลเดอร์ `mods/` ได้ตอนมีอะไรผิดพลาด
+
+**ลิงก์ต้นทาง resolve มา ไม่ได้เดา** packwiz บันทึก project *id* ไว้ ไม่เคยบันทึก slug
+สคริปต์นี้จึงตาม id ไปจนถึงหน้าที่มันไปจบแล้วลิงก์หน้านั้น มันไม่ประกอบ URL ขึ้นจากชื่อมอดเด็ดขาด —
+สอง​ครั้งแล้วที่ slug ที่เดาใน repo นี้ชี้ไปผิดโปรเจกต์ ครั้งหนึ่งชี้ไปที่ modpack แทนที่จะเป็นตัวมอด
+
+**Client / Server** บอกว่ามอดตัวนั้นทำงานฝั่งไหน ถ้าคุณจะเปิด server คุณต้องใช้ 87 ตัวใน *Both*
+กับ 2 ตัวใน *Server only* ส่วนมอดฝั่ง client 10 ตัวจะไม่ถูกติดตั้งบน server
+และการที่มันไม่อยู่ตรงนั้นไม่ใช่ของหาย
+
+> **หมายเหตุ** ตารางด้านล่างมีชุดเดียว ไม่ได้ทำสองภาษา เพราะเนื้อในเป็นชื่อมอด ชื่อไฟล์ และ URL ซึ่งเป็น
+> ภาษาอังกฤษอยู่แล้วทั้งหมด หัวตารางเป็นสองภาษา
+
+---
+
+## Both — client and server · ทั้งสองฝั่ง (87)
+
+| Mod · มอด | File · ไฟล์ | Source · ต้นทาง |
+|---|---|---|
+| [TACZ] Durability | `gundb-2.1.0-all.jar` | [Modrinth](https://modrinth.com/mod/tacz-durability) |
+| [TaCZ] Timeless and Classics Zero Guns | `tacz-1.20.1-1.1.8-hotfix.jar` | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/timeless-and-classics-zero) |
+| Architectury API | `architectury-9.2.14-forge.jar` | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/architectury-api) |
+| Atlas Lib | `Atlas Lib-1.20.1-1.1.12.jar` | [Modrinth](https://modrinth.com/mod/atlas-lib) |
+| Attract to Sound ([NEO]Forge/Fabric): Sound & Stealth. | `forge_soundattract_1.20.1-6.3.8.jar` | [Modrinth](https://modrinth.com/mod/attract-to-sound) |
+| Balm | `balm-forge-1.20.1-7.3.42.jar` | [Modrinth](https://modrinth.com/mod/balm) |
+| BlockUI | `blockui-1.20.1-1.0.194-snapshot.jar` | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/blockui) |
+| Born in Chaos | `born_in_chaos_[Forge]1.20.1_1.7.5.jar` | [Modrinth](https://modrinth.com/mod/borninchaos) |
+| Brimm Armors \| Tactical Military Armors | `brimm-2.0.3.jar` | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/brimm-armors-tactical-military-armors) |
+| CAPS_Awim - TACTICAL_GEAR | `caps_awim_tactical_gear_rework-3.0.0408.26_en-forge-1.20.1.jar` | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/caps-awim-tactical-gear) |
+| Carry On | `carryon-forge-1.20.1-2.1.2.7.jar` | [Modrinth](https://modrinth.com/mod/carry-on) |
+| Chunky | `Chunky-1.3.146.jar` | [Modrinth](https://modrinth.com/mod/chunky) |
+| Cloth Config API | `cloth-config-11.1.136-forge.jar` | [Modrinth](https://modrinth.com/mod/cloth-config) |
+| ClothingCraft | `clothingcraft-1.0.0.jar` | [Modrinth](https://modrinth.com/mod/clothingcraft) |
+| Clumps | `Clumps-forge-1.20.1-12.0.0.4.jar` | [Modrinth](https://modrinth.com/mod/clumps) |
+| Corpse | `corpse-forge-1.20.1-1.0.23.jar` | [Modrinth](https://modrinth.com/mod/corpse) |
+| Crafting Tweaks | `craftingtweaks-forge-1.20.1-18.2.9.jar` | [Modrinth](https://modrinth.com/mod/crafting-tweaks) |
+| Create | `create-1.20.1-6.0.8.jar` | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/create) |
+| Create Big Cannons | `createbigcannons-5.11.4-mc.1.20.1-forge.jar` | [Modrinth](https://modrinth.com/mod/create-big-cannons) |
+| Create Crafts & Additions | `createaddition-1.20.1-1.3.3.jar` | [Modrinth](https://modrinth.com/mod/createaddition) |
+| Create: Diesel Generators | `createdieselgenerators-1.20.1-1.3.12.jar` | [Modrinth](https://modrinth.com/mod/create-diesel-generators) |
+| Create: Steam 'n' Rails | `Steam_Rails-1.7.2+forge-mc1.20.1.jar` | [Modrinth](https://modrinth.com/mod/create-steam-n-rails) |
+| Create: Timeless and Classics Zero [TaCZ] | `tacz_c-1.0.2-forge-1.20.1.jar` | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/tacz-create) |
+| CreativeCore | `CreativeCore_FORGE_v2.12.39_mc1.20.1.jar` | [Modrinth](https://modrinth.com/mod/creativecore) |
+| Critters and Companions | `crittersandcompanions-forge-1.20.1-2.7.1.jar` | [Modrinth](https://modrinth.com/mod/critters-and-companions) |
+| Cupboard | `cupboard-1.20.1-4.0.jar` | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/cupboard) |
+| Curios API | `curios-forge-5.14.1+1.20.1.jar` | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/curios) |
+| Domum Ornamentum | `domum_ornamentum-1.20.1-1.0.303-snapshot-universal.jar` | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/domum-ornamentum) |
+| Eating Animation [Neo/Forge] | `eatinganimation-1.20.1-5.1.0.jar` | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/eating-animation-forge) |
+| Ecologics | `ecologics-forge-1.20.1-2.2.7.jar` | [Modrinth](https://modrinth.com/mod/ecologics) |
+| Enhanced AI | `enhancedai-3.3.7.3.jar` | [Modrinth](https://modrinth.com/mod/enhanced-ai) |
+| Farmer's Delight | `FarmersDelight-1.20.1-1.3.3.jar` | [Modrinth](https://modrinth.com/mod/farmers-delight) |
+| FastSuite | `FastSuite-1.20.1-5.1.2.jar` | [Modrinth](https://modrinth.com/mod/fastsuite) |
+| FerriteCore | `ferritecore-6.0.1-forge.jar` | [Modrinth](https://modrinth.com/mod/ferrite-core) |
+| Flashier Flashlights | `Flashier Flashlights 1.2.0.jar` | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/flashier-flashlights) |
+| Framework | `framework-forge-1.20.1-0.8.0.jar` | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/framework) |
+| FTB Library (NeoForge) | `ftb-library-forge-2001.2.13.jar` | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/ftb-library-forge) |
+| FTB Quests (NeoForge) | `ftb-quests-forge-2001.4.22.jar` | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/ftb-quests-forge) |
+| FTB Teams (NeoForge) | `ftb-teams-forge-2001.3.2.jar` | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/ftb-teams-forge) |
+| GeckoLib | `geckolib-forge-1.20.1-4.8.4.jar` | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/geckolib) |
+| GlitchCore | `GlitchCore-forge-1.20.1-0.0.1.1.jar` | [Modrinth](https://modrinth.com/mod/glitchcore) |
+| Grillo's Clothes | `clothes_mod-1.4.10-1.20.1.jar` | [Modrinth](https://modrinth.com/mod/grillos-clothes) |
+| GroovyModLoader (GML) | `gml-4.0.11-all.jar` | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/gml) |
+| IceAndFire Community Edition | `IceAndFireCE-1.2.7-1.20.1-forge.jar` | [Modrinth](https://modrinth.com/mod/iceandfire-ce) |
+| Immersive Engineering | `ImmersiveEngineering-1.20.1-10.2.0-183.jar` | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/immersive-engineering) |
+| Immersive Posts | `ImmersivePosts-1.20.1-4.3.0-15.jar` | [Modrinth](https://modrinth.com/mod/immersiveposts) |
+| Improved Mobs | `improvedmobs-1.20.1-1.13.7-forge.jar` | [Modrinth](https://modrinth.com/mod/improved-mobs) |
+| InsaneLib | `insanelib-1.23.4.6.jar` | [Modrinth](https://modrinth.com/mod/insanelib) |
+| ItemPhysic | `ItemPhysic_FORGE_v1.8.13_mc1.20.1.jar` | [Modrinth](https://modrinth.com/mod/itemphysic) |
+| Jade 🔍 | `Jade-1.20.1-Forge-11.13.3.jar` | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/jade) |
+| Jade Addons (Neo/Forge) | `JadeAddons-1.20.1-Forge-5.5.1.jar` | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/jade-addons) |
+| Jupiter | `jupiter-2.3.7-1.20.1-forge.jar` | [Modrinth](https://modrinth.com/mod/jupiter) |
+| Just Enough Items (JEI) | `jei-1.20.1-forge-15.49.0.191.jar` | [Modrinth](https://modrinth.com/mod/jei) |
+| KubeJS | `kubejs-forge-2001.6.5-build.26.jar` | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/kubejs) |
+| Lexiconfig | `lexiconfig-forge-1.4.21-epic.jar` | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/lexiconfig) |
+| Macaw's Lights and Lamps | `mcw-lights-1.1.5-mc1.20.1forge.jar` | [Modrinth](https://modrinth.com/mod/macaws-lights-and-lamps) |
+| MineColonies | `minecolonies-1.20.1-1.1.1278-snapshot.jar` | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/minecolonies) |
+| ModernFix | `modernfix-forge-5.27.77+mc1.20.1.jar` | [Modrinth](https://modrinth.com/mod/modernfix) |
+| MrCrayfish's Furniture Mod: Refurbished | `refurbished_furniture-forge-1.20.1-1.0.20.jar` | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/refurbished-furniture) |
+| Multi-Piston | `multipiston-1.20-0.0.47-snapshot.jar` | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/multi-piston) |
+| Naturalist | `naturalist-5.0pre4+forge-1.20.1.jar` | [Modrinth](https://modrinth.com/mod/naturalist) |
+| Placebo | `Placebo-1.20.1-8.6.3.jar` | [Modrinth](https://modrinth.com/mod/placebo) |
+| Player Microchip (Tracker) | `player_tracking_chip-1.0.2-forge-1.20.1.jar` | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/player-microchip) |
+| playerAnimator | `player-animation-lib-forge-1.0.2-rc1+1.20.jar` | [Modrinth](https://modrinth.com/mod/playeranimator) |
+| PlayerRevive | `PlayerRevive_FORGE_v2.0.31_mc1.20.1.jar` | [Modrinth](https://modrinth.com/mod/playerrevive) |
+| Polymorph | `polymorph-forge-0.49.10+1.20.1.jar` | [Modrinth](https://modrinth.com/mod/polymorph) |
+| Puzzles Lib | `PuzzlesLib-v8.1.33-1.20.1-Forge.jar` | [Modrinth](https://modrinth.com/mod/puzzles-lib) |
+| Rhino | `rhino-forge-2001.2.3-build.10.jar` | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/rhino) |
+| Ritchie's Projectile Library | `ritchiesprojectilelib-2.1.1+mc.1.20.1-forge.jar` | [Modrinth](https://modrinth.com/mod/rpl) |
+| Security Craft | `[1.20.1] SecurityCraft v1.10.2.1.jar` | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/security-craft) |
+| Serene Seasons | `SereneSeasons-forge-1.20.1-9.1.0.3.jar` | [Modrinth](https://modrinth.com/mod/serene-seasons) |
+| Simple Voice Chat | `voicechat-forge-1.20.1-2.6.22.jar` | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/simple-voice-chat) |
+| Simple Voice Radio | `simpleradio-forge-1.20.1-4.5.7.9.jar` | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/simple-voice-radio) |
+| Smooth Movement | `smoothmovement-1.20.1-2.6.jar` | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/smooth-movement) |
+| Sophisticated Backpacks | `sophisticatedbackpacks-1.20.1-3.24.67.2109.jar` | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/sophisticated-backpacks) |
+| Sophisticated Core | `sophisticatedcore-1.20.1-1.3.84.2308.jar` | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/sophisticated-core) |
+| Sophisticated Tactical Backpacks | `militarybackpack-1.0.0-all.jar` | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/sophisticated-tactical-backpacks) |
+| Structurize | `structurize-1.20.1-1.0.818.jar` | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/structurize) |
+| TaCZ Additions | `taczadditions-1.20.1-1.3.0.jar` | [Modrinth](https://modrinth.com/mod/tacz-additions) |
+| TaCZ x Guns Lights Addon [NEW] - Update 2.5.0 | `tacz_x_guns_lights_addon-2.5.0.jar` | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/tacz-x-gunslightsaddon-addon) |
+| TakKit | `takkit-1.3.1-1.20.1.jar` | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/takkit) |
+| TenshiLib | `tenshilib-1.20.1-1.7.6-forge.jar` | [Modrinth](https://modrinth.com/mod/tenshilib) |
+| The Hordes | `The-Hordes-1.20.1-1.6.3g-all.jar` | [Modrinth](https://modrinth.com/mod/the-hordes) |
+| TownTalk | `towntalk-1.20.1-1.1.0.jar` | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/towntalk) |
+| Uranus | `uranus-2.2.6-bugfix.2-1.20.1-forge.jar` | [Modrinth](https://modrinth.com/mod/uranus) |
+| Visual Workbench | `VisualWorkbench-v8.0.1-1.20.1-Forge.jar` | [Modrinth](https://modrinth.com/mod/visual-workbench) |
+| YetAnotherConfigLib (YACL) | `yet_another_config_lib_v3-3.6.6+1.20.1-forge.jar` | [Modrinth](https://modrinth.com/mod/yacl) |
+
+## Client only · เฉพาะฝั่ง client (10)
+
+Not installed on a server. `docs/side-classification.md` records the evidence for each call.
+
+ไม่ถูกติดตั้งบน server `docs/side-classification.md` บันทึกหลักฐานของการตัดสินแต่ละตัวไว้
+
+| Mod · มอด | File · ไฟล์ | Source · ต้นทาง |
+|---|---|---|
+| AmbientSounds | `AmbientSounds_FORGE_v6.3.8_mc1.20.1.jar` | [Modrinth](https://modrinth.com/mod/ambientsounds) |
+| Better Animations Collection | `BetterAnimationsCollection-v8.0.1-1.20.1-Forge.jar` | [Modrinth](https://modrinth.com/mod/better-animations-collection) |
+| Client Dynamic Light | `clientdynamiclight-1.20.1-3.2.1.jar` | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/client-dynamic-light) |
+| Embeddium | `embeddium-0.3.31+mc1.20.1.jar` | [Modrinth](https://modrinth.com/mod/embeddium) |
+| Entity Culling | `entityculling-forge-1.10.5-mc1.20.1.jar` | [Modrinth](https://modrinth.com/mod/entityculling) |
+| ImmediatelyFast | `ImmediatelyFast-1.2.7+1.20.2.jar` | [Modrinth](https://modrinth.com/mod/immediatelyfast) |
+| Mouse Tweaks | `MouseTweaks-forge-mc1.20.1-2.25.1.jar` | [Modrinth](https://modrinth.com/mod/mouse-tweaks) |
+| Not Enough Animations | `notenoughanimations-forge-1.12.4-mc1.20.1.jar` | [Modrinth](https://modrinth.com/mod/not-enough-animations) |
+| SmoothPlayerAnimations | `SmoothPlayerAnimations_Forge_1.20.1_1.0.3.jar` | [Modrinth](https://modrinth.com/mod/smoothplayeranimations) |
+| Sound Physics Remastered | `sound-physics-remastered-forge-1.20.1-1.5.1.jar` | [Modrinth](https://modrinth.com/mod/sound-physics-remastered) |
+
+## Server only · เฉพาะฝั่ง server (2)
+
+| Mod · มอด | File · ไฟล์ | Source · ต้นทาง |
+|---|---|---|
+| In Control! | `incontrol-1.20-9.4.7.jar` | [Modrinth](https://modrinth.com/mod/in-control) |
+| ServerCore | `servercore-forge-1.5.2+1.20.1.jar` | [Modrinth](https://modrinth.com/mod/servercore) |
+
+---
+
+## What this file does not tell you · สิ่งที่ไฟล์นี้ไม่ได้บอก
+
+**Licences.** Knowing where a mod came from is not the same as knowing what you may do with it.
+Check each project page before redistributing anything.
+
+**Dependencies between these mods.** packwiz records what is installed, not why. A mod in this list
+may be here only because another one requires it.
+
+**Which mods this pack modifies.** Recipes, spawn rules and balance are changed by this pack's own
+configs and scripts, not by the mod authors. `docs/customization-map.md` is that list.
+
+**สัญญาอนุญาต** การรู้ว่ามอดมาจากไหนไม่เท่ากับการรู้ว่าคุณทำอะไรกับมันได้บ้าง
+ตรวจหน้าโปรเจกต์ของแต่ละตัวก่อนแจกจ่ายต่อ
+
+**ความสัมพันธ์ระหว่างมอดในนี้** packwiz บันทึกว่าอะไรถูกติดตั้ง ไม่ได้บันทึกว่าทำไม
+มอดบางตัวในรายชื่อนี้อาจอยู่ที่นี่เพราะมอดอีกตัวต้องการมันเท่านั้น
+
+**มอดตัวไหนที่แพ็กนี้ไปแก้บ้าง** สูตรคราฟต์ กฎการเกิดของมอนสเตอร์ และสมดุลถูกเปลี่ยนโดย config
+และสคริปต์ของแพ็กนี้เอง ไม่ใช่โดยผู้เขียนมอด `docs/customization-map.md` คือรายชื่อนั้น

--- a/scripts/build/build-instance.mjs
+++ b/scripts/build/build-instance.mjs
@@ -15,7 +15,7 @@
 // is fatal — a silently corrupt jar in a 130 MB artifact is exactly the kind
 // of failure nobody finds until a friend cannot launch.
 
-import { readdirSync, writeFileSync, mkdirSync, existsSync, statSync, rmSync } from 'node:fs'
+import { readdirSync, writeFileSync, mkdirSync, existsSync, statSync, rmSync, copyFileSync } from 'node:fs'
 import { execFileSync } from 'node:child_process'
 import { join } from 'node:path'
 import { readPack, readMetas, fetchAndVerify, versionStamp } from './lib/pack.mjs'
@@ -74,6 +74,20 @@ const stripMarkdown = (dir) => {
 }
 stripMarkdown(join(STAGE, '.minecraft'))
 console.log(`stripped ${stripped} maintainer .md file(s) — they are repo documentation, not pack content`)
+
+
+// The mod roster ships *after* the strip, deliberately. The strip exists to keep
+// maintainer READMEs out of a player's install; `docs/MODLIST.md` is the
+// opposite — it is the one document written for the person who downloaded this.
+// Anyone reading it is holding the artifact, so it goes where they will see it.
+const roster = join(ROOT, 'docs', 'MODLIST.md')
+if (existsSync(roster)) {
+  copyFileSync(roster, join(STAGE, 'MODLIST.md'))
+  console.log('bundled docs/MODLIST.md — the roster a downloader reads')
+} else {
+  console.error('docs/MODLIST.md is missing — run: node scripts/build/generate-modlist.mjs')
+  process.exit(1)
+}
 
 writeFileSync(join(STAGE, 'mmc-pack.json'), JSON.stringify({
   components: [

--- a/scripts/build/build-server.mjs
+++ b/scripts/build/build-server.mjs
@@ -25,7 +25,7 @@
 // installer places correctly, and a stale copy inside a pack zip is a support
 // problem waiting to happen.
 
-import { readdirSync, writeFileSync, mkdirSync, existsSync, statSync, rmSync } from 'node:fs'
+import { readdirSync, writeFileSync, mkdirSync, existsSync, statSync, rmSync, copyFileSync } from 'node:fs'
 import { execFileSync } from 'node:child_process'
 import { join } from 'node:path'
 import { readPack, readMetas, fetchAndVerify, versionStamp } from './lib/pack.mjs'
@@ -85,6 +85,19 @@ const stripMarkdown = (dir) => {
 stripMarkdown(STAGE)
 console.log(`stripped ${stripped} maintainer .md file(s)`)
 
+// The mod roster ships *after* the strip, deliberately. The strip exists to keep
+// maintainer READMEs out of an install; `docs/MODLIST.md` is the opposite — it
+// is the one document written for the person who downloaded this. A server host
+// in particular needs it, because it is the only place that says which mods are
+// client-only and therefore correctly absent here.
+const roster = join(ROOT, 'docs', 'MODLIST.md')
+if (!existsSync(roster)) {
+  console.error('docs/MODLIST.md is missing — run: node scripts/build/generate-modlist.mjs')
+  process.exit(1)
+}
+copyFileSync(roster, join(STAGE, 'MODLIST.md'))
+console.log('bundled docs/MODLIST.md — the roster a downloader reads')
+
 writeFileSync(join(STAGE, 'pack-version.txt'), versionStamp(pack, 'server'))
 
 writeFileSync(join(STAGE, 'README.txt'), [
@@ -107,6 +120,10 @@ writeFileSync(join(STAGE, 'README.txt'), [
   '  pack-version.txt here against the one in the client instance',
   '  (.minecraft/pack-version.txt). If they disagree, that IS the problem —',
   '  do not debug anything else first.',
+  '',
+  'WHAT IS IN HERE',
+  '',
+  '  MODLIST.md lists every mod in this pack with a link to its source.',
   '',
   'WHAT IS NOT HERE',
   '',

--- a/scripts/build/generate-modlist.mjs
+++ b/scripts/build/generate-modlist.mjs
@@ -1,0 +1,314 @@
+#!/usr/bin/env node
+// Generates `docs/MODLIST.md` — the roster a downloader reads to find out what
+// they just installed, and the only place this repo credits the 99 authors whose
+// work the pack ships.
+//
+// Generated rather than written by hand, for the same reason `SHA256SUMS.txt` is:
+// a hand-maintained list of 99 rows is wrong the first time a version bumps, and
+// nothing would catch it. `verify.mjs` refuses a roster that disagrees with
+// `mods/`.
+//
+// ---------------------------------------------------------------------------
+// The one rule this script exists to enforce: NEVER COMPOSE A SOURCE URL FROM A
+// GUESSED SLUG.
+//
+// packwiz metafiles store project *ids*, not slugs, and this repo has been
+// burned by guessing the difference twice:
+//
+//   - `smoothplayeranimations` vs `smooth-player-animations`  (compatibility matrix)
+//   - `create-industry`, which on Modrinth is a MODPACK, not TFMG  (ADR 0004)
+//
+// Both hosts redirect an id-only URL to the canonical page, so this script
+// follows the id once and records where it *landed*. Every slug in the output is
+// therefore measured. When a lookup fails the id URL is emitted instead — it
+// still works in a browser — and the failure is counted in the output rather
+// than papered over.
+// ---------------------------------------------------------------------------
+
+import { writeFileSync, readFileSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { readPack, readMetas, rosterDigest, parseMeta } from './lib/pack.mjs'
+
+const ROOT = process.cwd()
+const OUT = join(ROOT, 'docs', 'MODLIST.md')
+
+/** Project-page URLs built from ids alone. Neither contains a slug. */
+const idUrl = (m) =>
+  m.modId ? `https://modrinth.com/mod/${m.modId}`
+    : m.projectId ? `https://www.curseforge.com/projects/${m.projectId}`
+      : null
+
+const hostOf = (m) => (m.modId ? 'Modrinth' : m.projectId ? 'CurseForge' : '—')
+
+const UA = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) minecraft-100day-modlist'
+const sleep = (ms) => new Promise(r => setTimeout(r, ms))
+
+/** Every lookup is bounded. `fetch` has no default timeout, so one stalled
+ *  connection parks a worker for as long as the OS will hold the socket open —
+ *  which is how a 40-second job became a ten-minute one the first time
+ *  CurseForge decided to stop answering rather than refuse. */
+const get = (url) => fetch(url, {
+  redirect: 'follow',
+  headers: { 'User-Agent': UA },
+  signal: AbortSignal.timeout(12_000),
+})
+
+/** Modrinth publishes the slug as a field. Reading it is still resolution, not
+ *  guessing — the slug arrives as data from the id, and the API is documented
+ *  and rate-limited generously, unlike the Cloudflare-fronted website. */
+async function resolveModrinth(m) {
+  const api = `https://api.modrinth.com/v2/project/${m.modId}`
+  const r = await get(api)
+  if (!r.ok) return { url: idUrl(m), resolved: false, why: `HTTP ${r.status} from the Modrinth API` }
+  const p = await r.json()
+  if (!p.slug) return { url: idUrl(m), resolved: false, why: 'the API returned no slug' }
+  // The path segment comes from `project_type`, not a hardcoded `/mod/`:
+  // `create-industry` on Modrinth is a MODPACK, and that exact confusion is why
+  // this script resolves instead of composing (ADR 0004). If a metafile ever
+  // points at a non-mod project, the URL says so rather than 404ing.
+  return { url: `https://modrinth.com/${p.project_type ?? 'mod'}/${p.slug}`, resolved: true }
+}
+
+/** CurseForge has no public API without a key, so the id URL's own redirect is
+ *  the only handle. It is Cloudflare-fronted and will 403/429 under load.
+ *
+ *  Retrying with backoff is right for a *transient* block and wrong for a
+ *  sustained one: when Cloudflare has decided about this IP, four attempts per
+ *  mod turns a 40-second job into a ten-minute one and still resolves nothing.
+ *  So the first few failures are retried, and once enough have failed in a row
+ *  the opener is treated as shut — the rest fall back immediately and the doc
+ *  says so. Giving up quickly is the honest read of a systemic block. */
+let cfConsecutiveBlocks = 0
+const CF_GIVE_UP_AFTER = 5
+
+async function resolveCurseForge(m) {
+  const url = idUrl(m)
+  if (cfConsecutiveBlocks >= CF_GIVE_UP_AFTER) {
+    return { url, resolved: false, why: 'skipped — CurseForge is blocking this address' }
+  }
+  for (let attempt = 0; attempt < 3; attempt++) {
+    if (attempt) await sleep(600 * 2 ** attempt)
+    let r
+    try {
+      r = await get(url)
+    } catch (e) {
+      // A timeout is a block by another name here — count it as one, so the
+      // circuit breaker below can still trip instead of retrying forever.
+      if (attempt === 2) { cfConsecutiveBlocks++; return { url, resolved: false, why: `no answer: ${e.message}` } }
+      continue
+    }
+    if (r.ok) { cfConsecutiveBlocks = 0; return { url: r.url || url, resolved: true } }
+    if (r.status !== 403 && r.status !== 429) {
+      cfConsecutiveBlocks = 0
+      return { url, resolved: false, why: `HTTP ${r.status}` }
+    }
+  }
+  cfConsecutiveBlocks++
+  return { url, resolved: false, why: 'HTTP 403/429 after 3 attempts — rate-limited' }
+}
+
+async function resolveOne(m) {
+  if (!idUrl(m)) return { url: null, resolved: false, why: 'metafile carries neither a Modrinth nor a CurseForge id' }
+  try {
+    return m.modId ? await resolveModrinth(m) : await resolveCurseForge(m)
+  } catch (e) {
+    return { url: idUrl(m), resolved: false, why: e.message }
+  }
+}
+
+/** Two pools, because the two hosts tolerate wildly different rates: Modrinth's
+ *  API is fine in parallel, CurseForge's website is not. Running them as one
+ *  queue would pace the whole job at CurseForge's speed for no reason. */
+async function resolveAll(metas) {
+  const out = new Array(metas.length)
+  let done = 0
+  const pool = async (idxs, width) => {
+    let next = 0
+    const worker = async () => {
+      while (next < idxs.length) {
+        const i = idxs[next++]
+        out[i] = await resolveOne(metas[i])
+        process.stdout.write(`\r  resolving ${++done}/${metas.length}   `)
+      }
+    }
+    await Promise.all(Array.from({ length: Math.min(width, idxs.length) }, worker))
+  }
+  const idx = (pred) => metas.map((m, i) => [m, i]).filter(([m]) => pred(m)).map(([, i]) => i)
+  await Promise.all([
+    pool(idx(m => m.modId), 8),
+    pool(idx(m => !m.modId), 2),
+  ])
+  process.stdout.write('\r')
+  return out
+}
+
+/** Previously-resolved URLs, read back out of the file we are about to replace.
+ *
+ *  Without this, regeneration is not monotonic: run the script on a day when
+ *  CurseForge is blocking and 12 rows that had real links get downgraded to id
+ *  URLs. A generator whose output gets worse when the network is bad is one
+ *  people stop running. A resolved URL is a fact that does not expire, so a
+ *  fresh failure falls back to the last good answer before it falls back to the
+ *  id.
+ *
+ *  Keyed by the metafile's `filename`, which is the one field that changes
+ *  whenever the project does. */
+function previouslyResolved() {
+  const map = new Map()
+  try {
+    const old = readFileSync(OUT, 'utf8')
+    for (const line of old.split('\n')) {
+      const m = line.match(/^\|[^|]*\|\s*`([^`]+)`\s*\|\s*\[[^\]]*\]\(([^)]+)\)/)
+      if (!m) continue
+      const [, filename, url] = m
+      if (!/\/(projects|project)\/\d+$/.test(url)) map.set(filename, url)
+    }
+  } catch { /* no previous file — first run */ }
+  return map
+}
+
+const esc = (s) => String(s ?? '').replace(/\|/g, '\\|')
+
+function table(rows) {
+  return [
+    '| Mod · มอด | File · ไฟล์ | Source · ต้นทาง |',
+    '|---|---|---|',
+    ...rows.map(({ m, r }) => {
+      const src = r.url ? `[${hostOf(m)}](${r.url})` : hostOf(m)
+      return `| ${esc(m.name)} | \`${esc(m.filename)}\` | ${src} |`
+    }),
+  ].join('\n')
+}
+
+// ------------------------------------------------------------------- run
+const pack = readPack(ROOT)
+const metas = readMetas(ROOT).sort((a, b) =>
+  (a.name ?? '').localeCompare(b.name ?? '', 'en', { sensitivity: 'base' }))
+
+console.log(`${pack.name} ${pack.version} — ${metas.length} mods`)
+const cached = previouslyResolved()
+const results = await resolveAll(metas)
+
+let reused = 0
+const rows = metas.map((m, i) => {
+  let r = results[i]
+  if (!r.resolved && cached.has(m.filename)) {
+    r = { url: cached.get(m.filename), resolved: true, fromCache: true }
+    reused++
+  }
+  return { m, r }
+})
+const unresolved = rows.filter(({ r }) => !r.resolved)
+const bySide = (s) => rows.filter(({ m }) => m.side === s)
+const both = bySide('both'), client = bySide('client'), server = bySide('server')
+
+for (const { m, r } of unresolved) console.log(`  ! ${m.name}: ${r.why} — falling back to the id URL`)
+console.log(`  resolved ${rows.length - unresolved.length}/${rows.length} source URLs` +
+  (reused ? ` (${reused} kept from the previous roster — this run could not reach the host)` : ''))
+
+const digest = rosterDigest(
+  readdirSync(join(ROOT, 'mods'))
+    .filter(f => f.endsWith('.pw.toml'))
+    .map(f => ({ file: `mods/${f}`, meta: parseMeta(readFileSync(join(ROOT, 'mods', f), 'utf8')) })))
+
+const doc = `<!-- roster-digest: ${digest} -->
+<!-- GENERATED FILE — do not edit by hand.
+     Run: node scripts/build/generate-modlist.mjs
+     \`verify\` refuses a roster that disagrees with mods/. -->
+
+# What is in this pack · ในแพ็กนี้มีอะไรบ้าง
+
+**${pack.name} ${pack.version}** — **${metas.length} mods** on Minecraft \`${pack.mc}\`,
+Forge \`${pack.forge}\`.
+
+Every mod here is somebody else's work. This file exists so you can see whose, and go and find
+the original.
+
+**Where you will find this file.** It ships at the top of the client instance zip and at the top of
+the server zip. The CurseForge-format zip instead carries packwiz's own \`modlist.html\`, which lists
+${both.length + client.length} names — the client-side set — with no versions, sides or links. This
+file is the complete one.
+
+**ไฟล์นี้อยู่ตรงไหน** มันอยู่บนสุดของ zip ตัว client instance และบนสุดของ zip ตัว server
+ส่วน zip รูปแบบ CurseForge จะมี \`modlist.html\` ของ packwiz เองแทน ซึ่งลงชื่อไว้ ${both.length + client.length} ชื่อ —
+ชุดฝั่ง client — โดยไม่มีเวอร์ชัน ไม่มี side ไม่มีลิงก์ ไฟล์นี้คือตัวที่ครบ
+
+## Reading the table
+
+**The File column is the exact jar filename**, not a tidied-up version number. That is deliberate:
+99 mods use 99 filename conventions, and parsing a version out of them would mean guessing. The
+filename is what is actually on your disk, so it is also what you can match against your \`mods/\`
+folder when something goes wrong.
+
+**Source links are resolved, not guessed.** packwiz records a project *id*, never a slug, so this
+script follows the id to whatever page it lands on and links that. It never assembles a URL out of a
+mod's name — twice now, a guessed slug in this repo has pointed at the wrong project entirely, once
+at a modpack rather than the mod.
+
+**Client / Server** tells you where a mod runs. If you are hosting a server, you need the
+${both.length} in *Both* and the ${server.length} in *Server only*; the ${client.length} client-only
+mods are not installed on a server and are not missing when they are absent.
+
+## อ่านตารางยังไง
+
+**คอลัมน์ File คือชื่อไฟล์ jar จริง ๆ** ไม่ใช่เลขเวอร์ชันที่จัดให้สวย ตั้งใจให้เป็นแบบนั้น เพราะมอด 99 ตัว
+ใช้รูปแบบการตั้งชื่อไฟล์ 99 แบบ การพยายามแกะเวอร์ชันออกมาคือการเดา ชื่อไฟล์คือสิ่งที่อยู่บนเครื่องคุณจริง ๆ
+ดังนั้นมันจึงเป็นสิ่งที่คุณเอาไปเทียบกับโฟลเดอร์ \`mods/\` ได้ตอนมีอะไรผิดพลาด
+
+**ลิงก์ต้นทาง resolve มา ไม่ได้เดา** packwiz บันทึก project *id* ไว้ ไม่เคยบันทึก slug
+สคริปต์นี้จึงตาม id ไปจนถึงหน้าที่มันไปจบแล้วลิงก์หน้านั้น มันไม่ประกอบ URL ขึ้นจากชื่อมอดเด็ดขาด —
+สอง​ครั้งแล้วที่ slug ที่เดาใน repo นี้ชี้ไปผิดโปรเจกต์ ครั้งหนึ่งชี้ไปที่ modpack แทนที่จะเป็นตัวมอด
+
+**Client / Server** บอกว่ามอดตัวนั้นทำงานฝั่งไหน ถ้าคุณจะเปิด server คุณต้องใช้ ${both.length} ตัวใน *Both*
+กับ ${server.length} ตัวใน *Server only* ส่วนมอดฝั่ง client ${client.length} ตัวจะไม่ถูกติดตั้งบน server
+และการที่มันไม่อยู่ตรงนั้นไม่ใช่ของหาย
+
+> **หมายเหตุ** ตารางด้านล่างมีชุดเดียว ไม่ได้ทำสองภาษา เพราะเนื้อในเป็นชื่อมอด ชื่อไฟล์ และ URL ซึ่งเป็น
+> ภาษาอังกฤษอยู่แล้วทั้งหมด หัวตารางเป็นสองภาษา
+
+---
+
+## Both — client and server · ทั้งสองฝั่ง (${both.length})
+
+${table(both)}
+
+## Client only · เฉพาะฝั่ง client (${client.length})
+
+Not installed on a server. \`docs/side-classification.md\` records the evidence for each call.
+
+ไม่ถูกติดตั้งบน server \`docs/side-classification.md\` บันทึกหลักฐานของการตัดสินแต่ละตัวไว้
+
+${table(client)}
+
+## Server only · เฉพาะฝั่ง server (${server.length})
+
+${table(server)}
+
+---
+
+## What this file does not tell you · สิ่งที่ไฟล์นี้ไม่ได้บอก
+
+**Licences.** Knowing where a mod came from is not the same as knowing what you may do with it.
+Check each project page before redistributing anything.
+
+**Dependencies between these mods.** packwiz records what is installed, not why. A mod in this list
+may be here only because another one requires it.
+
+**Which mods this pack modifies.** Recipes, spawn rules and balance are changed by this pack's own
+configs and scripts, not by the mod authors. \`docs/customization-map.md\` is that list.
+
+**สัญญาอนุญาต** การรู้ว่ามอดมาจากไหนไม่เท่ากับการรู้ว่าคุณทำอะไรกับมันได้บ้าง
+ตรวจหน้าโปรเจกต์ของแต่ละตัวก่อนแจกจ่ายต่อ
+
+**ความสัมพันธ์ระหว่างมอดในนี้** packwiz บันทึกว่าอะไรถูกติดตั้ง ไม่ได้บันทึกว่าทำไม
+มอดบางตัวในรายชื่อนี้อาจอยู่ที่นี่เพราะมอดอีกตัวต้องการมันเท่านั้น
+
+**มอดตัวไหนที่แพ็กนี้ไปแก้บ้าง** สูตรคราฟต์ กฎการเกิดของมอนสเตอร์ และสมดุลถูกเปลี่ยนโดย config
+และสคริปต์ของแพ็กนี้เอง ไม่ใช่โดยผู้เขียนมอด \`docs/customization-map.md\` คือรายชื่อนั้น
+`
+
+writeFileSync(OUT, doc)
+console.log(`\n✓ docs/MODLIST.md  (${metas.length} mods — ${both.length} both · ${client.length} client · ${server.length} server)`)
+if (unresolved.length) {
+  console.log(`  ${unresolved.length} source URL(s) unresolved — the id URL is in the file and still works in a browser`)
+}

--- a/scripts/build/lib/pack.mjs
+++ b/scripts/build/lib/pack.mjs
@@ -32,7 +32,34 @@ export function parseMeta(text) {
     mode: get('mode'),
     projectId: num('project-id'),
     fileId: num('file-id'),
+    // Modrinth's base62 project id. Present only on Modrinth-sourced metafiles,
+    // and the only stable handle we have to the project page — packwiz records
+    // no slug, which is exactly why the roster resolves ids instead of guessing.
+    modId: get('mod-id'),
   }
+}
+
+/** The roster digest, defined in exactly one place so the generator and the ship
+ *  gate cannot disagree about what "the same list" means.
+ *
+ *  Takes already-parsed metas rather than raw text: an earlier version re-derived
+ *  the fields with its own regexes, which is a second metafile parser living in
+ *  the file whose whole reason for existing is that a second copy drifts.
+ *
+ *  Sorted by metafile path, so a re-ordered directory listing is not a change.
+ *  Deliberately covers only locally-derivable facts — no resolved URLs — so the
+ *  gate that checks it never needs the network. */
+export function rosterDigest(entries) {
+  const rows = entries
+    .map(({ file, meta }) => [
+      file,
+      meta.name ?? '',
+      meta.filename ?? '',
+      meta.side ?? 'both',
+      meta.modId ?? meta.projectId ?? '',
+    ].join('\t'))
+    .sort()
+  return createHash('sha256').update(rows.join('\n')).digest('hex')
 }
 
 export function readPack(root) {

--- a/scripts/validate/verify.mjs
+++ b/scripts/validate/verify.mjs
@@ -44,6 +44,7 @@ import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs'
 import { execFileSync } from 'node:child_process'
 import { createHash } from 'node:crypto'
 import { join, relative, sep } from 'node:path'
+import { rosterDigest, parseMeta } from '../build/lib/pack.mjs'
 
 const ROOT = process.cwd()
 const SKIP_DIRS = new Set(['.git', 'node_modules', '.gradle', 'run', 'logs', 'crash-reports'])
@@ -285,6 +286,42 @@ function lintPackManifest() {
   return indexed
 }
 
+// -------------------------------------------------- lint: mod roster is fresh
+// `docs/MODLIST.md` is the only file a downloader reads to find out what they
+// just installed. If it disagrees with `mods/`, it is not merely out of date —
+// it is a false statement about the contents of an artifact somebody already
+// has on disk.
+//
+// The digest covers only what is derivable **locally**: name, filename, side,
+// and which project the metafile points at. Resolved URLs are deliberately
+// outside it, because this check must never need the network — a ship gate that
+// fails when CurseForge is slow is a gate people learn to bypass.
+function lintModlist() {
+  const metafiles = files.filter(f => f.startsWith('mods/') && f.endsWith('.pw.toml'))
+  if (!metafiles.length) return 0
+
+  const listPath = 'docs/MODLIST.md'
+  if (!existsSync(join(ROOT, listPath))) {
+    fail(listPath, `${metafiles.length} mods are installed and nothing tells a downloader what they are.\n  Run: node scripts/build/generate-modlist.mjs`)
+    return 0
+  }
+
+  const doc = readFileSync(join(ROOT, listPath), 'utf8')
+  const declared = doc.match(/<!--\s*roster-digest:\s*([0-9a-f]{64})\s*-->/)
+  if (!declared) {
+    fail(listPath, 'no `<!-- roster-digest: … -->` marker — the file cannot be checked against mods/, so it cannot be trusted.\n  Run: node scripts/build/generate-modlist.mjs')
+    return 0
+  }
+
+  const actual = rosterDigest(metafiles.map(f => ({
+    file: f, meta: parseMeta(readFileSync(join(ROOT, f), 'utf8')),
+  })))
+  if (declared[1] !== actual) {
+    fail(listPath, `stale — it describes a different set of mods than mods/ contains.\n  declared ${declared[1].slice(0, 12)}…, mods/ is ${actual.slice(0, 12)}…\n  Run: node scripts/build/generate-modlist.mjs`)
+  }
+  return metafiles.length
+}
+
 // ------------------------------------------------------- test: KubeJS syntax
 function testKubejs() {
   const targets = files.filter(f => f.startsWith('kubejs/') && f.endsWith('.js'))
@@ -309,6 +346,7 @@ if (phase === 'all' || phase === 'lint') {
   counts['files scanned for placeholders'] = lintPlaceholders()
   counts['KubeJS scripts scanned for orphaned recipes'] = lintJeiOrphans()
   counts['files in the packwiz index'] = lintPackManifest()
+  counts['mods in the shipped roster'] = lintModlist()
 }
 if (phase === 'all' || phase === 'test') {
   counts['KubeJS scripts'] = testKubejs()


### PR DESCRIPTION
## Summary

Nothing told a downloader what they had just installed. `INSTALL.md` covers *how* to install; 99
mods by dozens of authors shipped uncredited anywhere a player would look.

**`docs/MODLIST.md`** — all 99 mods, the exact jar filename of each, which side it runs on, and a
link to the page it came from. It ships at the **root of both the instance zip and the server zip**.

Generated from `mods/*.pw.toml` through the existing `lib/pack.mjs`, so the roster and the pack
cannot disagree about what is installed.

## Source URLs are resolved, never composed

packwiz records project **ids**, not slugs. A guessed slug has pointed at the wrong project twice in
this repo — `smoothplayeranimations` vs `smooth-player-animations`, and `create-industry`, which on
Modrinth is **a modpack, not TFMG** (ADR 0004). So the generator never assembles a URL from a name:

- **Modrinth** returns the slug as *data* from its documented API (`/v2/project/{id}`), along with
  `project_type` — which the URL path is built from rather than hardcoding `/mod/`, precisely
  because a metafile pointing at a non-mod project is the failure ADR 0004 recorded.
- **CurseForge** has no public API without a key, so the id URL's own redirect is followed and the
  **landing** URL recorded.

**99 of 99 resolved.** Zero rows fell back to an id URL.

## Three things the resolver learned the hard way

Each was measured, not anticipated:

| Symptom | Cause | Fix |
|---|---|---|
| A 78-second job ran past **10 minutes** | `fetch` has no default timeout, so one stalled socket parks a worker for as long as the OS holds it | every lookup bounded at 12 s |
| 4 retries × 40 mods resolved **nothing**, slowly | backoff is right for a *transient* block, wrong for a sustained one — Cloudflare had decided about this address | after 5 consecutive rate-limits CurseForge is treated as shut; the rest fall back at once |
| A re-run **downgraded** 12 rows that already had real links | regeneration was not monotonic | previously-resolved URLs are read back out of the file being replaced |

That last one matters most: a generator whose output gets *worse* when the network is bad is one
people stop running. First pass resolved 36/99, second 87/99, third 99/99 — because each run keeps
what the last one learned.

## The freshness gate

A roster that disagrees with `mods/` is not merely out of date — **it is a false statement about an
artifact somebody already has on disk**. `verify.mjs` refuses one.

The digest covers **only locally-derivable facts** — name, filename, side, project id. Resolved URLs
are deliberately outside it, because a ship gate that fails when CurseForge is slow is a gate people
learn to bypass.

**Falsified four ways before being trusted**, each observed failing and then passing again:

```
side "both" → "client"      ✗ stale — declared effcececefa9…, mods/ is 8f637eebd839…
name renamed                ✗ stale
a metafile removed          ✗ stale
digest marker deleted       ✗ no `<!-- roster-digest: … -->` marker
restored                    ✓ lint passed
```

## INSTALL.md was stale in a way that would have contradicted this on sight

It claimed **93 mods**, *"No balance work"*, and *"No KubeJS recipes, no quests, no custom
configs"* — all of which stopped being true during the customization run. Shipping a 99-mod roster
next to that would have been incoherent. Corrected in **both** language mirrors, and it now states
the limit plainly: everything is verified on a dedicated-server boot and **nothing is verified in a
running game**, plus the one known unfixed interaction (Improved Mobs cannot read Brimm's defence
values).

## What the CurseForge zip carries instead

`docs/` is in `.packwizignore`, so the roster cannot ride along in the CurseForge export. That
artifact carries packwiz's own `modlist.html` — **97 names** (the client-side set: 99 minus the two
server-only mods), with no versions, sides or links. `MODLIST.md` says so, so nobody has to work out
why the counts differ.

## `/simplify` — ran, two findings, both fixed

**The skill mandates four parallel sub-agents and this session's system prompt forbids spawning
any**, so the four angles (reuse · simplification · efficiency · altitude) were run inline instead.
Recorded here rather than left as a bare `simplify=ran`.

1. **`rosterDigest` re-implemented `parseMeta`'s field extraction** with its own regex pair — a
   second metafile parser inside the file whose own header says *"two copies of a hash check is the
   one duplication that actually matters here."* Now takes parsed metas.
2. **The Modrinth resolver computed a `project_type` label it never used.** Removed; the useful part
   (building the URL path from `project_type`) stayed and is now commented for why.

**The refactor is verified equivalent for free:** `MODLIST.md` was generated by the *old*
implementation, and `verify` — running the new one — still accepts its digest.

One finding was **skipped**: the roster-copy block is near-duplicated in both build scripts and
could move into `lib/pack.mjs`. That file's header states it is *"pure resolution … Nothing in this
file decides what an artifact looks like"*, and deciding what goes in a zip is exactly that. Eight
lines of duplication is cheaper than breaking the lib's stated contract.

## Testing

- `node scripts/validate/verify.mjs` — green, now covering **99 mods in the shipped roster**
- Both artifacts rebuilt and the roster confirmed present in each: instance 389 MB / 99 jars,
  server 332 MB / 89 jars
- `sha256sum -c SHA256SUMS.txt` — 3 of 3 OK

## What this does not do

**It does not audit licences.** Knowing where a mod came from is not knowing what you may do with
it. `MODLIST.md` says so in both languages rather than implying coverage it does not have.

**It does not record dependencies.** packwiz knows what is installed, not why. A mod in the list may
be there only because another one requires it.

Closes #50

---

## สรุปภาษาไทย

### สรุป

ไม่มีอะไรบอกคนที่โหลดไปว่าเขาเพิ่งติดตั้งอะไรลงไป `INSTALL.md` บอกแค่*วิธี*ติดตั้ง
ส่วนมอด 99 ตัวจากผู้เขียนหลายสิบคนถูกส่งไปโดยไม่มีเครดิตอยู่ในที่ที่ผู้เล่นจะเห็นเลย

**`docs/MODLIST.md`** — มอดครบทั้ง 99 ตัว ชื่อไฟล์ jar ที่แน่นอนของแต่ละตัว มันทำงานฝั่งไหน
และลิงก์ไปยังหน้าที่มันมา ไฟล์นี้อยู่ที่ **รากของทั้ง zip ตัว instance และ zip ตัว server**

สร้างจาก `mods/*.pw.toml` ผ่าน `lib/pack.mjs` ที่มีอยู่แล้ว รายชื่อกับ pack
จึงขัดแย้งกันเรื่องสิ่งที่ติดตั้งไม่ได้

### URL ต้นทาง resolve มา ไม่ได้ประกอบขึ้นเอง

packwiz บันทึก project **id** ไว้ ไม่ใช่ slug และ slug ที่เดาเคยชี้ไปผิดโปรเจกต์ใน repo นี้มาแล้วสองครั้ง —
`smoothplayeranimations` เทียบ `smooth-player-animations` และ `create-industry` ซึ่งบน Modrinth คือ
**modpack ไม่ใช่ TFMG** (ADR 0004) generator จึงไม่ประกอบ URL ขึ้นจากชื่อเด็ดขาด:

- **Modrinth** คืน slug มาเป็น*ข้อมูล*จาก API ที่มีเอกสาร (`/v2/project/{id}`) พร้อมกับ `project_type` —
  ซึ่ง path ของ URL ถูกสร้างจากค่านั้นแทนที่จะฮาร์ดโค้ด `/mod/` ไว้ ด้วยเหตุผลตรง ๆ ว่า metafile
  ที่ชี้ไปโปรเจกต์ที่ไม่ใช่มอดคือความล้มเหลวที่ ADR 0004 บันทึกไว้
- **CurseForge** ไม่มี API สาธารณะถ้าไม่มีคีย์ จึงตาม redirect ของ URL แบบ id เองแล้วบันทึก URL
  ที่มัน**ไปจบ**

**resolve ได้ 99 จาก 99** ไม่มีแถวไหนต้องถอยไปใช้ URL แบบ id เลย

### สามเรื่องที่ตัว resolver เรียนรู้แบบเจ็บตัว

แต่ละเรื่องมาจากการวัด ไม่ใช่การคาดเดา:

| อาการ | สาเหตุ | การแก้ |
|---|---|---|
| งาน 78 วินาทีลากยาวเกิน **10 นาที** | `fetch` ไม่มี timeout เริ่มต้น socket ที่ค้างตัวเดียวจอด worker ไว้นานเท่าที่ OS จะถือมันไว้ | จำกัดทุกการเรียกไว้ที่ 12 วิ |
| retry 4 ครั้ง × 40 มอด resolve ได้ **ศูนย์** แถมช้า | backoff เหมาะกับการบล็อกชั่วคราว ไม่เหมาะกับการบล็อกยาว — Cloudflare ตัดสินใจกับ IP นี้ไปแล้ว | เมื่อโดน rate-limit ติดกัน 5 ครั้ง ถือว่า CurseForge ปิด ที่เหลือ fallback ทันที |
| รันซ้ำแล้ว **ลดคุณภาพ** 12 แถวที่มีลิงก์จริงอยู่แล้ว | การสร้างใหม่ไม่ monotonic | อ่าน URL ที่เคย resolve ได้กลับออกมาจากไฟล์ที่กำลังจะเขียนทับ |

ข้อสุดท้ายสำคัญที่สุด: generator ที่ผลลัพธ์*แย่ลง*เมื่อเน็ตไม่ดีคือ generator ที่คนจะเลิกรัน
รอบแรก resolve ได้ 36/99 รอบสอง 87/99 รอบสาม 99/99 เพราะแต่ละรอบเก็บสิ่งที่รอบก่อนหน้าเรียนรู้ไว้

### ด่านตรวจความสด

รายชื่อที่ขัดแย้งกับ `mods/` ไม่ใช่แค่ข้อมูลเก่า — **มันคือคำกล่าวเท็จเกี่ยวกับ artifact
ที่ใครบางคนมีอยู่บนเครื่องแล้ว** `verify.mjs` ปฏิเสธมัน

digest ครอบคลุม**เฉพาะข้อเท็จจริงที่หาได้ในเครื่อง** — ชื่อ ชื่อไฟล์ side project id
URL ที่ resolve แล้วถูกกันออกโดยตั้งใจ เพราะด่านตรวจที่ fail เวลา CurseForge ช้าคือด่านที่คนจะเรียนรู้ที่จะข้าม

**Falsify มาสี่แบบก่อนจะเชื่อถือ** แต่ละแบบเห็นมัน fail แล้วกลับมาผ่านอีกครั้ง:

```
side "both" → "client"      ✗ stale — declared effcececefa9…, mods/ is 8f637eebd839…
เปลี่ยนชื่อ                   ✗ stale
ลบ metafile ออกหนึ่งไฟล์        ✗ stale
ลบ digest marker             ✗ no `<!-- roster-digest: … -->` marker
คืนค่าเดิม                    ✓ lint passed
```

### INSTALL.md ค้างในแบบที่จะขัดกับรายชื่อใหม่ทันทีที่เห็น

มันเขียนว่า **93 มอด**, *"ยังไม่มีงาน balance เลย"* และ *"ยังไม่มี KubeJS recipe ไม่มี quest
ไม่มี config ที่ปรับเอง"* — ซึ่งทั้งหมดเลิกเป็นจริงไปแล้วระหว่างรอบ customization
การส่งรายชื่อ 99 มอดไปวางข้าง ๆ ข้อความนั้นคือความไม่สอดคล้องกันในตัวเอง แก้แล้วใน**ทั้งสอง**ภาษา
และตอนนี้มันบอกขีดจำกัดตรง ๆ ว่าทุกอย่างตรวจสอบบน dedicated server และ**ไม่มีอะไรตรวจสอบในเกมจริง**
บวกกับ interaction ที่รู้แล้วและยังไม่ได้แก้หนึ่งข้อ (Improved Mobs อ่านค่าป้องกันของ Brimm ไม่ได้)

### zip แบบ CurseForge มีอะไรแทน

`docs/` อยู่ใน `.packwizignore` รายชื่อจึงติดไปกับ CurseForge export ไม่ได้ artifact ตัวนั้นมี
`modlist.html` ของ packwiz เอง — **97 ชื่อ** (ชุดฝั่ง client: 99 ลบมอดฝั่ง server สองตัว)
โดยไม่มีเวอร์ชัน ไม่มี side ไม่มีลิงก์ `MODLIST.md` เขียนเรื่องนี้ไว้ จะได้ไม่มีใครต้องมานั่งงงว่าทำไมตัวเลขไม่ตรงกัน

### `/simplify` — รันแล้ว เจอสองข้อ แก้ทั้งสองข้อ

**สกิลบังคับให้ใช้ sub-agent แบบขนานสี่ตัว และ system prompt ของเซสชันนี้ห้ามสร้าง sub-agent**
ผมจึงรันทั้งสี่มุม (reuse · simplification · efficiency · altitude) แบบ inline แทน
บันทึกไว้ตรงนี้แทนที่จะปล่อยเป็น `simplify=ran` เปล่า ๆ

1. **`rosterDigest` เขียนการแกะฟิลด์ของ `parseMeta` ขึ้นมาใหม่**ด้วย regex ของตัวเอง — เป็น parser
   ของ metafile ตัวที่สองอยู่ในไฟล์ที่หัวไฟล์เขียนเองว่า *"การมี hash check สองชุดคือความซ้ำซ้อน
   ชนิดเดียวที่สำคัญจริงตรงนี้"* ตอนนี้มันรับ meta ที่ parse แล้ว
2. **ตัว resolver ของ Modrinth คำนวณป้าย `project_type` ที่ไม่เคยถูกใช้** ลบออก
   ส่วนที่มีประโยชน์ (การสร้าง path ของ URL จาก `project_type`) ยังอยู่ และตอนนี้มีคอมเมนต์บอกเหตุผลแล้ว

**การ refactor ถูกยืนยันว่าให้ผลเท่าเดิมโดยไม่ต้องทำอะไรเพิ่ม:** `MODLIST.md` ถูกสร้างด้วย
implementation *เก่า* และ `verify` ที่รัน implementation ใหม่ก็ยังรับ digest ของมัน

มีข้อที่ **ข้าม** หนึ่งข้อ: บล็อกที่คัดลอกรายชื่อไปใส่ artifact เกือบซ้ำกันในสคริปต์ build ทั้งสองตัว
และย้ายเข้า `lib/pack.mjs` ได้ แต่หัวไฟล์นั้นเขียนไว้ว่ามันคือ *"pure resolution …
ไม่มีอะไรในไฟล์นี้ตัดสินว่า artifact หน้าตาเป็นยังไง"* และการตัดสินว่าอะไรอยู่ใน zip คือสิ่งนั้นพอดี
ความซ้ำแปดบรรทัดถูกกว่าการทำลายสัญญาที่ lib ประกาศไว้เอง

### การทดสอบ

- `node scripts/validate/verify.mjs` — เขียว ตอนนี้ครอบคลุม **99 mods in the shipped roster** ด้วย
- rebuild artifact ทั้งสองตัวและยืนยันว่ารายชื่ออยู่ในนั้นจริง: instance 389 MB / 99 jar,
  server 332 MB / 89 jar
- `sha256sum -c SHA256SUMS.txt` — ผ่าน 3 จาก 3

### สิ่งที่ PR นี้ไม่ได้ทำ

**มันไม่ได้ตรวจสัญญาอนุญาต** การรู้ว่ามอดมาจากไหนไม่เท่ากับการรู้ว่าคุณทำอะไรกับมันได้
`MODLIST.md` เขียนเรื่องนี้ไว้ทั้งสองภาษา แทนที่จะทำเป็นว่ามันครอบคลุมสิ่งที่มันไม่ได้ครอบคลุม

**มันไม่ได้บันทึกความสัมพันธ์ระหว่างมอด** packwiz รู้ว่าอะไรถูกติดตั้ง ไม่รู้ว่าทำไม
มอดบางตัวในรายชื่ออาจอยู่ตรงนั้นเพราะมอดอีกตัวต้องการมันเท่านั้น

Closes #50
