### PR TITLE
feat(pack-infra): register the Visuals Spec and run its V0 reference audit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ The design document is the source of truth for intent:
 **`docs/Industrial Civilization Survival — Claude Code Handoff & Implementation Plan.md`**
 (read it before any pack work; unqualified `§N` references throughout this repo are to it).
 
-Five further specs layer on top of it. All share the same platform constraints and the same
+Six further specs layer on top of it. All share the same platform constraints and the same
 design rules, and each numbers its own sections — **cite them by name, never as a bare `§N`**:
 
 | Document | What it governs | Cite as |
@@ -29,6 +29,7 @@ design rules, and each numbers its own sections — **cite them by name, never a
 | `docs/Addon Modpack — Distribution & Updates.md` | **Release engineering, not content.** Source of truth, what counts as the pack, versioning, the release gate, branching, changelog, friend installation and updates | *Distribution Spec §N* |
 | `docs/Addon Performance — Optimization & Profiling.md` | The performance stack and the benchmark method. §2 is the approved Core stack; §3 Experimental stays out until each mod has its own benchmark branch | *Performance Spec §N* |
 | `docs/Addon Spec — Animation & Movement Layer.md` | Animation ownership, movement feel, first-person camera, and per-mod compatibility. §3 rejects **AMF: Better Movement** outright — do not re-propose without explicit direction | *Animation Spec §N* |
+| `docs/Addon Spec —  Khaojee Enchanted Visuals Integration.md` | The Vanilla+ visual layer adapted from a reference modpack — grass, biome blending, particles, weather, connected textures, world-block animation. Carries its own phase list, V0–V10. §22 forbids a **required** shader | *Visuals Spec §N* |
 
 The Distribution Spec is the one that constrains **this repository's own process**, not the game.
 Its §22 branching model and §16 release gate govern how work ships; see `docs/agents/workflow.md`.
@@ -177,9 +178,12 @@ docs/
   Addon Spec — Crafting Assistance ….md      JEI / Jade / tactical tracker
   Addon Spec — Natural Wildlife ….md         Naturalist / Critters / Ecologics, phases W0–W9
   Addon Modpack — Distribution & Updates.md  release engineering — governs THIS repo's process
+  Addon Spec —  Khaojee Enchanted ….md      the Vanilla+ visual layer, phases V0–V10
   OPEN-WORK-LEDGER.md         open work, tracked and untracked — read at session start
   MODLIST.md                  GENERATED — the roster a downloader reads. Ships inside both
                               artifacts. `verify` refuses one that disagrees with mods/
+  khaojee-visual-reference.md the Visuals Spec §36 source-tracking table — V0 audit results,
+                              every version and licence measured, not recalled
   customization-map.md        WHAT STILL HAS TO BE BUILT — the 22 mods the design docs
                               tag for custom work, with their concrete targets
   compatibility-matrix.md     what has been OBSERVED — versions, sources, boot results

