### PR TITLE
fix(docs): #53 overstated what the CurseForge API flag means

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -106,7 +106,7 @@ This is `0.1.0-alpha`.
 - ❌ **One known problem, unfixed:** Improved Mobs cannot read the defence values of Brimm Armors,
   so no Brimm armour will ever be worn by a mob.
 
-- ⚠️ **Do not post this publicly yet.** The pack bundles all 99 mods, and at least two authors
+- ⚠️ **Do not post this publicly yet.** The pack bundles all 99 mods, and at least three authors
   permit modpack inclusion only on condition that their jar is **not** rehosted. Whether this pack
   may be distributed at all is **unestablished** — not permitted, not prohibited, just unchecked
   until now. `docs/distribution-licenses.md` has the detail and names the decisions it needs.
@@ -222,7 +222,7 @@ java -jar packwiz-installer-bootstrap.jar http://localhost:8080/pack.toml
 - ❌ **ปัญหาที่รู้แล้วหนึ่งข้อ ยังไม่ได้แก้:** Improved Mobs อ่านค่าป้องกันของ Brimm Armors ไม่ได้
   ดังนั้นจะไม่มีมอบตัวไหนสวมเกราะ Brimm เลย
 - ⚠️ **ยังอย่าเพิ่งโพสต์สาธารณะ** pack รวมมอดทั้ง 99 ตัวไว้ข้างใน
-  และมีผู้เขียนอย่างน้อยสองคนที่อนุญาตให้ใส่ modpack ได้โดยมีเงื่อนไขว่าต้อง**ไม่** rehost ตัว jar ของเขา
+  และมีผู้เขียนอย่างน้อยสามคนที่อนุญาตให้ใส่ modpack ได้โดยมีเงื่อนไขว่าต้อง**ไม่** rehost ตัว jar ของเขา
   เรื่องที่ว่า pack นี้แจกจ่ายได้หรือไม่นั้น **ยังไม่ได้ถูกกำหนด** — ไม่ใช่อนุญาต ไม่ใช่ห้าม
   แค่ยังไม่มีใครตรวจจนถึงตอนนี้ `docs/distribution-licenses.md` มีรายละเอียดและระบุการตัดสินใจที่ต้องใช้
 

--- a/docs/distribution-licenses.md
+++ b/docs/distribution-licenses.md
@@ -57,8 +57,27 @@ because the CurseForge API refuses to serve them:
 | Player Microchip (Tracker) | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/player-microchip) | All Rights Reserved | project page |
 | TakKit | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/takkit) | MIT License | project page |
 
-**Disabling API distribution is how an author says "not in someone else's pack."** It is a setting,
-not prose, and it is the clearest statement of intent in this audit.
+**That claim was too strong when this file first said it, and it is corrected here.**
+
+The original wording was *"disabling API distribution is how an author says 'not in someone else's
+pack'"*. What the flag **demonstrably** does is narrower: the third-party CurseForge API stops
+returning a download URL, which is why `pack.mjs` falls back to the website endpoint. It is not by
+itself a statement about modpacks.
+
+The measurement that forces the correction: **all four appear in this pack's own CurseForge manifest
+by project and file id**, which is the form CurseForge's own installer resolves —
+
+```
+takkit                1269552   IN MANIFEST
+flashier-flashlights  1604184   IN MANIFEST
+client-dynamic-light  1302060   IN MANIFEST
+player-microchip      1488872   IN MANIFEST
+```
+
+So the flag distinguishes *third-party launchers* from *CurseForge itself*, and reading it as "no
+modpacks" conflates the two. **What the author actually intended still has to be read off the
+project page** — which for these four has not been done. They stay in the unread column; they are
+just no longer described as prohibited.
 
 **But the four are not one case.** *TakKit* is **MIT** and *Client Dynamic Light* is **MPL-2.0** —
 both licences grant redistribution in their own text, so for those two the opt-out reads as a
@@ -74,6 +93,22 @@ nothing to stand on.
 | Serene Seasons | [Modrinth](https://modrinth.com/mod/serene-seasons) | All Rights Reserved | Modrinth API |
 
 Both **permit hosted modpacks** and both **forbid rehosting the jar**. Quoted above.
+
+## Read and permitted — with conditions
+
+Two authors state modpack terms plainly. Both were **misread by the abandoned classifier** and are
+recorded here from the prose itself.
+
+| Mod | What the author wrote | Reading |
+|---|---|---|
+| **Subtle Effects** | ✅ *"Use this mod in modpacks with credit and one or more links to any of the project pages"* · ❌ *"Reupload/publish this mod to any website without explicit permission"* | **modpack use permitted**, and `docs/MODLIST.md` already supplies the credit and the link. The reupload clause is the same rehosting question as Serene Seasons and Entity Culling |
+| **Immersive Posts** | *"Do not redistribute this mod unless as part of a pack!"* | **permitted for packs**, explicitly. The classifier read this as a prohibition — it is the opposite |
+
+## What the CurseForge half of this audit could not read
+
+Descriptions on 16 CurseForge project pages did not yield any modpack-permission prose to the
+scraper. That is a **limit of the method, not a finding about the mods** — CurseForge renders
+descriptions in a form this extraction did not reach. Those rows stay unread and need a browser.
 
 ## Permissively licensed — 59 mods
 
@@ -278,8 +313,25 @@ packwiz เอามอดที่มาจาก Modrinth ไปไว้ใ�
 | Player Microchip (Tracker) | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/player-microchip) | All Rights Reserved | project page |
 | TakKit | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/takkit) | MIT License | project page |
 
-**การปิดการแจกจ่ายผ่าน API คือวิธีที่ผู้เขียนบอกว่า "ไม่เอาไปใส่ pack ของคนอื่น"**
-มันเป็นการตั้งค่า ไม่ใช่ข้อความ และเป็นการแสดงเจตนาที่ชัดที่สุดใน audit นี้
+**คำกล่าวนั้นแรงเกินไปตอนที่ไฟล์นี้เขียนครั้งแรก และแก้ตรงนี้แล้ว**
+
+ถ้อยคำเดิมคือ *"การปิดการแจกจ่ายผ่าน API คือวิธีที่ผู้เขียนบอกว่าไม่เอาไปใส่ pack ของคนอื่น"*
+สิ่งที่แฟล็กนั้นทำ**ได้จริง**แคบกว่านั้น: CurseForge API ของบุคคลที่สามจะหยุดคืน URL ดาวน์โหลด
+ซึ่งเป็นเหตุผลที่ `pack.mjs` ถอยไปใช้ endpoint ของเว็บ มันไม่ใช่คำแถลงเรื่อง modpack ในตัวมันเอง
+
+การวัดที่บังคับให้ต้องแก้: **ทั้งสี่ตัวปรากฏใน CurseForge manifest ของ pack นี้เองด้วย project
+และ file id** ซึ่งเป็นรูปแบบที่ตัวติดตั้งของ CurseForge เองอ่าน —
+
+```
+takkit                1269552   IN MANIFEST
+flashier-flashlights  1604184   IN MANIFEST
+client-dynamic-light  1302060   IN MANIFEST
+player-microchip      1488872   IN MANIFEST
+```
+
+แฟล็กนั้นจึงแยก *launcher ของบุคคลที่สาม* ออกจาก *ตัว CurseForge เอง* และการอ่านมันว่า "ห้าม modpack"
+คือการรวมสองเรื่องเข้าด้วยกัน **เจตนาจริงของผู้เขียนยังต้องไปอ่านจากหน้าโปรเจกต์อยู่ดี** —
+ซึ่งสำหรับสี่ตัวนี้ยังไม่ได้ทำ พวกมันจึงยังอยู่ในคอลัมน์ที่ยังไม่ได้อ่าน แค่ไม่ได้ถูกอธิบายว่าต้องห้ามอีกต่อไป
 
 **แต่ทั้งสี่ไม่ใช่กรณีเดียวกัน** *TakKit* เป็น **MIT** และ *Client Dynamic Light* เป็น **MPL-2.0** —
 สัญญาอนุญาตทั้งสองให้สิทธิ์แจกจ่ายซ้ำในตัวข้อความเอง สำหรับสองตัวนี้การปิด API