--- a/docs/Addon Spec —  Khaojee Enchanted Visuals Integration.md
+++ b/docs/Addon Spec —  Khaojee Enchanted Visuals Integration.md
@@ -1,0 +1,1106 @@
+# Addon Spec — Khaojee Enchanted Visuals Integration
+## Claude Code CLI Implementation Handoff
+
+> **Project:** Industrial Civilization Survival  
+> **Repository:** `xenodeve/minecraft-100day`  
+> **Platform:** Minecraft 1.20.1 / Forge / Java 17  
+> **Reference Video:** https://youtu.be/cxahj-PuLb0  
+> **Reference Modpack:** https://modrinth.com/modpack/khaojee-enchanted-visuals  
+> **Goal:** Adapt the strongest Vanilla+ visual ideas from Khaojee Enchanted Visuals without changing platform, breaking combat readability, duplicating existing systems, or turning the pack into a shader showcase.
+
+---
+
+# 1. Core Philosophy
+
+Reference principle:
+
+> Make Minecraft look better without losing Minecraft's charm.
+
+Our version:
+
+```text
+Vanilla identity
++ environmental detail
++ smoother animation
++ better weather
++ richer particles
++ connected surfaces
++ industrial/tactical world
+= Minecraft still looks like Minecraft
+```
+
+Default visuals must remain comfortable for long 100–300+ day multiplayer sessions.
+
+---
+
+# 2. Integration Strategy
+
+Do **not** import the reference `.mrpack` directly.
+
+Our hard constraints remain:
+
+```text
+Minecraft 1.20.1
+Forge
+Java 17
+```
+
+Each reference component must be classified as:
+
+```text
+ADOPT
+ADOPT WITH REPLACEMENT
+PROTOTYPE
+OPTIONAL PROFILE
+ALREADY COVERED
+REJECT
+```
+
+---
+
+# 3. Reference Inventory
+
+## Terrain / Biomes
+- Grassier Grass
+- Biomes O' Plenty
+- Regions Unexplored
+- Better Biome Reblend
+- Pufferfish's Biome Dither
+- Countered's Terrain Slabs
+
+## Textures / Decoration
+- Continuity
+- Connected Paths
+- Connected Texture+
+- Soft Imprints
+- Musgo
+- Lushier Forests
+- 3D World Decorations
+- Rainbow's Foliage
+- Polytone
+
+## Particles / Atmosphere
+- Wakes
+- Particular
+- Subtle Effects
+- Particle Rain
+- Particle Interactions
+
+## Animation
+- EMF
+- ETF
+- Fresh Animations
+- Fresh Animations: Player Extension
+- Just Expressions
+- Fancy World Animations
+- Tree Physics
+- Punchy
+
+## Extra
+- Item Interactions
+- Client Backpack
+
+## Sound
+- AmbientSounds
+- Auditory Continued
+- Sound Physics Remastered
+- Presence Footsteps
+
+---
+
+# 4. Initial Decisions
+
+## Adopt / Strong Candidate
+
+```text
+Grassier Grass
+Better Biome Blend / equivalent
+Soft Imprints
+Subtle Effects
+Particle Rain
+Fancy World Animations
+Fusion (Forge-native connected-texture solution)
+```
+
+## Selective / Optional
+
+```text
+EMF
+ETF
+Fresh Animations
+```
+
+Governed by the separate Animation & Movement Spec.
+
+## Prototype
+
+```text
+Biomes O' Plenty
+Regions Unexplored
+Countered's Terrain Slabs
+3D World Decorations
+Musgo
+Lushier Forests
+Polytone / foliage enhancements
+Particle Interactions
+```
+
+## Already Covered
+
+```text
+AmbientSounds
+Sound Physics Remastered
+```
+
+## Reject / Defer for Current Platform
+
+```text
+Wakes
+Particular
+Tree Physics
+Item Interactions
+Presence Footsteps
+Auditory Continued
+```
+
+Do not add Fabric compatibility infrastructure solely to reproduce these visuals.
+
+---
+
+# 5. Grassier Grass
+
+**Status:** CORE VISUAL CANDIDATE
+
+Purpose:
+
+```text
+flat grass
+→ denser
+→ more natural
+→ more alive
+```
+
+Must preserve Vanilla readability.
+
+Test with:
+- Embeddium
+- Entity Culling
+- ImmediatelyFast
+- Serene Seasons
+- Naturalist
+- Ecologics
+- MineColonies
+- Create
+
+Measure FPS, frame time and seasonal color behavior.
+
+---
+
+# 6. Better Biome Blend
+
+**Status:** CORE VISUAL CANDIDATE
+
+Smooth visual transitions between:
+- grass
+- leaves
+- water
+
+High-value situations:
+- train travel
+- city borders
+- outposts
+- long-distance exploration
+- future aviation
+
+It must not change biome logic, spawning or worldgen.
+
+---
+
+# 7. Soft Imprints
+
+**Status:** CORE VISUAL CANDIDATE
+
+Adds environmental traces such as footprints in:
+- snow
+- sand
+- red sand
+
+Useful for tactical atmosphere and wildlife ambience.
+
+Performance requirements:
+- bounded lifetime
+- bounded density
+- bounded distance where configurable
+
+Do not allow persistent mark spam around colonies, farms or Horde battlefields.
+
+---
+
+# 8. Subtle Effects
+
+**Status:** CORE VISUAL CANDIDATE
+
+Desired effects:
+- sparks
+- smoke
+- fire feedback
+- block particles
+- entity feedback
+- low-health effects where tasteful
+
+Rule:
+
+> More feedback, not more noise.
+
+Combat visibility must remain clear during TaCZ fights.
+
+---
+
+# 9. Particle Rain
+
+**Status:** CORE / WEATHER CANDIDATE
+
+Improves:
+- rain
+- snow
+- wind feel
+- atmospheric weather particles
+
+Complements:
+- Serene Seasons
+- AmbientSounds
+- Sound Physics Remastered
+
+Mandatory stress test:
+
+```text
+Heavy rain
++ Horde
++ TaCZ automatic fire
++ Create factory
++ MineColonies
+```
+
+Keep only if frame-time and visibility remain acceptable.
+
+---
+
+# 10. Fancy World Animations
+
+**Status:** CORE ANIMATION CANDIDATE
+
+Target:
+- doors
+- trapdoors
+- gates
+- buttons
+- levers
+- chests
+- lanterns
+- chains
+- supported world blocks
+
+Animation architecture becomes:
+
+```text
+Player → Smooth Player Animations + NEA
+Vanilla mobs → BAC / selective Fresh Animations
+Modded mobs → native animations
+Position interpolation → Smooth Movement
+World blocks → Fancy World Animations
+```
+
+High-value locations:
+- factories
+- bunkers
+- control rooms
+- stations
+- warehouses
+- refineries
+- command centers
+
+---
+
+# 11. Fresh Animations
+
+**Status:** SELECTIVE / OPTIONAL
+
+Use through:
+
+```text
+EMF
++
+ETF
++
+Fresh Animations
+```
+
+Hard rule:
+
+> Fresh Animations does not become the default global owner.
+
+Use it only for Vanilla entities selected in `docs/animation-coverage.md`.
+
+Fresh Animations: Player Extension remains **OFF initially** because Player ownership already belongs to:
+
+```text
+Smooth Player Animations
++
+Not Enough Animations
+```
+
+---
+
+# 12. Connected Textures
+
+Reference pack uses Continuity and related texture packs.
+
+Our policy:
+
+```text
+Do not add Fabric compatibility infrastructure only for Continuity.
+```
+
+Preferred route:
+
+```text
+Fusion
++
+compatible connected-texture resource pack
+```
+
+Use cases:
+- factory glass
+- control rooms
+- station windows
+- industrial walls
+- greenhouses
+- urban architecture
+
+Test dense builds with Embeddium and ImmediatelyFast.
+
+---
+
+# 13. Biomes O' Plenty
+
+**Status:** PROTOTYPE
+
+This is not merely visual.
+
+It affects:
+- world geography
+- travel distance
+- oil-field search
+- dragon territory
+- rail planning
+- wildlife distribution
+- settlement locations
+
+Do not merge automatically.
+
+---
+
+# 14. Regions Unexplored
+
+**Status:** PROTOTYPE
+
+Same worldgen concerns as BOP.
+
+Worldgen evaluation must compare:
+
+```text
+A. Current pack
+B. + BOP
+C. + Regions Unexplored
+D. + Both
+```
+
+Default bias:
+
+> Prefer one biome expansion unless testing proves both are worth the cost.
+
+Avoid kitchen-sink geography.
+
+---
+
+# 15. Worldgen Test Criteria
+
+Across multiple seeds evaluate:
+- spawn safety
+- settlement locations
+- oil access
+- dragon worldgen
+- rail corridors
+- biome readability
+- world size
+- generation time
+- wildlife distribution
+
+Do not decide from one seed.
+
+---
+
+# 16. Countered's Terrain Slabs
+
+**Status:** PROTOTYPE
+
+Potential compatibility risks:
+- MineColonies pathfinding
+- player movement
+- rail construction
+- Create contraptions
+- mob navigation
+- future vehicles
+
+Visual improvement alone does not justify gameplay regressions.
+
+---
+
+# 17. 3D World Decorations
+
+**Status:** PROTOTYPE
+
+Evaluate:
+- model density
+- GPU cost
+- visual clutter
+- Horde visibility
+- city FPS
+
+Do not sacrifice tactical readability for decoration.
+
+---
+
+# 18. Musgo / Lushier Forests / Foliage
+
+**Status:** PROTOTYPE / OPTIONAL
+
+Goal:
+
+```text
+better forests
+without
+visual clutter
+or
+target visibility problems
+```
+
+A foliage mod fails if it makes TaCZ combat frustrating.
+
+---
+
+# 19. Polytone / Color Layer
+
+**Status:** PROTOTYPE
+
+Only keep if it:
+- improves atmosphere
+- works with Serene Seasons
+- does not create platform compromise
+- does not conflict with biome blending/resource packs
+
+---
+
+# 20. Platform-Mismatch Components
+
+Current default decision:
+
+```text
+Wakes → REJECT/DEFER
+Particular → REJECT/DEFER
+Tree Physics → REJECT/DEFER
+Item Interactions → REJECT/DEFER
+Presence Footsteps → REJECT/DEFER
+Auditory Continued → REJECT/DEFER
+```
+
+Reason:
+
+> Compatibility cost is greater than the unique value they currently add.
+
+Do not use a compatibility bridge unless a future requirement justifies it at architecture level.
+
+---
+
+# 21. Sound Stack
+
+Already owned by:
+
+```text
+AmbientSounds
+Sound Physics Remastered
+Simple Voice Chat
+Simple Voice Radio
+```
+
+Do not duplicate AmbientSounds or Sound Physics.
+
+---
+
+# 22. Shader Policy
+
+Default pack:
+
+```text
+NO REQUIRED SHADER
+```
+
+Reason:
+- 3–4 players may have different GPUs
+- Hordes are render-heavy
+- Create cities are render-heavy
+- combat readability matters
+
+Shaders may be:
+
+```text
+OPTIONAL CINEMATIC PROFILE
+```
+
+Never required for multiplayer.
+
+---
+
+# 23. Visual Profiles
+
+## Standard
+
+```text
+Grassier Grass
+Better Biome Blend
+Soft Imprints
+Subtle Effects
+Particle Rain
+Fancy World Animations
+Fusion
+SPA + NEA + BAC + Smooth Movement
+```
+
+## Enhanced
+
+```text
+Standard
++
+EMF
+ETF
+Selective Fresh Animations
+approved extra foliage
+```
+
+## Cinematic Optional
+
+```text
+Enhanced
++
+user-selected shader
+```
+
+Gameplay behavior must remain identical between profiles.
+
+---
+
+# 24. Performance Philosophy
+
+Optimize for:
+
+```text
+frame-time stability
+1% lows
+combat readability
+Horde performance
+```
+
+not maximum screenshot quality.
+
+The visual layer must be tested with:
+
+```text
+Embeddium
+ModernFix
+FerriteCore
+Entity Culling
+ImmediatelyFast
+ServerCore
+```
+
+---
+
+# 25. Benchmark Scene A — Natural World
+
+Scene:
+
+```text
+forest
+grass
+wildlife
+weather
+```
+
+Measure:
+- average FPS
+- 1% low
+- frame time
+- GPU usage
+- VRAM
+- RAM
+
+---
+
+# 26. Benchmark Scene B — Main City
+
+Scene:
+
+```text
+MineColonies
+street lights
+factories
+connected textures
+Fancy World Animations
+players
+```
+
+This is a realistic sustained-load scene.
+
+---
+
+# 27. Benchmark Scene C — Horde in Rain
+
+Mandatory stress test:
+
+```text
+100+ hostiles
+Particle Rain
+Subtle Effects
+TaCZ gunfire
+muzzle effects
+entity animation
+```
+
+Reject or tune any component that causes severe frame-time instability.
+
+---
+
+# 28. Benchmark Scene D — Rail Travel
+
+Use:
+- Create train
+- multiple biomes
+- weather
+- biome blending
+- foliage
+
+Look for:
+- chunk stutter
+- color transition artifacts
+- weather hitching
+
+---
+
+# 29. Benchmark Scene E — Night Tactical Operation
+
+Use:
+- flashlight
+- weapon light
+- NVG
+- dynamic light
+- forest
+- rain
+- particles
+
+Ensure target visibility remains good.
+
+---
+
+# 30. Visual Density Budget
+
+If performance is insufficient, reduce in this order:
+
+```text
+1. extra particles
+2. decorative 3D elements
+3. dense foliage
+4. optional Fresh Animations coverage
+5. weather particle density
+```
+
+Do not first cut core gameplay systems.
+
+---
+
+# 31. Particle Budget
+
+Combined particle load includes:
+
+```text
+TaCZ muzzle effects
+TaCZ tracers
+Subtle Effects
+Particle Rain
+Create processing
+fire
+explosions
+Horde combat
+CBC later
+```
+
+Benchmark the stack as a whole.
+
+---
+
+# 32. Weather Visibility Rule
+
+Rain/snow must never make:
+- ADS unreadable
+- NVG unusable
+- Horde silhouettes invisible
+
+Reduce density if necessary.
+
+---
+
+# 33. Worldgen Lock Rule
+
+Do not casually add/remove major biome mods after the persistent multiplayer world begins.
+
+Worldgen decisions should be finalized before long-term play where practical.
+
+---
+
+# 34. Multiplayer Target
+
+Balance visual testing around:
+
+```text
+3 players = baseline team
+4 players = full team
+```
+
+Benchmark:
+- city
+- rain
+- Horde
+- train
+- forest
+- gunfight
+
+---
+
+# 35. Redistribution / Licensing
+
+Before shipping:
+- verify license
+- verify redistribution permission
+- record attribution
+- record resource-pack conditions
+
+Especially inspect:
+- Fresh Animations
+- connected texture packs
+- decorative resource packs
+
+Update:
+
+```text
+docs/distribution-licenses.md
+```
+
+---
+
+# 36. Source Tracking
+
+Create:
+
+```text
+docs/khaojee-visual-reference.md
+```
+
+Recommended columns:
+
+```text
+Reference Project
+Our Choice
+Version
+Platform
+Status
+Reason
+License
+```
+
+---
+
+# 37. Implementation Phases
+
+## V0 — Reference Audit
+
+Verify each selected project:
+- exact Forge 1.20.1 build
+- dependencies
+- client/server side
+- license
+
+## V1 — Safe Visual Baseline
+
+Add:
+```text
+Grassier Grass
+Better Biome Blend
+Soft Imprints
+Subtle Effects
+Fancy World Animations
+```
+
+Do not add worldgen expansion in the same phase.
+
+## V2 — Weather
+
+Add:
+```text
+Particle Rain
+```
+
+Test with Serene Seasons + TaCZ + Horde.
+
+## V3 — Connected Textures
+
+Evaluate:
+```text
+Fusion
+```
+
+Test dense industrial builds.
+
+## V4 — Animation Integration
+
+Follow Animation & Movement Spec:
+```text
+EMF
+ETF
+Selective Fresh Animations
+```
+
+No Player Extension initially.
+
+## V5 — Decorative Prototypes
+
+Test separately:
+```text
+3D World Decorations
+Musgo
+Lushier Forests
+Polytone-based foliage
+Particle Interactions
+```
+
+## V6 — Worldgen Branch A
+
+Test:
+```text
+Biomes O' Plenty
+```
+
+## V7 — Worldgen Branch B
+
+Test:
+```text
+Regions Unexplored
+```
+
+## V8 — Worldgen Comparison
+
+Compare:
+```text
+Base
+BOP
+RU
+BOP + RU
+```
+
+## V9 — Multiplayer Benchmark
+
+Test 3–4 players in representative scenarios.
+
+## V10 — Final Visual Profiles
+
+Define:
+```text
+Standard
+Enhanced
+Cinematic Optional
+```
+
+---
+
+# 38. Definition of Done — Standard Visual Layer
+
+Ready when:
+
+- Minecraft still looks unmistakably like Minecraft.
+- No shader is required.
+- No unnecessary Fabric compatibility bridge exists.
+- Grass / biome / environmental improvements work.
+- Weather remains combat-readable.
+- Fancy World Animations does not break interaction.
+- Particle load is acceptable during Horde combat.
+- TaCZ / NVG / flashlight remain readable.
+- FPS/frame-time are acceptable.
+- Licenses are documented.
+- Exact versions are pinned.
+- Clean client boot succeeds.
+
+---
+
+# 39. Definition of Done — Worldgen Layer
+
+Ready only when:
+
+- multiple seeds are tested
+- Ice & Fire worldgen works
+- oil/resource geography remains practical
+- settlement sites remain available
+- rail construction remains reasonable
+- world generation performance is measured
+- persistent-world decision is documented
+
+---
+
+# 40. Failure Conditions
+
+Reject or reduce a component if it causes:
+
+```text
+combat visibility loss
+motion sickness
+severe FPS regression
+worldgen incompatibility
+MineColonies pathfinding problems
+Create interaction bugs
+NVG readability problems
+particle overload
+model corruption
+license uncertainty
+```
+
+---
+
+# 41. Claude Code Hard Rules
+
+## DO
+
+1. Treat Khaojee Enchanted Visuals as a reference, not a dependency.
+2. Preserve Minecraft's art direction.
+3. Prefer native Forge 1.20.1 solutions.
+4. Prefer Fusion over adding a Fabric bridge only for Continuity.
+5. Test particles under real combat load.
+6. Test visual mods with the performance stack.
+7. Keep Fresh Animations selective.
+8. Keep Player animation under SPA + NEA.
+9. Prototype biome mods separately.
+10. Benchmark 3–4 player scenarios.
+11. Protect tactical readability.
+12. Document licensing.
+13. Pin exact versions.
+14. Keep shaders optional.
+
+## DO NOT
+
+1. Do not import the whole reference modpack.
+2. Do not change Minecraft version or loader.
+3. Do not add Fabric Connector solely for visuals.
+4. Do not install BOP + RU automatically.
+5. Do not duplicate AmbientSounds or Sound Physics.
+6. Do not enable Fresh Animations Player Extension by default.
+7. Do not stack particles without profiling.
+8. Do not let foliage block targets.
+9. Do not make shaders mandatory.
+10. Do not casually change worldgen after persistent play starts.
+11. Do not claim compatibility without launch testing.
+
+---
+
+# 42. Recommended Initial Adoption Set
+
+```text
+Grassier Grass
+Better Biome Blend
+Soft Imprints
+Subtle Effects
+Particle Rain
+Fancy World Animations
+Fusion
+```
+
+Animation integration:
+
+```text
+EMF
+ETF
+Fresh Animations
+```
+
+only where approved by the Animation Coverage Matrix.
+
+---
+
+# 43. Prototype Set
+
+```text
+Biomes O' Plenty
+Regions Unexplored
+Countered's Terrain Slabs
+3D World Decorations
+Musgo
+Lushier Forests
+Polytone / foliage enhancements
+Particle Interactions
+```
+
+---
+
+# 44. Rejected / Deferred Set
+
+```text
+Wakes
+Particular
+Tree Physics
+Item Interactions
+Presence Footsteps
+Auditory Continued
+```
+
+---
+
+# 45. Final Architecture
+
+```text
+               INDUSTRIAL CIVILIZATION SURVIVAL
+                          │
+                          ▼
+                 Vanilla Visual Identity
+                          │
+        ┌─────────────────┼─────────────────┐
+        │                 │                 │
+        ▼                 ▼                 ▼
+   ENVIRONMENT         ANIMATION         ATMOSPHERE
+        │                 │                 │
+Grassier Grass      SPA + NEA         Subtle Effects
+Biome Blend         BAC / FA          Particle Rain
+Soft Imprints       Smooth Move       AmbientSounds
+Fusion              Fancy World       Sound Physics
+        │                 │                 │
+        └─────────────────┼─────────────────┘
+                          ▼
+                  Performance Layer
+                          │
+                          ▼
+                 3–4 Player Multiplayer
+```
+
+---
+
+# 46. Final Feature Definition
+
+> **Khaojee Enchanted Visuals Integration adapts the strongest Vanilla+ visual ideas from the reference pack to Industrial Civilization Survival's Forge 1.20.1 architecture. The goal is not to copy Khaojee exactly, but to make the world greener, smoother, more atmospheric and more alive while keeping combat readable, performance stable and Minecraft instantly recognizable.**
+
+Guiding sentence:
+
+> **Minecraft, but every part of the world feels a little more alive — without becoming a different game.**