@@ -295,6 +347,22 @@ packwiz เอามอดที่มาจาก Modrinth ไปไว้ใ�
 | Serene Seasons | [Modrinth](https://modrinth.com/mod/serene-seasons) | All Rights Reserved | Modrinth API |
 
 ทั้งคู่**อนุญาต modpack แบบโฮสต์** และทั้งคู่**ห้าม rehost ตัว jar** อ้างข้อความไว้ข้างบนแล้ว
+
+## อ่านแล้วและอนุญาต — โดยมีเงื่อนไข
+
+ผู้เขียนสองคนระบุเงื่อนไข modpack ไว้ตรง ๆ ทั้งคู่**ถูกตัวจัดประเภทที่เลิกใช้แล้วอ่านผิด**
+และบันทึกตรงนี้จากตัวข้อความเอง
+
+| มอด | ผู้เขียนเขียนว่า | การอ่าน |
+|---|---|---|
+| **Subtle Effects** | ✅ *"ใช้มอดนี้ใน modpack ได้โดยให้เครดิตและใส่ลิงก์ไปยังหน้าโปรเจกต์อย่างน้อยหนึ่งลิงก์"* · ❌ *"ห้ามอัปโหลดซ้ำ/เผยแพร่มอดนี้ไปยังเว็บไซต์ใด ๆ โดยไม่ได้รับอนุญาตชัดแจ้ง"* | **อนุญาตให้ใช้ใน modpack** และ `docs/MODLIST.md` ให้เครดิตกับลิงก์ไว้แล้ว ส่วนข้อห้ามอัปโหลดซ้ำคือคำถามเรื่อง rehost เดียวกับ Serene Seasons และ Entity Culling |
+| **Immersive Posts** | *"อย่าแจกจ่ายมอดนี้ซ้ำ เว้นแต่เป็นส่วนหนึ่งของ pack!"* | **อนุญาตสำหรับ pack** อย่างชัดเจน ตัวจัดประเภทอ่านมันเป็นข้อห้าม — ซึ่งตรงข้ามกัน |
+
+## สิ่งที่ฝั่ง CurseForge ของ audit นี้อ่านไม่ได้
+
+คำอธิบายบนหน้าโปรเจกต์ CurseForge 16 หน้าไม่ได้ให้ข้อความเรื่องสิทธิ์ modpack กับตัวดึงข้อมูลเลย
+นั่นเป็น**ข้อจำกัดของวิธี ไม่ใช่สิ่งที่พบเกี่ยวกับมอด** — CurseForge แสดงคำอธิบายในรูปแบบที่การดึงนี้เข้าไม่ถึง
+แถวเหล่านั้นยังเป็นยังไม่ได้อ่าน และต้องใช้เบราว์เซอร์
 
 ## สัญญาอนุญาตแบบเปิด — 59 มอด
 


### PR DESCRIPTION
## Summary

#53 stated:

> **Disabling API distribution is how an author says "not in someone else's pack."** It is a setting,
> not prose, and it is the clearest statement of intent in this audit.

**That was too strong,** and continuing the audit produced the measurement that disproves it.

## The measurement

All four "opt-out" mods appear in **this pack's own CurseForge manifest**, referenced by project and
file id — the form CurseForge's own installer resolves:

```
takkit                1269552   IN MANIFEST
flashier-flashlights  1604184   IN MANIFEST
client-dynamic-light  1302060   IN MANIFEST
player-microchip      1488872   IN MANIFEST
```

What the flag **demonstrably** does is narrower than what #53 claimed: the **third-party** CurseForge
API stops returning a download URL, which is why `pack.mjs` falls back to the website endpoint. It
distinguishes *third-party launchers* from *CurseForge itself*, and reading it as "no modpacks"
conflates the two.

**This matters to the decision.** #53 put "the two All-Rights-Reserved opt-outs" in front of the
developer as the sharpest case. They are still unread — they are no longer *prohibited*.

## Two permissions actually read

Continuing through the 42 unread pages produced prose for two, and **both were misread by the
classifier #53 abandoned**:

| Mod | The author's words | Reading |
|---|---|---|
| **Subtle Effects** | ✅ *"Use this mod in modpacks with credit and one or more links to any of the project pages"* · ❌ *"Reupload/publish this mod to any website without explicit permission"* | **permitted** — and `docs/MODLIST.md` already supplies credit and link. The reupload clause is the same rehosting question as Serene Seasons |
| **Immersive Posts** | *"Do not redistribute this mod unless as part of a pack!"* | **permitted for packs**, explicitly |

## And a limit of the method, stated as one

16 CurseForge project pages yielded **no** modpack-permission prose to the scraper. That is not a
finding about those mods — CurseForge renders descriptions in a form this extraction did not reach.
Those rows stay unread and need a browser.

## Acceptance criteria

- [ ] The overclaim is corrected **in place**, with the measurement that forces it
- [ ] The four are described as unread, not prohibited
- [ ] Subtle Effects and Immersive Posts recorded from their own words
- [ ] The scraper's blind spot recorded as a limit of the method
- [ ] Both language mirrors updated

## Out of scope

**Reading the 16 by browser.** Still the bulk of the remaining work.

**#53's decision.** Unchanged: whether a self-contained pack may rehost jars at all. This narrows
which mods are evidence for the hard case; it does not answer it.

---

## สรุปภาษาไทย

### สรุป

#53 เขียนไว้ว่า:

> **การปิดการแจกจ่ายผ่าน API คือวิธีที่ผู้เขียนบอกว่า "ไม่เอาไปใส่ pack ของคนอื่น"**
> มันเป็นการตั้งค่า ไม่ใช่ข้อความ และเป็นการแสดงเจตนาที่ชัดที่สุดใน audit นี้

**นั่นแรงเกินไป** และการทำ audit ต่อก็ให้การวัดที่หักล้างมันเอง

### การวัด

มอด "opt-out" ทั้งสี่ตัวปรากฏใน **CurseForge manifest ของ pack นี้เอง** โดยอ้างด้วย project
และ file id — รูปแบบที่ตัวติดตั้งของ CurseForge เองอ่าน:

```
takkit                1269552   IN MANIFEST
flashier-flashlights  1604184   IN MANIFEST
client-dynamic-light  1302060   IN MANIFEST
player-microchip      1488872   IN MANIFEST
```

สิ่งที่แฟล็กนั้นทำ**ได้จริง**แคบกว่าที่ #53 อ้าง: CurseForge API ของ**บุคคลที่สาม**จะหยุดคืน
URL ดาวน์โหลด ซึ่งเป็นเหตุผลที่ `pack.mjs` ถอยไปใช้ endpoint ของเว็บ มันแยก
*launcher ของบุคคลที่สาม* ออกจาก *ตัว CurseForge เอง* และการอ่านมันว่า "ห้าม modpack"
คือการรวมสองเรื่องเข้าด้วยกัน

**เรื่องนี้มีผลต่อการตัดสินใจ** #53 วาง "สองตัวที่เป็น All-Rights-Reserved และปิด API"
ไว้ตรงหน้าผู้พัฒนาในฐานะกรณีที่ชัดที่สุด พวกมันยังเป็น "ยังไม่ได้อ่าน" อยู่ — แต่ไม่ใช่ *ต้องห้าม* อีกต่อไป

### สิทธิ์สองรายการที่อ่านได้จริง

การไล่อ่านหน้าที่ยังไม่ได้อ่าน 42 หน้าต่อ ได้ข้อความมาสองราย และ**ทั้งคู่ถูกตัวจัดประเภทที่ #53
เลิกใช้อ่านผิด**:

| มอด | ถ้อยคำของผู้เขียน | การอ่าน |
|---|---|---|
| **Subtle Effects** | ✅ *"ใช้มอดนี้ใน modpack ได้โดยให้เครดิตและใส่ลิงก์ไปหน้าโปรเจกต์อย่างน้อยหนึ่งลิงก์"* · ❌ *"ห้ามอัปโหลดซ้ำ/เผยแพร่มอดนี้ไปยังเว็บไซต์ใด ๆ โดยไม่ได้รับอนุญาตชัดแจ้ง"* | **อนุญาต** — และ `docs/MODLIST.md` ให้เครดิตกับลิงก์ไว้แล้ว ส่วนข้อห้ามอัปโหลดซ้ำคือคำถามเรื่อง rehost เดียวกับ Serene Seasons |
| **Immersive Posts** | *"อย่าแจกจ่ายมอดนี้ซ้ำ เว้นแต่เป็นส่วนหนึ่งของ pack!"* | **อนุญาตสำหรับ pack** อย่างชัดเจน |

### และข้อจำกัดของวิธี พูดในฐานะข้อจำกัด

หน้าโปรเจกต์ CurseForge 16 หน้า**ไม่ได้**ให้ข้อความเรื่องสิทธิ์ modpack กับตัวดึงข้อมูลเลย
นั่นไม่ใช่สิ่งที่พบเกี่ยวกับมอดพวกนั้น — CurseForge แสดงคำอธิบายในรูปแบบที่การดึงนี้เข้าไม่ถึง
แถวเหล่านั้นยังเป็นยังไม่ได้อ่าน และต้องใช้เบราว์เซอร์

### เกณฑ์การปิดงาน

- [ ] แก้คำกล่าวที่แรงเกิน **ในที่เดิม** พร้อมการวัดที่บังคับให้ต้องแก้
- [ ] ทั้งสี่ตัวถูกอธิบายว่ายังไม่ได้อ่าน ไม่ใช่ต้องห้าม
- [ ] บันทึก Subtle Effects กับ Immersive Posts จากถ้อยคำของพวกเขาเอง
- [ ] บันทึกจุดบอดของตัวดึงข้อมูลในฐานะข้อจำกัดของวิธี
- [ ] อัปเดตทั้งสองภาษา

### นอกขอบเขต

**การอ่าน 16 หน้าด้วยเบราว์เซอร์** ยังเป็นเนื้องานที่เหลือส่วนใหญ่

**การตัดสินใจของ #53** ไม่เปลี่ยน: ว่า pack แบบมีทุกอย่างในตัวจะ rehost jar ได้หรือไม่
เรื่องนี้ทำให้ชัดขึ้นว่ามอดตัวไหนเป็นหลักฐานของกรณียาก แต่ไม่ได้ตอบคำถามนั้น