--- a/docs/OPEN-WORK-LEDGER.md
+++ b/docs/OPEN-WORK-LEDGER.md
@@ -27,17 +27,18 @@ population (W3/W6/W7), the Brimm-vs-TakKit comparison (§15), the JEI active-rec
 Spec §5) and the twelve-test release gate (Distribution Spec §16) are all **measurements**, and a
 dedicated server cannot produce any of them.
 
-**Three rows need no client, and none of the three is actionable today** — which is a different
-statement from *"everything left needs a client"*, and the difference is the point. Search the table
-for 🟡 and check it:
+**Four rows need no client, and one of them is actionable right now.** That is a different
+statement from *"everything left needs a client"*, and the difference is the point:
 
 | Row | What it actually waits on |
 |---|---|
+| **Redistribution licences (#53)** | **nothing — hand-reading 40 CurseForge project pages** |
 | The three Player Microchip textures (**#35**) | an **artist** |
 | Re-add `cbc_firepower_components` | an **upstream release** supporting CBC ≥ 5.9 |
 | Re-evaluate `TaCZ: Accelerated` | a **benchmark baseline** — which does need a client to profile with |
 
-A fourth, the **Season 2 viability sweep**, needed neither and is now done — ADR 0004 (#44).
+Two more needed neither and are now done: the **Season 2 viability sweep** (ADR 0004, #44) and the
+**Visuals V0 reference audit** (#52).
 
 **Why this is spelled out rather than summarised.** An earlier version of this paragraph claimed
 *everything* left was downstream of a client launch. That was false when it was written: seven Track
@@ -85,6 +86,15 @@ tier — is now a decided operating mode rather than a pending task, which is wh
 | **Phase 2 — combat baseline, `docs/combat-baseline.md` TTK matrix** | 🟡 | the **gun side is done**; the mob side needs a client | `docs/combat-baseline.md` exists with all 54 guns and 84 Born in Chaos entities read from bytecode. What is missing is *measured* mob HP, and `DamageBaseMultiplier` stays 1.0 until it exists (**#30**, **#33**) |
 | **All 22 mods tagged for custom work** | ✅ | — | **20 implemented, 3 declined with reasons, 2 parked with named blockers.** `docs/customization-map.md` is now a status report rather than a plan (**#21**, **#27**–**#36**) |
 | Phases 3–12 | ✅ | — | Threat director **#27** · Sound **#28** · Consumption economy **#31** · Horde **#29** · Civilization **#33** · Dragon frontier **#33** · Tactical gear **#30** · City infrastructure **#32** · Quest campaign **#36** |
+| **Visuals V0** — reference audit | ✅ | — | **#52**. `docs/khaojee-visual-reference.md` — 24 projects swept by title, versions and licences read from the Modrinth API. Six of the seven adoption-set mods have real Forge 1.20.1 builds |
+| **Visuals V1** — safe visual baseline | 🔴 | **needs a client** | Visuals Spec §37. Grassier Grass · Better Biome Blend · Soft Imprints · Subtle Effects (needs **Fzzy Config**) · Fancy World Animations. §38's done-criteria are all measurements: FPS, 1% lows, combat readability |
+| **Visuals V2** — weather | 🔴 | needs V1 and a client | Visuals Spec §9. Particle Rain, stress-tested against §32's rule that rain must never make ADS or NVG unreadable |
+| **Visuals V3** — connected textures | 🔴 | needs a client | Visuals Spec §12. Fusion is Forge-native, so §41's no-Fabric-bridge rule costs nothing. Test dense industrial builds |
+| **Visuals V4** — selective Fresh Animations | 🔴 | needs `docs/animation-coverage.md`, which needs a client | Visuals Spec §11 via the Animation Spec. EMF + ETF are Forge mods; **Fresh Animations is a resource pack**. Player Extension stays OFF |
+| **Visuals V5–V8** — decorative and worldgen prototypes | 🔴 | needs a client, and §33 wants worldgen settled before persistent play | BOP and Regions Unexplored both need **TerraBlender** (absent). §15 requires multiple seeds. Particle Interactions has **no 1.20.1 build** and should move to §44 |
+| **Visuals V9–V10** — multiplayer benchmark, visual profiles | 🔴 | needs 3–4 players | Visuals Spec §34. Standard / Enhanced / Cinematic Optional |
+| `docs/animation-coverage.md` | 🔴 | needs a client | Visuals Spec §11 and the Animation Spec both cite it and it does not exist. Decides which vanilla entities Fresh Animations may own |
+| **Redistribution licences** — `docs/distribution-licenses.md` | 🔴 **UNTRACKED risk, now tracked** | needs hand-reading 40 CurseForge project pages | **#53**. The pack ships 99 jars self-contained and has never checked whether it may. 21 of 59 Modrinth mods are All-Rights-Reserved or custom; 40 CurseForge licences are not machine-readable; **four mods opted out of API distribution and the build fetches them by direct URL anyway** |
 | Phase 13 — Season 2 prototype | 🔴 | out of scope until Season 1 is played | §24 Phase 13. Create: New Age, VS2, Clockwork, TFMG, Warium |
 | **Brimm Armors balance** | 🟡 | **needs a client** — §15 wants a comparison against TakKit and Brimm registers its stats in code | Read both armour sets off JEI tooltips, then write `config/brimm/overrides/*.xml` (root tag `config`; keys `defense` · `durability` · `toughness` · `knockback-resistance` · `rarity`). The format ships no example and fails open (**#32**) |
 | **Player Microchip textures** | 🟡 | needs an artist | §20 wants the beacon to look like it clips to a plate carrier. Names and recipes are done (**#35**); the three 16×16 PNGs are not |

--- a/docs/khaojee-visual-reference.md
+++ b/docs/khaojee-visual-reference.md
@@ -1,0 +1,236 @@
+<!-- lang:en -->
+# Khaojee visual reference — V0 audit
+
+**What this is.** The source-tracking table *Visuals Spec §36* asks for: every project in the
+reference modpack, what we decided about it, and the evidence for the decision.
+
+**What it is not.** A claim that any of these works. Nothing here has been installed and nothing has
+been booted. This answers only the cheap questions — *does a Forge 1.20.1 build exist, what does it
+need, and what is its licence* — which is exactly the scope *Visuals Spec §37* gives V0.
+
+- **Reference modpack:** <https://modrinth.com/modpack/khaojee-enchanted-visuals>
+- **Reference video:** <https://youtu.be/cxahj-PuLb0>
+- **Swept:** 2026-08-27 · 24 projects
+- **Related:** issue #52, and the licence risk this audit surfaced — issue #53
+
+## Method, so it can be redone
+
+Search by **title**, never by a guessed slug. The design document's TFMG URL was a CurseForge slug
+and `create-industry` on Modrinth is a *modpack* (ADR 0004); the compatibility matrix records the
+same trap for `smoothplayeranimations`. This sweep hit it again in a quieter form: **Soft Imprints
+lives at the slug `snow-imprints`.** A composed URL would have 404ed at best.
+
+```bash
+# 1. find the project by title; the API returns the slug as data
+curl -s "https://api.modrinth.com/v2/search?query=Soft%20Imprints&limit=5"
+
+# 2. ask for a file that is BOTH forge AND 1.20.1 — a project can carry both
+#    facets without any single file carrying both, which is how a resource pack
+#    ends up looking like a Forge mod
+curl -s "https://api.modrinth.com/v2/project/<slug>/version\
+?loaders=%5B%22forge%22%5D&game_versions=%5B%221.20.1%22%5D"
+
+# 3. the project endpoint carries licence, client_side and server_side
+curl -s "https://api.modrinth.com/v2/project/<slug>"
+```
+
+## ADOPT — *Visuals Spec §42* initial adoption set
+
+Six of seven are real Forge 1.20.1 mods. None is installed.
+
+| Reference project | Our choice | Version | Platform | Status | Reason | Licence |
+|---|---|---|---|---|---|---|
+| Grassier Grass | `grassier-grass` | `1.4.5` | Forge 1.20.1 | **ADOPT** | §5 core visual candidate; denser grass without losing vanilla readability | ⚠️ All Rights Reserved |
+| Better Biome Blend | `better-biome-blend` | `1.20.1-1.4.0-forge` | Forge 1.20.1 | **ADOPT** | §6; smooths grass/leaf/water transitions during train travel and long exploration | Unlicense |
+| Soft Imprints | `snow-imprints` ⚠️ *slug ≠ title* | `2.8.0` | Forge 1.20.1 | **ADOPT** | §7; footprints in snow and sand, for tactical atmosphere | MIT |
+| Subtle Effects | `subtle-effects` | `1.14.3` | Forge 1.20.1 | **ADOPT** | §8; more feedback, not more noise | ⚠️ All Rights Reserved |
+| Particle Rain | `particle-rain` | `v4-beta.11+1.20.1-forge` | Forge 1.20.1 | **ADOPT** | §9; weather feel alongside Serene Seasons | MIT |
+| Fancy World Animations | `fwa` | `1.2.31` | Forge 1.20.1 | **ADOPT** | §10; animated doors, levers, chests — reads well in factories and control rooms | MIT |
+| Continuity *(reference)* | **Fusion** `fusion-connected-textures` | `1.3.14a-forge-mc1.20.1` | Forge 1.20.1 | **ADOPT WITH REPLACEMENT** | §12; Fusion is Forge-native, so no Fabric bridge is needed | ⚠️ All Rights Reserved |
+
+**§12's reasoning is confirmed, not merely accepted.** Fusion ships a Forge 1.20.1 build, so the
+spec's refusal to add a Fabric compatibility bridge just for Continuity costs nothing.
+
+**One new dependency:** Subtle Effects requires **Fzzy Config**, which is not in the pack.
+
+## ANIM — governed by the *Animation Spec*, not by this one
+
+| Reference project | Our choice | Version | Platform | Status | Reason | Licence |
+|---|---|---|---|---|---|---|
+| EMF | `entity-model-features` | `3.2.4-forge-1.20.1` | Forge 1.20.1 | **SELECTIVE** | §11; the loader Fresh Animations needs. Requires ETF | LGPL-3.0-only |
+| ETF | `entitytexturefeatures` | `7.1-forge-1.20.1` | Forge 1.20.1 | **SELECTIVE** | §11; required by EMF | LGPL-3.0-only |
+| Fresh Animations | `fresh-animations` | **no Forge file** — loader `minecraft` | **resource pack** | **SELECTIVE, vanilla entities only** | §11; it is a resource pack, which is *why* it needs EMF + ETF | ⚠️ *See terms of use in description* |
+| Fresh Animations: Player Extension | — | — | — | **OFF** | §11; the player already belongs to SPA + NEA | — |
+
+**The pack's animation architecture is already complete.** *Visuals Spec §10* describes
+SPA + NEA + BAC + Smooth Movement, and all four are installed: `SmoothPlayerAnimations`,
+`Not Enough Animations`, `Better Animations Collection`, `Smooth Movement`. V4 adds a selective
+layer to a finished stack, it does not build one.
+
+## PROTOTYPE — *Visuals Spec §43*
+
+| Reference project | Our choice | Version | Platform | Status | Reason | Licence |
+|---|---|---|---|---|---|---|
+| Biomes O' Plenty | `biomes-o-plenty` | `19.0.0.96` | Forge 1.20.1 | **PROTOTYPE** | §13; changes geography, travel, oil search, rail planning. Needs **TerraBlender** (absent) and **GlitchCore** (already in the pack) | ⚠️ All Rights Reserved |
+| Regions Unexplored | `regions-unexplored` | `F-0.5.6+1.20.1` | Forge 1.20.1 | **PROTOTYPE** | §14; same worldgen concerns. Needs **TerraBlender** (absent) | MIT |
+| Countered's Terrain Slabs | `countereds-terrain-slabs` | `4.0.2-beta` | Forge 1.20.1 | **PROTOTYPE** | §16; risk to MineColonies pathfinding, rails and Create contraptions | MIT |
+| Polytone | `polytone` | `1.20-3.5.26` | Forge 1.20.1 | **PROTOTYPE** | §19; keep only if it works with Serene Seasons | GPL-3.0-or-later |
+| 3D World Decorations | `3ddecorations` | **no Forge file** — loader `minecraft` | **resource pack** | **PROTOTYPE, reclassified** | §17 treats it as a mod; it is a resource pack | ⚠️ All Rights Reserved |
+| Lushier Forests | `lushier-forests` | **no Forge file** — loader `minecraft` | **resource pack** | **PROTOTYPE, reclassified** | §18; a resource pack, and redistributable with attribution | CC-BY-4.0 |
+| Musgo | **unresolved** | — | — | **UNRESOLVED** | No Modrinth match. CurseForge has no search API without a key, so this is *not found*, not *absent*. **Do not guess a slug** | unknown |
+| Particle Interactions | `particle-interactions` | **no 1.20.1 file at all** | — | **→ REJECT** | §43 lists it as a prototype; there is nothing to prototype on any loader | CC-BY-NC-4.0 |
+
+## REJECT — *Visuals Spec §44*, and the reason is now measured
+
+The spec deferred these on a *compatibility-cost* argument. The measurement is stronger than the
+argument: on Forge 1.20.1 there is nothing to install.
+
+| Reference project | Finding | Licence |
+|---|---|---|
+| Wakes | 1.20.1 exists — **fabric only** | GPL-3.0-only |
+| Particular | 1.20.1 exists — **fabric only** | LGPL-3.0-only |
+| Item Interactions | 1.20.1 exists — **fabric only** | LGPL-3.0-only |
+| Presence Footsteps | 1.20.1 exists — **fabric/quilt only** | Polyform Shield 1.0 |
+| Auditory Continued | 1.20.1 exists — **fabric/quilt only** | MIT |
+| Tree Physics | **no 1.20.1 file at all** | All Rights Reserved |
+
+## ALREADY COVERED
+
+*Visuals Spec §21* and §24 both describe stacks this pack already owns, and the audit confirms it:
+
+- **Sound** — AmbientSounds, Sound Physics Remastered, Simple Voice Chat, Simple Voice Radio.
+- **Performance** — all six of §24's required stack are installed: Embeddium, ModernFix, FerriteCore,
+  Entity Culling, ImmediatelyFast, ServerCore.
+- **Animation** — SPA, NEA, BAC, Smooth Movement.
+
+## What V0 does not decide
+
+**Whether any of this works.** *Visuals Spec §41* rule 11 is *"Do not claim compatibility without
+launch testing"*, and §38's done-criteria are all measurements on a running client: FPS, 1% lows,
+combat readability under Horde-in-rain, NVG usability. This repo has never launched one.
+
+**Whether we may ship them.** Three of the seven adoption-set mods are All Rights Reserved. That is
+the ordinary default on both hosts and many such authors permit modpack inclusion — but nobody has
+read the terms, for these or for the 99 mods already in the pack. Issue **#53**.
+
+**The worldgen question.** §33 says worldgen must be settled before persistent play begins, and
+§15 requires multiple seeds. That is V6–V8 and it is a decision, not a lookup.
+<!-- lang:end -->
+
+<!-- lang:th -->
+# Khaojee visual reference — การ audit V0
+
+**นี่คืออะไร** ตารางติดตามต้นทางที่ *Visuals Spec §36* ขอไว้: ทุกโปรเจกต์ใน modpack อ้างอิง
+สิ่งที่เราตัดสินใจกับมัน และหลักฐานของการตัดสินใจนั้น
+
+**ไม่ใช่อะไร** ไม่ใช่การอ้างว่าอันไหนใช้งานได้ ไม่มีอะไรถูกติดตั้งและไม่มีอะไรถูก boot
+เอกสารนี้ตอบเฉพาะคำถามที่ถูกที่สุด — *มี build สำหรับ Forge 1.20.1 ไหม มันต้องใช้อะไร
+และสัญญาอนุญาตของมันคืออะไร* — ซึ่งเป็นขอบเขตที่ *Visuals Spec §37* ให้ V0 พอดี
+
+- **modpack อ้างอิง:** <https://modrinth.com/modpack/khaojee-enchanted-visuals>
+- **วิดีโออ้างอิง:** <https://youtu.be/cxahj-PuLb0>
+- **กวาดเมื่อ:** 2026-08-27 · 24 โปรเจกต์
+- **เกี่ยวข้อง:** issue #52 และความเสี่ยงเรื่องสัญญาอนุญาตที่ audit นี้เปิดโปงออกมา — issue #53
+
+## วิธีทำ เพื่อให้ทำซ้ำได้
+
+ค้นด้วย**ชื่อ** ห้ามเดา slug เด็ดขาด URL ของ TFMG ในเอกสารออกแบบเป็น slug ของ CurseForge
+และ `create-industry` บน Modrinth คือ *modpack* (ADR 0004) ส่วน compatibility matrix
+ก็บันทึกกับดักเดียวกันไว้สำหรับ `smoothplayeranimations` การกวาดรอบนี้เจอมันอีกในรูปแบบที่เงียบกว่า:
+**Soft Imprints อยู่ที่ slug ชื่อ `snow-imprints`** URL ที่ประกอบขึ้นเองจะ 404 อย่างดีที่สุด
+
+```bash
+# 1. หาโปรเจกต์จากชื่อ API จะคืน slug มาเป็นข้อมูล
+curl -s "https://api.modrinth.com/v2/search?query=Soft%20Imprints&limit=5"
+
+# 2. ขอไฟล์ที่เป็นทั้ง forge และ 1.20.1 — โปรเจกต์หนึ่งมี facet ทั้งสองได้
+#    โดยไม่มีไฟล์ไหนมีครบทั้งคู่ ซึ่งเป็นวิธีที่ resource pack ดูเหมือนมอด Forge
+curl -s "https://api.modrinth.com/v2/project/<slug>/version\
+?loaders=%5B%22forge%22%5D&game_versions=%5B%221.20.1%22%5D"
+
+# 3. project endpoint มีสัญญาอนุญาต client_side และ server_side
+curl -s "https://api.modrinth.com/v2/project/<slug>"
+```
+
+## ADOPT — ชุดรับมาเริ่มต้นตาม *Visuals Spec §42*
+
+หกจากเจ็ดเป็นมอด Forge 1.20.1 จริง ยังไม่มีตัวไหนถูกติดตั้ง
+
+| โปรเจกต์อ้างอิง | สิ่งที่เราเลือก | เวอร์ชัน | แพลตฟอร์ม | สถานะ | เหตุผล | สัญญาอนุญาต |
+|---|---|---|---|---|---|---|
+| Grassier Grass | `grassier-grass` | `1.4.5` | Forge 1.20.1 | **ADOPT** | §5; หญ้าหนาขึ้นโดยไม่เสียความอ่านง่ายแบบ vanilla | ⚠️ All Rights Reserved |
+| Better Biome Blend | `better-biome-blend` | `1.20.1-1.4.0-forge` | Forge 1.20.1 | **ADOPT** | §6; ไล่สีหญ้า/ใบไม้/น้ำให้เนียนตอนนั่งรถไฟและสำรวจไกล | Unlicense |
+| Soft Imprints | `snow-imprints` ⚠️ *slug ≠ ชื่อ* | `2.8.0` | Forge 1.20.1 | **ADOPT** | §7; รอยเท้าบนหิมะและทราย เพื่อบรรยากาศเชิงยุทธวิธี | MIT |
+| Subtle Effects | `subtle-effects` | `1.14.3` | Forge 1.20.1 | **ADOPT** | §8; feedback มากขึ้น ไม่ใช่สัญญาณรบกวนมากขึ้น | ⚠️ All Rights Reserved |
+| Particle Rain | `particle-rain` | `v4-beta.11+1.20.1-forge` | Forge 1.20.1 | **ADOPT** | §9; ความรู้สึกของสภาพอากาศ คู่กับ Serene Seasons | MIT |
+| Fancy World Animations | `fwa` | `1.2.31` | Forge 1.20.1 | **ADOPT** | §10; ประตู คันโยก หีบ มีแอนิเมชัน เข้ากับโรงงานและห้องควบคุม | MIT |
+| Continuity *(อ้างอิง)* | **Fusion** `fusion-connected-textures` | `1.3.14a-forge-mc1.20.1` | Forge 1.20.1 | **ADOPT WITH REPLACEMENT** | §12; Fusion เป็น Forge โดยกำเนิด จึงไม่ต้องใช้ Fabric bridge | ⚠️ All Rights Reserved |
+
+**เหตุผลของ §12 ได้รับการยืนยัน ไม่ใช่แค่ยอมรับ** Fusion มี build สำหรับ Forge 1.20.1
+การที่ spec ปฏิเสธการเพิ่ม Fabric compatibility bridge เพียงเพื่อ Continuity จึงไม่มีต้นทุนอะไรเลย
+
+**dependency ใหม่หนึ่งตัว:** Subtle Effects ต้องใช้ **Fzzy Config** ซึ่งไม่มีใน pack
+
+## ANIM — อยู่ใต้ *Animation Spec* ไม่ใช่ spec นี้
+
+| โปรเจกต์อ้างอิง | สิ่งที่เราเลือก | เวอร์ชัน | แพลตฟอร์ม | สถานะ | เหตุผล | สัญญาอนุญาต |
+|---|---|---|---|---|---|---|
+| EMF | `entity-model-features` | `3.2.4-forge-1.20.1` | Forge 1.20.1 | **SELECTIVE** | §11; ตัวโหลดที่ Fresh Animations ต้องใช้ ต้องมี ETF | LGPL-3.0-only |
+| ETF | `entitytexturefeatures` | `7.1-forge-1.20.1` | Forge 1.20.1 | **SELECTIVE** | §11; EMF ต้องการ | LGPL-3.0-only |
+| Fresh Animations | `fresh-animations` | **ไม่มีไฟล์ Forge** — loader `minecraft` | **resource pack** | **SELECTIVE เฉพาะ entity ของ vanilla** | §11; มันเป็น resource pack ซึ่งเป็น*เหตุผล*ที่ต้องมี EMF + ETF | ⚠️ *ดูเงื่อนไขการใช้งานในคำอธิบาย* |
+| Fresh Animations: Player Extension | — | — | — | **ปิด** | §11; ผู้เล่นเป็นของ SPA + NEA อยู่แล้ว | — |
+
+**สถาปัตยกรรมแอนิเมชันของ pack ครบอยู่แล้ว** *Visuals Spec §10* อธิบาย SPA + NEA + BAC +
+Smooth Movement และทั้งสี่ตัวติดตั้งอยู่แล้ว: `SmoothPlayerAnimations`, `Not Enough Animations`,
+`Better Animations Collection`, `Smooth Movement` V4 เพิ่มชั้นแบบเลือกสรรลงบนกองที่เสร็จแล้ว
+ไม่ใช่การสร้างกองขึ้นมาใหม่
+
+## PROTOTYPE — *Visuals Spec §43*
+
+| โปรเจกต์อ้างอิง | สิ่งที่เราเลือก | เวอร์ชัน | แพลตฟอร์ม | สถานะ | เหตุผล | สัญญาอนุญาต |
+|---|---|---|---|---|---|---|
+| Biomes O' Plenty | `biomes-o-plenty` | `19.0.0.96` | Forge 1.20.1 | **PROTOTYPE** | §13; เปลี่ยนภูมิศาสตร์ ระยะเดินทาง การหาแหล่งน้ำมัน การวางราง ต้องใช้ **TerraBlender** (ไม่มี) และ **GlitchCore** (มีใน pack แล้ว) | ⚠️ All Rights Reserved |
+| Regions Unexplored | `regions-unexplored` | `F-0.5.6+1.20.1` | Forge 1.20.1 | **PROTOTYPE** | §14; ข้อกังวลเรื่อง worldgen แบบเดียวกัน ต้องใช้ **TerraBlender** (ไม่มี) | MIT |
+| Countered's Terrain Slabs | `countereds-terrain-slabs` | `4.0.2-beta` | Forge 1.20.1 | **PROTOTYPE** | §16; เสี่ยงต่อ pathfinding ของ MineColonies ราง และ contraption ของ Create | MIT |
+| Polytone | `polytone` | `1.20-3.5.26` | Forge 1.20.1 | **PROTOTYPE** | §19; เก็บไว้ต่อเมื่อมันทำงานร่วมกับ Serene Seasons ได้ | GPL-3.0-or-later |
+| 3D World Decorations | `3ddecorations` | **ไม่มีไฟล์ Forge** — loader `minecraft` | **resource pack** | **PROTOTYPE จัดประเภทใหม่** | §17 ปฏิบัติกับมันเหมือนเป็นมอด แต่มันเป็น resource pack | ⚠️ All Rights Reserved |
+| Lushier Forests | `lushier-forests` | **ไม่มีไฟล์ Forge** — loader `minecraft` | **resource pack** | **PROTOTYPE จัดประเภทใหม่** | §18; เป็น resource pack และแจกซ้ำได้ถ้าให้เครดิต | CC-BY-4.0 |
+| Musgo | **ยังหาไม่เจอ** | — | — | **UNRESOLVED** | ไม่เจอบน Modrinth CurseForge ไม่มี search API ถ้าไม่มีคีย์ ดังนั้นนี่คือ *ยังหาไม่เจอ* ไม่ใช่ *ไม่มี* **ห้ามเดา slug** | ไม่ทราบ |
+| Particle Interactions | `particle-interactions` | **ไม่มีไฟล์ 1.20.1 เลย** | — | **→ REJECT** | §43 ลงมันไว้เป็น prototype แต่ไม่มีอะไรให้ prototype บน loader ไหนเลย | CC-BY-NC-4.0 |
+
+## REJECT — *Visuals Spec §44* และตอนนี้เหตุผลวัดมาแล้ว
+
+spec เลื่อนพวกนี้ออกไปด้วยเหตุผลเรื่อง*ต้นทุนความเข้ากันได้* การวัดหนักแน่นกว่าเหตุผลนั้น:
+บน Forge 1.20.1 ไม่มีอะไรให้ติดตั้งเลย
+
+| โปรเจกต์อ้างอิง | สิ่งที่พบ | สัญญาอนุญาต |
+|---|---|---|
+| Wakes | มี 1.20.1 — **fabric เท่านั้น** | GPL-3.0-only |
+| Particular | มี 1.20.1 — **fabric เท่านั้น** | LGPL-3.0-only |
+| Item Interactions | มี 1.20.1 — **fabric เท่านั้น** | LGPL-3.0-only |
+| Presence Footsteps | มี 1.20.1 — **fabric/quilt เท่านั้น** | Polyform Shield 1.0 |
+| Auditory Continued | มี 1.20.1 — **fabric/quilt เท่านั้น** | MIT |
+| Tree Physics | **ไม่มีไฟล์ 1.20.1 เลย** | All Rights Reserved |
+
+## ALREADY COVERED
+
+*Visuals Spec §21* และ §24 อธิบายกองที่ pack นี้เป็นเจ้าของอยู่แล้ว และ audit ยืนยันแล้ว:
+
+- **เสียง** — AmbientSounds, Sound Physics Remastered, Simple Voice Chat, Simple Voice Radio
+- **ประสิทธิภาพ** — ครบทั้งหกตัวที่ §24 บังคับ: Embeddium, ModernFix, FerriteCore,
+  Entity Culling, ImmediatelyFast, ServerCore
+- **แอนิเมชัน** — SPA, NEA, BAC, Smooth Movement
+
+## สิ่งที่ V0 ไม่ได้ตัดสิน
+
+**ว่าอันไหนใช้งานได้** กฎข้อ 11 ของ *Visuals Spec §41* คือ *"อย่าอ้างความเข้ากันได้โดยไม่ทดสอบการเปิด"*
+และเกณฑ์ done ของ §38 ทุกข้อเป็นการวัดบน client ที่รันอยู่: FPS, 1% lows,
+ความชัดในการต่อสู้ตอน horde ในสายฝน การใช้งาน NVG repo นี้ไม่เคยเปิด client เลย
+
+**ว่าเราแจกจ่ายมันได้หรือเปล่า** สามจากเจ็ดในชุด adoption เป็น All Rights Reserved
+นั่นคือค่าเริ่มต้นปกติของทั้งสองเจ้า และผู้เขียนจำนวนมากก็อนุญาตให้ใส่ modpack —
+แต่ยังไม่มีใครไปอ่านเงื่อนไข ทั้งของพวกนี้และของมอด 99 ตัวที่อยู่ใน pack แล้ว issue **#53**
+
+**คำถามเรื่อง worldgen** §33 บอกว่า worldgen ต้องนิ่งก่อนเริ่มเล่นโลกถาวร และ §15 ต้องการหลาย seed
+นั่นคือ V6–V8 และมันเป็นการตัดสินใจ ไม่ใช่การเปิดดู
+<!-- lang:end -->


### PR DESCRIPTION
## Summary

A **sixth** spec arrived and was registered nowhere — `CLAUDE.md`'s table listed five, and the new
file names three documents that do not exist.

This registers it (*Visuals Spec §N*) and runs **§37's V0 — Reference Audit**, the one phase that
needs no client. 24 projects swept.

## The method caught the trap it was written for

Searched by **title** through the Modrinth API, never by a composed slug — ADR 0004's rule. Then
asked the version endpoint for a file that is *both* `forge` **and** `1.20.1`, because a project can
carry both facets without any single file carrying both.

It paid off twice:

- **Soft Imprints lives at the slug `snow-imprints`.** A URL composed from the title would have
  404ed at best.
- The loader check is what exposed the resource packs below. The facet search alone would have
  reported them as Forge mods.

## Three entries the spec treats as mods are resource packs

| Project | Reality |
|---|---|
| Fresh Animations | loader `minecraft` — a resource pack. **This is why it needs EMF + ETF**, which §11 already routes correctly |
| 3D World Decorations | loader `minecraft` — a resource pack, listed under PROTOTYPE as a mod |
| Lushier Forests | loader `minecraft` — a resource pack, CC-BY-4.0 |

EMF (`3.2.4-forge-1.20.1`) and ETF (`7.1-forge-1.20.1`) *are* real Forge mods, both LGPL-3.0.

## Two prototype entries do not survive contact

- **Particle Interactions** — **no 1.20.1 file at all**, on any loader. Nothing to prototype; it
  belongs in §44.
- **Musgo** — **no Modrinth match**. CurseForge has no search API without a key, so it is recorded
  as **unresolved**, not absent, and **no slug was guessed for it**.

## §44's rejections are correct — and now measured rather than argued

The spec deferred six projects on a *compatibility-cost* argument. The measurement is stronger than
the argument: on this platform there is nothing to install.

| Project | Finding |
|---|---|
| Wakes · Particular · Item Interactions | 1.20.1 exists, **fabric only** |
| Presence Footsteps · Auditory Continued | 1.20.1 exists, **fabric/quilt only** |
| Tree Physics | **no 1.20.1 file at all** |

## The adoption set is real

Six of seven have Forge 1.20.1 builds: Grassier Grass `1.4.5`, Better Biome Blend
`1.20.1-1.4.0-forge`, Soft Imprints `2.8.0`, Subtle Effects `1.14.3`, Particle Rain
`v4-beta.11+1.20.1-forge`, Fancy World Animations `1.2.31`, Fusion `1.3.14a-forge-mc1.20.1`.

**§12's Fusion decision is confirmed, not merely accepted** — Fusion ships Forge natively, so the
spec's refusal to add a Fabric bridge for Continuity costs nothing.

**New dependencies found:** Subtle Effects needs **Fzzy Config** (absent). BOP and Regions Unexplored
both need **TerraBlender** (absent); BOP's other requirement, **GlitchCore**, is already in the pack.

## What the pack already has

§24 requires the visual layer be tested with Embeddium, ModernFix, FerriteCore, Entity Culling,
ImmediatelyFast and ServerCore — **all six are installed**. §10's animation architecture,
SPA + NEA + BAC + Smooth Movement, is **also already complete**. §21's sound layer is owned.

**V1 adds visuals to a stack that is otherwise finished.** None of the seven adoption-set mods is
installed, so V1 is genuinely new work.

## The audit surfaced something bigger, filed separately

Running §35's licence check produced **issue #53**: the pack ships 99 jars self-contained and has
never checked whether it may. 21 of 59 Modrinth mods are All-Rights-Reserved or custom, 40
CurseForge licences are not machine-readable, and **four mods opted out of API distribution while
the build fetches them by direct URL anyway**. That last one is a comment I wrote myself and
reported as a capability; read as a licensing question it says something else.

Out of scope here — but it is why the ledger preamble now names four non-client rows.

## The ledger preamble, corrected for the second time in three commits

#48 fixed it from *"one exception"* to *"three rows"*. Filing #53 made **that** wrong the same day,
because #53 needs no client either. Now four rows, with the one that is actionable **today** named
first. A completeness claim in this file is load-bearing — it is what a session reads instead of the
table.

## Testing

`node scripts/validate/verify.mjs` — green. Docs only; no code changed and no artifact was rebuilt.

## What this does not establish

**That any of it works.** Nothing installed, nothing booted. §41 rule 11 is *"Do not claim
compatibility without launch testing"*, and every §38 done-criterion is a measurement on a running
client — FPS, 1% lows, combat readability under Horde-in-rain, NVG usability.

**That we may ship them.** Three of the seven are All Rights Reserved. See #53.

**The worldgen question.** §33 wants worldgen settled before persistent play and §15 wants multiple
seeds. V6–V8 is a decision, not a lookup.

Closes #52

---

## สรุปภาษาไทย

### สรุป

spec ตัวที่ **หก** เข้ามาและไม่ได้ถูกขึ้นทะเบียนที่ไหนเลย — ตารางใน `CLAUDE.md` มีอยู่ห้าตัว
และไฟล์ใหม่อ้างถึงเอกสารสามฉบับที่ไม่มีอยู่จริง

PR นี้ขึ้นทะเบียนมัน (*Visuals Spec §N*) และรัน **V0 — Reference Audit ของ §37**
ซึ่งเป็นเฟสเดียวที่ไม่ต้องใช้ client กวาดไป 24 โปรเจกต์

### วิธีทำจับกับดักที่มันถูกเขียนขึ้นมาเพื่อจับได้จริง

ค้นด้วย**ชื่อ**ผ่าน Modrinth API ไม่เคยประกอบ slug เอง — กฎของ ADR 0004 แล้วถาม version endpoint
หาไฟล์ที่เป็นทั้ง `forge` **และ** `1.20.1` เพราะโปรเจกต์หนึ่งมี facet ทั้งสองได้โดยไม่มีไฟล์ไหนมีครบทั้งคู่

มันได้ผลสองครั้ง:

- **Soft Imprints อยู่ที่ slug ชื่อ `snow-imprints`** URL ที่ประกอบจากชื่อจะ 404 อย่างดีที่สุด
- การตรวจ loader คือสิ่งที่เปิดโปง resource pack ข้างล่างนี้ การค้นด้วย facet อย่างเดียวจะรายงานว่า
  พวกมันเป็นมอด Forge

### สามรายการที่ spec ปฏิบัติเหมือนเป็นมอด จริง ๆ เป็น resource pack

| โปรเจกต์ | ความจริง |
|---|---|
| Fresh Animations | loader `minecraft` — resource pack **นี่คือเหตุผลที่มันต้องใช้ EMF + ETF** ซึ่ง §11 จัดเส้นทางไว้ถูกแล้ว |
| 3D World Decorations | loader `minecraft` — resource pack ถูกลงไว้ใต้ PROTOTYPE ราวกับเป็นมอด |
| Lushier Forests | loader `minecraft` — resource pack, CC-BY-4.0 |

EMF (`3.2.4-forge-1.20.1`) กับ ETF (`7.1-forge-1.20.1`) *เป็น* มอด Forge จริง ทั้งคู่ LGPL-3.0

### สอง prototype ไม่รอดเมื่อเจอของจริง

- **Particle Interactions** — **ไม่มีไฟล์ 1.20.1 เลย** ไม่ว่า loader ไหน ไม่มีอะไรให้ prototype
  ควรอยู่ใน §44
- **Musgo** — **ไม่เจอบน Modrinth** CurseForge ไม่มี search API ถ้าไม่มีคีย์ จึงบันทึกว่า
  **ยังหาไม่เจอ** ไม่ใช่ไม่มี และ**ไม่มีการเดา slug ให้มัน**

### การปฏิเสธของ §44 ถูกต้อง และตอนนี้วัดมาแล้วแทนที่จะเถียง

spec เลื่อนหกโปรเจกต์ออกไปด้วยเหตุผลเรื่อง*ต้นทุนความเข้ากันได้* การวัดหนักแน่นกว่าเหตุผลนั้น:
บนแพลตฟอร์มนี้ไม่มีอะไรให้ติดตั้งเลย

| โปรเจกต์ | สิ่งที่พบ |
|---|---|
| Wakes · Particular · Item Interactions | มี 1.20.1 แต่ **fabric เท่านั้น** |
| Presence Footsteps · Auditory Continued | มี 1.20.1 แต่ **fabric/quilt เท่านั้น** |
| Tree Physics | **ไม่มีไฟล์ 1.20.1 เลย** |

### ชุด adoption มีจริง

หกจากเจ็ดมี build สำหรับ Forge 1.20.1: Grassier Grass `1.4.5`, Better Biome Blend
`1.20.1-1.4.0-forge`, Soft Imprints `2.8.0`, Subtle Effects `1.14.3`, Particle Rain
`v4-beta.11+1.20.1-forge`, Fancy World Animations `1.2.31`, Fusion `1.3.14a-forge-mc1.20.1`

**การตัดสินใจเรื่อง Fusion ของ §12 ได้รับการยืนยัน ไม่ใช่แค่ยอมรับ** — Fusion มี build Forge
โดยกำเนิด การที่ spec ปฏิเสธการเพิ่ม Fabric bridge เพื่อ Continuity จึงไม่มีต้นทุน

**dependency ใหม่ที่พบ:** Subtle Effects ต้องใช้ **Fzzy Config** (ไม่มี) BOP กับ Regions Unexplored
ต้องใช้ **TerraBlender** ทั้งคู่ (ไม่มี) ส่วนอีกตัวที่ BOP ต้องการคือ **GlitchCore** ซึ่งมีใน pack แล้ว

### สิ่งที่ pack มีอยู่แล้ว

§24 บังคับให้ทดสอบชั้นภาพกับ Embeddium, ModernFix, FerriteCore, Entity Culling, ImmediatelyFast
และ ServerCore — **ครบทั้งหกตัวติดตั้งอยู่แล้ว** สถาปัตยกรรมแอนิเมชันของ §10 คือ
SPA + NEA + BAC + Smooth Movement ก็ **ครบแล้วเช่นกัน** ชั้นเสียงของ §21 มีเจ้าของแล้ว

**V1 คือการเพิ่มภาพลงบนกองที่เสร็จแล้ว** ไม่มีมอดตัวไหนในชุด adoption ทั้งเจ็ดที่ติดตั้งอยู่
V1 จึงเป็นงานใหม่จริง ๆ

### audit เปิดโปงเรื่องใหญ่กว่า แยกไปอีก issue

การรันการตรวจสัญญาอนุญาตของ §35 ทำให้เกิด **issue #53**: pack ส่ง jar 99 ตัวแบบมีทุกอย่างในตัว
และไม่เคยตรวจเลยว่าทำได้หรือเปล่า 21 จาก 59 มอดบน Modrinth เป็น All-Rights-Reserved หรือ custom,
สัญญาอนุญาตของ CurseForge 40 ตัวเครื่องอ่านไม่ได้ และ **มอดสี่ตัวปิดการแจกจ่ายผ่าน API ไว้
แต่ build ก็ดึงมันมาผ่าน URL ตรงอยู่ดี** ข้อสุดท้ายเป็นคอมเมนต์ที่ผมเขียนเองและรายงานไว้ในฐานะ
ความสามารถ พออ่านในฐานะคำถามเรื่องสัญญาอนุญาต มันพูดอีกอย่าง

อยู่นอกขอบเขตของ PR นี้ — แต่มันคือเหตุผลที่ส่วนนำของ ledger ตอนนี้ระบุสี่แถวที่ไม่ต้องใช้ client

### ส่วนนำของ ledger ถูกแก้เป็นครั้งที่สองในสาม commit

#48 แก้มันจาก *"ข้อยกเว้นหนึ่งเดียว"* เป็น *"สามแถว"* การเปิด #53 ทำให้ **อันนั้น** ผิดในวันเดียวกัน
เพราะ #53 ก็ไม่ต้องใช้ client เหมือนกัน ตอนนี้เป็นสี่แถว โดยแถวที่ลงมือได้**วันนี้**อยู่บนสุด
คำอ้างเรื่องความครบถ้วนในไฟล์นี้รับน้ำหนัก — มันคือสิ่งที่เซสชันหนึ่งอ่านแทนตาราง

### การทดสอบ

`node scripts/validate/verify.mjs` — เขียว เป็น docs อย่างเดียว ไม่มีโค้ดเปลี่ยนและไม่ได้ rebuild artifact

### สิ่งที่ PR นี้ไม่ได้พิสูจน์

**ว่าอันไหนใช้งานได้** ไม่มีอะไรถูกติดตั้ง ไม่มีอะไรถูก boot กฎข้อ 11 ของ §41 คือ
*"อย่าอ้างความเข้ากันได้โดยไม่ทดสอบการเปิด"* และเกณฑ์ done ของ §38 ทุกข้อเป็นการวัดบน client
ที่รันอยู่ — FPS, 1% lows, ความชัดในการต่อสู้ตอน horde ในสายฝน, การใช้งาน NVG

**ว่าเราแจกจ่ายมันได้** สามจากเจ็ดเป็น All Rights Reserved ดู #53

**คำถามเรื่อง worldgen** §33 ต้องการให้ worldgen นิ่งก่อนเริ่มเล่นโลกถาวร และ §15 ต้องการหลาย seed
V6–V8 เป็นการตัดสินใจ ไม่ใช่การเปิดดู

Closes #52
