### PR TITLE
fix(docs): the mod count went 99 to 107 and eight documents did not follow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,10 +42,10 @@ no entry, no tag, and is never handed to a friend as if it were a release.
   previously showed nothing; doors, chests, levers and lanterns that animate when you use them; and
   weather you can feel — rain and snow as real particles, wind, and ripples where rain hits water.
   **None of it is verified** — see the note at the end.
-- **`MODLIST.md`** and a licence record for every mod in it. The pack ships 99 mods by dozens of
+- **`MODLIST.md`** and a licence record for every mod in it. The pack ships 107 mods by dozens of
   authors; `docs/distribution-licenses.md` says what each one's licence is and where that was read.
 - **A mod list you can actually read.** `MODLIST.md` sits at the top of both the client and the
-  server download: all 99 mods, the exact jar filename of each, whether it runs on the client, the
+  server download: all 107 mods, the exact jar filename of each, whether it runs on the client, the
   server or both, and a link to the page it came from. Every mod in this pack is somebody else's
   work and this is where they are credited.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,10 +139,10 @@ node scripts/validate/verify.mjs          # both phases — this is the local sh
 node scripts/validate/verify.mjs lint     # syntax · placeholders · JEI orphans · the packwiz manifest
 node scripts/validate/verify.mjs test     # node --check over every kubejs/**/*.js
 
-node scripts/build/build-instance.mjs     # the self-contained client instance (389 MB, 99 mods)
-node scripts/build/build-server.mjs       # the server pack (332 MB, 89 mods — Distribution Spec §12)
+node scripts/build/build-instance.mjs     # the self-contained client instance (405 MB, 107 mods)
+node scripts/build/build-server.mjs       # the server pack (341 MB, 91 mods — Distribution Spec §12)
 node scripts/build/generate-checksums.mjs # build/SHA256SUMS.txt, and refuses a stale artifact
-node scripts/build/generate-modlist.mjs   # docs/MODLIST.md — 99 mods, source URLs resolved from ids
+node scripts/build/generate-modlist.mjs   # docs/MODLIST.md — 107 mods, source URLs resolved from ids
 
 node scripts/validate/config-drift.mjs <install>   # "friend A works, friend B doesn't" (§38)
 

--- a/DONE.md
+++ b/DONE.md
@@ -6,6 +6,128 @@
 
 ---
 
+## The roster, the licence question, and the sixth spec (2026-08-27, #50 – #64)
+
+**Goal:** tell a downloader what they are installing, then find out whether we are allowed to ship
+it, then execute the Visuals Spec that arrived mid-session.
+
+Nine PRs. The through-line is that **each answer produced a sharper question than the one asked.**
+
+### `docs/MODLIST.md` — and the rule that URLs are resolved, never composed
+
+99 mods by dozens of authors shipped uncredited anywhere a player would look. The roster is
+**generated** from `mods/*.pw.toml` through the existing `lib/pack.mjs`, and ships at the root of
+both the instance and the server zip — *after* the `.md` strip, because the strip keeps maintainer
+READMEs out of an install and this file is the opposite of that.
+
+**Slugs are measured, not guessed.** packwiz records project *ids*; a guessed slug has pointed at the
+wrong project twice here (`smoothplayeranimations`, and `create-industry` which is a modpack). The
+generator follows the id and records where it lands. It caught the trap again in a quieter form:
+**Soft Imprints lives at `snow-imprints`.**
+
+Three things the resolver learned by measurement, each of which had to happen before it was believed:
+
+| Symptom | Cause |
+|---|---|
+| a 78-second job ran past **10 minutes** | `fetch` has no default timeout; one stalled socket parks a worker |
+| 4 retries × 40 mods resolved **nothing**, slowly | backoff is right for a *transient* block, wrong for a sustained one |
+| a re-run **downgraded 12 rows** that already had links | regeneration was not monotonic |
+
+First pass 36/99, second 87/99, third **99/99** — because each run now keeps what the last one
+learned.
+
+### The licence audit asked the wrong question first
+
+It started as *"how many mods are All Rights Reserved."* That was wrong. The authors who write about
+modpacks mostly **permit** them, with a condition:
+
+> *Serene Seasons* — "as long as you **do not rehost the mod** and only use builds uploaded directly
+> by us"
+
+> *Entity Culling* — "**Do not redistribute the JAR files anywhere else!**"
+
+Both permit a **hosted** modpack, where the platform fetches from the author's upload. ADR 0003 chose
+**self-contained** delivery. **The conflict is with the distribution model, not the mod list** —
+swapping mods cannot fix it, and no artifact avoids it: even the CurseForge export bundles 65 jars in
+`overrides/` because a CurseForge manifest cannot reference Modrinth-sourced mods.
+
+**Automated classification was tried and abandoned.** It read *"Do not redistribute this mod **unless
+as part of a pack**!"* as a prohibition, and a bare FAQ heading as permission. Only the extracted
+evidence survives, quoted, for a person to judge.
+
+### Two things I wrote into committed documents that were wrong
+
+Both are the kind an adversarial reader catches, and `code-review` did not run all session because it
+mandates sub-agents this session could not spawn.
+
+**One.** I wrote that disabling CurseForge API distribution *"is how an author says 'not in someone
+else's pack'"* and called it the clearest statement of intent in the audit. **Too strong.** All four
+such mods appear in this pack's own CurseForge manifest by project and file id — the flag separates
+*third-party launchers* from *CurseForge itself*. Retracted in #61, which changed the sharpest case
+the audit had put in front of the developer.
+
+**Two.** I wrote that 16 CurseForge pages *"yielded no permission prose — CurseForge renders
+descriptions in a form this extraction did not reach."* That was **my regex**: a project page carries
+~49 separate `description` fields and the extraction matched the first. Fixed in #63; 19 of 20 then
+parsed fine. *"The tool couldn't reach it"* is a more comfortable finding than *"my extraction was
+wrong"*, and it went in unchecked.
+
+**All 107 pages are now read**: 3 explicit grants, 38 silent, 1 with no description field. Two of the
+three grants ask for **credit and a link** — which `MODLIST.md` has supplied since #50 without anyone
+having planned it as a compliance measure. **Silence is the ordinary case and it is not consent.**
+
+### The sixth spec, and where it turned out to be wrong about itself
+
+`Addon Spec — Khaojee Enchanted Visuals Integration.md` arrived registered nowhere and naming three
+documents that did not exist. **V0** swept 24 projects by title:
+
+- **Three entries it treats as mods are resource packs** — Fresh Animations, 3D World Decorations,
+  Lushier Forests. That is *why* Fresh Animations needs EMF + ETF.
+- **Particle Interactions has no 1.20.1 build on any loader.** It cannot be prototyped.
+- **Musgo has no Modrinth match**, and CurseForge has no search API without a key — recorded as
+  *unresolved*, not absent, and no slug was guessed.
+- **§44's six rejections are correct**, and now measured rather than argued: all are Fabric-only or
+  have no 1.20.1 file.
+
+**V1** added five visual mods, and packwiz got one side wrong: Modrinth says Subtle Effects is
+`server: optional`, so packwiz wrote `both`; the jar declares `side = "CLIENT"` with zero `data/`.
+**`optional` is neither** — §11 says inspect, and the jar answers what the field cannot. **Kotlin for
+Forge** arrived as a transitive dependency one level deeper than V0 looked.
+
+**V2** added Particle Rain. **V3 was not attempted**, and the reason is in the spec: Fusion is a
+*library* that changes nothing without a connected-texture resource pack, and §12 never names one.
+Adding it would put an All-Rights-Reserved library into a pack with an unresolved redistribution basis
+for **no visual change at all**. Ledger row reads *"needs a decision, not a client."*
+
+### What the boots proved, and what they cannot
+
+Two green boots (`Done (15.037s)`, `Done (12.803s)`, 83 recipes, 0 failed, all 50 ERROR lines
+pre-existing). **Every visual mod is `side = "client"`, so the only test this repo owns is
+structurally blind to the entire layer.** The boots prove the layer was correctly kept *off* the
+server. Nothing more.
+
+### A third rig trap
+
+`run.sh` points at `unix_args.txt`, whose classpath uses `:` separators. On Windows the JVM dies with
+an `InvalidPathException` that names no mod and no pack content. Use `win_args.txt`. A Forge server
+install ships **both** arg files and only `run.sh`.
+
+### Gates, stated honestly
+
+`code-review` and `scrutinize` **did not run on any of the nine PRs** — both mandate parallel
+sub-agents and this session's system prompt forbade spawning any. `/simplify` was run **inline** once
+(#51) and found two real defects, which is evidence the single-context form works and that not
+running it eight more times had a cost — the two retracted claims above are that cost, measured.
+
+### State
+
+**107 mods** · three artifacts (405 / 341 / 148 MB), `sha256sum -c` clean · `verify` covers 165
+indexed files, the roster's contents **and its stated count**, and a recorded licence for every mod
+· 17 boots · **one** ledger row left that needs neither a client nor a decision, and it needs an
+artist.
+
+---
+
 ## Release engineering — the seven rows I had wrongly written off (2026-08-25, `feat/41-side-classification-validate-pack`)
 
 **Goal:** answer "what is left in the MD before final" honestly, then do it.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -93,7 +93,7 @@ hundred lines name the mod. `crash-reports/` has the same information formatted 
 
 This is `0.1.0-alpha`.
 
-- ✅ **99 mods** at exact, verified versions; Create pinned to `6.0.8`. **`MODLIST.md`, at the top
+- ✅ **107 mods** at exact, verified versions; Create pinned to `6.0.8`. **`MODLIST.md`, at the top
   of this download, lists every one of them with a link to where it came from.**
 - ✅ **The balance work is done.** Guns are gated behind four tiers of factory output, ammunition is
   an industrial product, hordes arrive roughly every twelve days and grow, monsters fade in over
@@ -106,7 +106,7 @@ This is `0.1.0-alpha`.
 - ❌ **One known problem, unfixed:** Improved Mobs cannot read the defence values of Brimm Armors,
   so no Brimm armour will ever be worn by a mob.
 
-- ⚠️ **Do not post this publicly yet.** The pack bundles all 99 mods, and at least three authors
+- ⚠️ **Do not post this publicly yet.** The pack bundles all 107 mods, and at least three authors
   permit modpack inclusion only on condition that their jar is **not** rehosted. Whether this pack
   may be distributed at all is **unestablished** — not permitted, not prohibited, just unchecked
   until now. `docs/distribution-licenses.md` has the detail and names the decisions it needs.
@@ -210,7 +210,7 @@ java -jar packwiz-installer-bootstrap.jar http://localhost:8080/pack.toml
 
 นี่คือ `0.1.0-alpha`
 
-- ✅ **99 mod** ที่เวอร์ชันเป๊ะและตรวจสอบแล้ว Create pin ที่ `6.0.8`
+- ✅ **107 mod** ที่เวอร์ชันเป๊ะและตรวจสอบแล้ว Create pin ที่ `6.0.8`
   **`MODLIST.md` ที่อยู่บนสุดของไฟล์ที่โหลดมา ลงชื่อทุกตัวพร้อมลิงก์ไปยังที่มาของมัน**
 - ✅ **งาน balance ทำเสร็จแล้ว** ปืนถูกกั้นด้วยสี่ขั้นของกำลังการผลิต กระสุนเป็นของที่ต้องผลิต
   ในโรงงาน horde มาทุก ๆ สิบสองวันโดยประมาณและใหญ่ขึ้นเรื่อย ๆ สัตว์ประหลาดโผล่มาทีละนิด
@@ -221,7 +221,7 @@ java -jar packwiz-installer-bootstrap.jar http://localhost:8080/pack.toml
   และตัวเลขอาจผิดในแบบที่มีแต่การเล่นเท่านั้นที่จะเผย
 - ❌ **ปัญหาที่รู้แล้วหนึ่งข้อ ยังไม่ได้แก้:** Improved Mobs อ่านค่าป้องกันของ Brimm Armors ไม่ได้
   ดังนั้นจะไม่มีมอบตัวไหนสวมเกราะ Brimm เลย
-- ⚠️ **ยังอย่าเพิ่งโพสต์สาธารณะ** pack รวมมอดทั้ง 99 ตัวไว้ข้างใน
+- ⚠️ **ยังอย่าเพิ่งโพสต์สาธารณะ** pack รวมมอดทั้ง 107 ตัวไว้ข้างใน
   และมีผู้เขียนอย่างน้อยสามคนที่อนุญาตให้ใส่ modpack ได้โดยมีเงื่อนไขว่าต้อง**ไม่** rehost ตัว jar ของเขา
   เรื่องที่ว่า pack นี้แจกจ่ายได้หรือไม่นั้น **ยังไม่ได้ถูกกำหนด** — ไม่ใช่อนุญาต ไม่ใช่ห้าม
   แค่ยังไม่มีใครตรวจจนถึงตอนนี้ `docs/distribution-licenses.md` มีรายละเอียดและระบุการตัดสินใจที่ต้องใช้

--- a/docs/MODLIST.md
+++ b/docs/MODLIST.md
@@ -1,4 +1,5 @@
 <!-- roster-digest: 3cdd2d4a02b4b18d47b99b6fe6a6e5de2bcea5ace0b5591e33b999f95369b766 -->
+<!-- mod-count: 107 -->
 <!-- GENERATED FILE — do not edit by hand.
      Run: node scripts/build/generate-modlist.mjs
      `verify` refuses a roster that disagrees with mods/. -->
@@ -23,7 +24,8 @@ file is the complete one.
 ## Reading the table
 
 **The File column is the exact jar filename**, not a tidied-up version number. That is deliberate:
-99 mods use 99 filename conventions, and parsing a version out of them would mean guessing. The
+107 mods use 107 filename conventions, and parsing a version out of them would mean
+guessing. The
 filename is what is actually on your disk, so it is also what you can match against your `mods/`
 folder when something goes wrong.
 
@@ -38,8 +40,8 @@ mods are not installed on a server and are not missing when they are absent.
 
 ## อ่านตารางยังไง
 
-**คอลัมน์ File คือชื่อไฟล์ jar จริง ๆ** ไม่ใช่เลขเวอร์ชันที่จัดให้สวย ตั้งใจให้เป็นแบบนั้น เพราะมอด 99 ตัว
-ใช้รูปแบบการตั้งชื่อไฟล์ 99 แบบ การพยายามแกะเวอร์ชันออกมาคือการเดา ชื่อไฟล์คือสิ่งที่อยู่บนเครื่องคุณจริง ๆ
+**คอลัมน์ File คือชื่อไฟล์ jar จริง ๆ** ไม่ใช่เลขเวอร์ชันที่จัดให้สวย ตั้งใจให้เป็นแบบนั้น เพราะมอด 107 ตัว
+ใช้รูปแบบการตั้งชื่อไฟล์ 107 แบบ การพยายามแกะเวอร์ชันออกมาคือการเดา ชื่อไฟล์คือสิ่งที่อยู่บนเครื่องคุณจริง ๆ
 ดังนั้นมันจึงเป็นสิ่งที่คุณเอาไปเทียบกับโฟลเดอร์ `mods/` ได้ตอนมีอะไรผิดพลาด
 
 **ลิงก์ต้นทาง resolve มา ไม่ได้เดา** packwiz บันทึก project *id* ไว้ ไม่เคยบันทึก slug

--- a/docs/OPEN-WORK-LEDGER.md
+++ b/docs/OPEN-WORK-LEDGER.md
@@ -11,7 +11,7 @@
 🔴 **UNTRACKED** (MD-only, no GitHub issue — highest miss-risk) · ⛔ decided won't-do (kept
 visible so it is not re-proposed as if it were open)
 
-**Current state, stated plainly:** the pack is **built and customized**. 99 mods pinned with
+**Current state, stated plainly:** the pack is **built and customized**. 107 mods pinned with
 exact versions and hashes, `config/` · `defaultconfigs/` · `kubejs/` · `config/ftbquests/` all
 written, and **20 of the 22 customization rows implemented** with 3 declined-with-reasons and 2
 parked against named blockers (`docs/customization-map.md`). Every change was proven on a
@@ -145,7 +145,7 @@ Folded into the operating layer under **#7**.
 | `scripts/build/` — `build-server`, `generate-checksums` | ✅ | — | **#42**. Both written, plus `lib/pack.mjs` extracted so the two builds cannot disagree about a hash check. `build-instance` went 222 → 149 lines |
 | Grow `verify.mjs` into `validate-pack` | ✅ 7 of 10 · 🟡 3 | the rest need a launched game or a dependency graph packwiz does not record | **#41**. Added pack metadata (incl. a stale `[index]` hash), missing mods, duplicate mods, unexpected client/server. Still open: missing dependencies, KubeJS startup errors, broken config references |
 | COMMON / SERVER / CLIENT side classification | ✅ | — | **#41**. `docs/side-classification.md` — 87 `both` · 10 `client` · 2 `server`, each one-sided call graded by evidence. Three errors found: two by cross-referencing the metafiles against the matrix (one wrong in each), one by a `clientSideOnly` sweep |
-| Server pack, version-locked to the client pack | ✅ | — | **#42**. 89 mods, 332 MB, `pack-version.txt` in both artifacts. Booted green from a **fresh** Forge install — and that boot verified the tracker recipes and found the Brimm × Improved Mobs interaction |
+| Server pack, version-locked to the client pack | ✅ | — | **#42**. 89 mods / 332 MB **as shipped then** — 91 / 341 MB today after Visuals V1. `pack-version.txt` in both artifacts. Booted green from a **fresh** Forge install — and that boot verified the tracker recipes and found the Brimm × Improved Mobs interaction |
 | Config ownership map — PACK CONTROLLED vs USER PREFERENCE | ✅ | — | **#43**. `docs/config-ownership.md`. The rule is structural, not a list: the pack owns exactly the 39 files it ships, because those are the only ones in the index for packwiz to write |
 | `scripts/validate/config-drift` | ✅ | — | **#43**. Compares **values**, not hashes — measured: 4 of 4 TOML configs drift at byte level after one boot and 2 of 2 JSON do not, so a hash check would be wrong on every install |
 | Release gate — the 12 in-game tests | 🔴 | needs a launchable pack | Distribution Spec §16. **Not automatable.** Human protocol, sibling of §26–27 |

--- a/docs/distribution-licenses.md
+++ b/docs/distribution-licenses.md
@@ -3,7 +3,7 @@
 
 **What this is.** One row per mod the pack ships, its licence, and where that licence was read.
 *Visuals Spec §35* asks for it before shipping; ADR 0003 made the pack self-contained, which means
-it has been redistributing 99 jars since the first build (107 as of Visuals V2).
+it has been redistributing every jar it ships since the first build — **107** of them today.
 
 **What it is not.** A legal opinion, and not a clean bill of health. **All 107 have now been read. 38 of them say nothing about
 redistribution, which is not the same as permitting it.** A licence that could not be determined is recorded as unread, never assumed.
@@ -38,11 +38,11 @@ their licences.** Swapping mods will not fix it; only changing how the pack is d
 
 | Artifact | How mods reach the player | Rehosts a jar? |
 |---|---|---|
-| `…-instance.zip` (389 MB) | all 99 jars inside the zip | **yes, 99** |
-| `…-server.zip` (332 MB) | all 89 jars inside the zip | **yes, 89** |
-| `…-alpha.zip` (CurseForge, 132 MB) | **40** referenced by project/file id · **57** bundled in `overrides/mods/` | **yes, 57** |
+| `…-instance.zip` (405 MB) | all 107 jars inside the zip | **yes, 107** |
+| `…-server.zip` (341 MB) | all 91 jars inside the zip | **yes, 91** |
+| `…-alpha.zip` (CurseForge, 148 MB) | **40** referenced by project/file id · **65** bundled in `overrides/mods/` | **yes, 65** |
 
-The CurseForge-format export is closest to compliant, and still bundles 57 jars — packwiz puts
+The CurseForge-format export is closest to compliant, and still bundles 65 jars — packwiz puts
 Modrinth-sourced mods in `overrides/` because a CurseForge manifest cannot reference them.
 
 ## Four authors switched off third-party distribution
@@ -271,7 +271,7 @@ proposes but has not installed. `docs/khaojee-visual-reference.md` records their
 
 **นี่คืออะไร** หนึ่งแถวต่อหนึ่งมอดที่ pack ส่งไป สัญญาอนุญาตของมัน และอ่านมาจากไหน
 *Visuals Spec §35* ขอไว้ให้ทำก่อนส่งมอบ ส่วน ADR 0003 ทำให้ pack เป็นแบบมีทุกอย่างในตัว
-ซึ่งแปลว่ามันแจกจ่าย jar 99 ตัวซ้ำมาตั้งแต่ build แรก (107 ตัวนับตั้งแต่ Visuals V2)
+ซึ่งแปลว่ามันแจกจ่าย jar ทุกตัวที่มันส่งซ้ำมาตั้งแต่ build แรก — วันนี้คือ **107** ตัว
 
 **ไม่ใช่อะไร** ไม่ใช่ความเห็นทางกฎหมาย และไม่ใช่ใบรับรองว่าทุกอย่างสะอาด **ทั้ง 107 ตัวถูกอ่านแล้ว 38 ตัวไม่ได้พูดถึงการแจกจ่ายซ้ำเลย ซึ่งไม่เท่ากับการอนุญาต**
 สัญญาอนุญาตที่หาไม่ได้ถูกบันทึกว่ายังไม่ได้อ่าน ไม่ใช่สมมติเอา
@@ -306,11 +306,11 @@ proposes but has not installed. `docs/khaojee-visual-reference.md` records their
 
 | Artifact | มอดไปถึงผู้เล่นยังไง | rehost jar ไหม |
 |---|---|---|
-| `…-instance.zip` (389 MB) | jar ทั้ง 99 ตัวอยู่ใน zip | **ใช่ 99 ตัว** |
-| `…-server.zip` (332 MB) | jar ทั้ง 89 ตัวอยู่ใน zip | **ใช่ 89 ตัว** |
-| `…-alpha.zip` (CurseForge, 132 MB) | **40** อ้างด้วย project/file id · **57** ใส่ไว้ใน `overrides/mods/` | **ใช่ 57 ตัว** |
+| `…-instance.zip` (405 MB) | jar ทั้ง 107 ตัวอยู่ใน zip | **ใช่ 107 ตัว** |
+| `…-server.zip` (341 MB) | jar ทั้ง 91 ตัวอยู่ใน zip | **ใช่ 91 ตัว** |
+| `…-alpha.zip` (CurseForge, 148 MB) | **40** อ้างด้วย project/file id · **65** ใส่ไว้ใน `overrides/mods/` | **ใช่ 65 ตัว** |
 
-ตัว export รูปแบบ CurseForge ใกล้เคียงกับที่ถูกต้องที่สุด และก็ยังใส่ jar มา 57 ตัว —
+ตัว export รูปแบบ CurseForge ใกล้เคียงกับที่ถูกต้องที่สุด และก็ยังใส่ jar มา 65 ตัว —
 packwiz เอามอดที่มาจาก Modrinth ไปไว้ใน `overrides/` เพราะ manifest ของ CurseForge อ้างถึงมันไม่ได้
 
 ## ผู้เขียนสี่คนปิดการแจกจ่ายผ่านบุคคลที่สาม

--- a/docs/khaojee-visual-reference.md
+++ b/docs/khaojee-visual-reference.md
@@ -111,7 +111,8 @@ combat readability under Horde-in-rain, NVG usability. This repo has never launc
 
 **Whether we may ship them.** Three of the seven adoption-set mods are All Rights Reserved. That is
 the ordinary default on both hosts and many such authors permit modpack inclusion — but nobody has
-read the terms, for these or for the 99 mods already in the pack. Issue **#53**.
+read the terms, for these or for the mods already in the pack. Issue **#53**, which has since
+read all 107.
 
 **The worldgen question.** §33 says worldgen must be settled before persistent play begins, and
 §15 requires multiple seeds. That is V6–V8 and it is a decision, not a lookup.
@@ -229,7 +230,7 @@ spec เลื่อนพวกนี้ออกไปด้วยเหตุ
 
 **ว่าเราแจกจ่ายมันได้หรือเปล่า** สามจากเจ็ดในชุด adoption เป็น All Rights Reserved
 นั่นคือค่าเริ่มต้นปกติของทั้งสองเจ้า และผู้เขียนจำนวนมากก็อนุญาตให้ใส่ modpack —
-แต่ยังไม่มีใครไปอ่านเงื่อนไข ทั้งของพวกนี้และของมอด 99 ตัวที่อยู่ใน pack แล้ว issue **#53**
+แต่ยังไม่มีใครไปอ่านเงื่อนไข ทั้งของพวกนี้และของมอดที่อยู่ใน pack แล้ว issue **#53** ซึ่งตอนนี้อ่านครบทั้ง 107 ตัวแล้ว
 
 **คำถามเรื่อง worldgen** §33 บอกว่า worldgen ต้องนิ่งก่อนเริ่มเล่นโลกถาวร และ §15 ต้องการหลาย seed
 นั่นคือ V6–V8 และมันเป็นการตัดสินใจ ไม่ใช่การเปิดดู

--- a/scripts/build/generate-modlist.mjs
+++ b/scripts/build/generate-modlist.mjs
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 // Generates `docs/MODLIST.md` — the roster a downloader reads to find out what
-// they just installed, and the only place this repo credits the 99 authors whose
+// they just installed, and the only place this repo credits the authors whose
 // work the pack ships.
 //
 // Generated rather than written by hand, for the same reason `SHA256SUMS.txt` is:
-// a hand-maintained list of 99 rows is wrong the first time a version bumps, and
+// a hand-maintained list of a hundred-odd rows is wrong the first time a version bumps, and
 // nothing would catch it. `verify.mjs` refuses a roster that disagrees with
 // `mods/`.
 //
@@ -212,6 +212,7 @@ const digest = rosterDigest(
     .map(f => ({ file: `mods/${f}`, meta: parseMeta(readFileSync(join(ROOT, 'mods', f), 'utf8')) })))
 
 const doc = `<!-- roster-digest: ${digest} -->
+<!-- mod-count: ${metas.length} -->
 <!-- GENERATED FILE — do not edit by hand.
      Run: node scripts/build/generate-modlist.mjs
      \`verify\` refuses a roster that disagrees with mods/. -->
@@ -236,7 +237,8 @@ file is the complete one.
 ## Reading the table
 
 **The File column is the exact jar filename**, not a tidied-up version number. That is deliberate:
-99 mods use 99 filename conventions, and parsing a version out of them would mean guessing. The
+${metas.length} mods use ${metas.length} filename conventions, and parsing a version out of them would mean
+guessing. The
 filename is what is actually on your disk, so it is also what you can match against your \`mods/\`
 folder when something goes wrong.
 
@@ -251,8 +253,8 @@ mods are not installed on a server and are not missing when they are absent.
 
 ## อ่านตารางยังไง
 
-**คอลัมน์ File คือชื่อไฟล์ jar จริง ๆ** ไม่ใช่เลขเวอร์ชันที่จัดให้สวย ตั้งใจให้เป็นแบบนั้น เพราะมอด 99 ตัว
-ใช้รูปแบบการตั้งชื่อไฟล์ 99 แบบ การพยายามแกะเวอร์ชันออกมาคือการเดา ชื่อไฟล์คือสิ่งที่อยู่บนเครื่องคุณจริง ๆ
+**คอลัมน์ File คือชื่อไฟล์ jar จริง ๆ** ไม่ใช่เลขเวอร์ชันที่จัดให้สวย ตั้งใจให้เป็นแบบนั้น เพราะมอด ${metas.length} ตัว
+ใช้รูปแบบการตั้งชื่อไฟล์ ${metas.length} แบบ การพยายามแกะเวอร์ชันออกมาคือการเดา ชื่อไฟล์คือสิ่งที่อยู่บนเครื่องคุณจริง ๆ
 ดังนั้นมันจึงเป็นสิ่งที่คุณเอาไปเทียบกับโฟลเดอร์ \`mods/\` ได้ตอนมีอะไรผิดพลาด
 
 **ลิงก์ต้นทาง resolve มา ไม่ได้เดา** packwiz บันทึก project *id* ไว้ ไม่เคยบันทึก slug

--- a/scripts/validate/verify.mjs
+++ b/scripts/validate/verify.mjs
@@ -313,6 +313,20 @@ function lintModlist() {
     return 0
   }
 
+  // The digest covers the metafiles, deliberately not the prose — it must never
+  // need the network. That left the generated *narrative* unguarded, and it
+  // drifted: the file listed 107 rows under a paragraph that said 99, because
+  // the generator had the number as a literal. This checks the one number the
+  // prose states about itself.
+  const count = doc.match(/<!--\s*mod-count:\s*(\d+)\s*-->/)
+  if (!count) {
+    fail(listPath, `no \`<!-- mod-count: N -->\` marker — the roster's own prose cannot be checked against mods/.
+  Run: node scripts/build/generate-modlist.mjs`)
+  } else if (Number(count[1]) !== metafiles.length) {
+    fail(listPath, `says it covers ${count[1]} mods, but mods/ has ${metafiles.length}.
+  Run: node scripts/build/generate-modlist.mjs`)
+  }
+
   const actual = rosterDigest(metafiles.map(f => ({
     file: f, meta: parseMeta(readFileSync(join(ROOT, f), 'utf8')),
   })))


### PR DESCRIPTION
## Summary

The pack went 99 → 106 → 107 mods across #56 and #58. **The documents did not follow**, and one of
them is a *generated* file that says the wrong number about itself.

## The worst one: `docs/MODLIST.md` contradicts its own table

`scripts/build/generate-modlist.mjs` **hardcodes `99` in the prose it emits**:

```js
99 mods use 99 filename conventions, and parsing a version out of them would mean guessing.
```

So the file lists **107** rows under a paragraph that says **99**, in both languages. Regenerating
does not fix it — regenerating *reproduces* it.

**And the freshness gate cannot see this.** `rosterDigest` covers name, filename, side and project id
from the metafiles. The prose is outside it by design — the digest exists so the gate never needs the
network — but that design left the generated *narrative* unguarded.

## Everything else that is stale

| File | Says | Should say |
|---|---|---|
| `CLAUDE.md` | `build-instance` → "389 MB, 99 mods" | 406 MB, 107 |
| `CLAUDE.md` | `build-server` → "332 MB, 89 mods" | 341 MB, 91 |
| `CLAUDE.md` | `generate-modlist` → "99 mods" | 107 |
| `INSTALL.md` | "99 mods" (EN **and** TH), "bundles all 99 mods" | 107 |
| `CHANGELOG.md` | "ships 99 mods", "all 99 mods" | 107 |
| `docs/distribution-licenses.md` | table row "`…-instance.zip` (389 MB) … **yes, 99**" | 406 MB, 107 |
| `docs/OPEN-WORK-LEDGER.md` | "99 mods pinned" | 107 |
| `docs/khaojee-visual-reference.md` | "the 99 mods already in the pack" | 107 |

**`docs/side-classification.md` is correct** — its census reads 89 / 16 / 2, which is 107. It was
updated in #56 and #58 because those PRs touched it directly.

That is the pattern: **the documents a PR edits stay right; the documents it merely invalidates go
stale.** Nothing in the repo connects "the mod count changed" to "these eight files quote the mod
count."

## And the ship log is missing five units of work

`DONE.md` has nine entries and the newest is the Track 5 batch. It has **no entry** for the roster
(#50), the licence audit (#53), the Visuals Spec registration and V0 (#52), V1 (#56), V2 (#58), or
the two corrections (#60, #62). `CLAUDE.md` calls `DONE.md` the ship log and the session-end protocol
says to record what shipped.

## Proposal

1. **Make the generator's prose derive its numbers**, so `MODLIST.md` cannot disagree with itself
   again.
2. **Add a `verify` check**: the roster must state the current mod count. Cheap, offline, and
   falsifiable — the same shape as the digest check, aimed at the part the digest deliberately
   ignores.
3. Correct the eight stale files.
4. Write the missing `DONE.md` entry.

## Acceptance criteria

- [ ] `generate-modlist.mjs` emits no hardcoded mod count; regenerating a changed pack produces
      correct prose
- [ ] `verify` fails on a roster whose stated count disagrees with `mods/`, **demonstrated** before
      it is trusted
- [ ] All eight files corrected, both language mirrors where they have one
- [ ] `DONE.md` covers #50 through #63
- [ ] Artifact sizes quoted anywhere match the artifacts on disk

## Out of scope

**A general "no stale numbers" gate.** Prose counts in eight unrelated documents are not
mechanically checkable without inventing a markup convention. The gate here is scoped to the one file
that is *generated* and therefore has a machine-knowable truth.

---

## สรุปภาษาไทย

### สรุป

pack ไปจาก 99 → 106 → 107 มอดผ่าน #56 และ #58 **เอกสารไม่ได้ตามไปด้วย**
และหนึ่งในนั้นเป็นไฟล์ที่ *สร้างอัตโนมัติ* ซึ่งบอกตัวเลขของตัวเองผิด

### ตัวที่แย่ที่สุด: `docs/MODLIST.md` ขัดกับตารางของตัวเอง

`scripts/build/generate-modlist.mjs` **hardcode เลข `99` ไว้ในข้อความที่มันสร้าง**:

```js
99 mods use 99 filename conventions, and parsing a version out of them would mean guessing.
```

ไฟล์จึงลงตาราง **107** แถวอยู่ใต้ย่อหน้าที่บอกว่า **99** ทั้งสองภาษา การ regenerate ไม่ได้แก้ —
มัน*ผลิตซ้ำ*ปัญหา

**และด่านตรวจความสดมองไม่เห็นเรื่องนี้** `rosterDigest` ครอบคลุมชื่อ ชื่อไฟล์ side และ project id
จาก metafile ส่วนตัวข้อความอยู่นอกขอบเขตโดยตั้งใจ — digest มีไว้เพื่อให้ด่านตรวจไม่ต้องใช้เน็ต —
แต่การออกแบบนั้นทำให้*เนื้อความ*ที่ถูกสร้างขึ้นไม่มีใครเฝ้า

### ทุกอย่างที่เหลือที่ค้าง

| ไฟล์ | เขียนว่า | ควรเป็น |
|---|---|---|
| `CLAUDE.md` | `build-instance` → "389 MB, 99 mods" | 406 MB, 107 |
| `CLAUDE.md` | `build-server` → "332 MB, 89 mods" | 341 MB, 91 |
| `CLAUDE.md` | `generate-modlist` → "99 mods" | 107 |
| `INSTALL.md` | "99 mods" (ทั้ง EN **และ** TH), "bundles all 99 mods" | 107 |
| `CHANGELOG.md` | "ships 99 mods", "all 99 mods" | 107 |
| `docs/distribution-licenses.md` | แถว "`…-instance.zip` (389 MB) … **yes, 99**" | 406 MB, 107 |
| `docs/OPEN-WORK-LEDGER.md` | "99 mods pinned" | 107 |
| `docs/khaojee-visual-reference.md` | "the 99 mods already in the pack" | 107 |

**`docs/side-classification.md` ถูกต้อง** — census อ่านได้ 89 / 16 / 2 ซึ่งเท่ากับ 107
มันถูกอัปเดตใน #56 และ #58 เพราะ PR เหล่านั้นแก้มันโดยตรง

นั่นคือรูปแบบของปัญหา: **เอกสารที่ PR แก้จะถูกต้อง เอกสารที่ PR แค่ทำให้ไม่จริงจะค้าง**
ไม่มีอะไรใน repo เชื่อม "จำนวนมอดเปลี่ยน" เข้ากับ "แปดไฟล์นี้อ้างจำนวนมอด"

### และ ship log ขาดงานไปห้าชิ้น

`DONE.md` มีเก้า entry และอันใหม่สุดคือชุด Track 5 มัน **ไม่มี entry** สำหรับ roster (#50),
การ audit สัญญาอนุญาต (#53), การขึ้นทะเบียน Visuals Spec และ V0 (#52), V1 (#56), V2 (#58)
หรือการแก้สองครั้ง (#60, #62) `CLAUDE.md` เรียก `DONE.md` ว่า ship log
และ protocol ตอนจบเซสชันบอกให้บันทึกสิ่งที่ ship ไป

### ข้อเสนอ

1. **ทำให้ข้อความที่ generator สร้างอนุมานตัวเลขเอง** เพื่อให้ `MODLIST.md` ขัดกับตัวเองไม่ได้อีก
2. **เพิ่มการตรวจใน `verify`**: roster ต้องระบุจำนวนมอดปัจจุบัน ถูก ไม่ต้องใช้เน็ต และ falsify ได้ —
   รูปแบบเดียวกับการตรวจ digest แต่เล็งไปที่ส่วนที่ digest จงใจไม่ดู
3. แก้ไฟล์ที่ค้างทั้งแปด
4. เขียน entry ของ `DONE.md` ที่ขาดไป

### เกณฑ์การปิดงาน

- [ ] `generate-modlist.mjs` ไม่มีจำนวนมอดที่ hardcode ไว้; regenerate บน pack ที่เปลี่ยนแล้วได้ข้อความถูก
- [ ] `verify` fail เมื่อ roster ระบุจำนวนไม่ตรงกับ `mods/` โดย **สาธิตให้เห็น** ก่อนจะเชื่อถือ
- [ ] แก้ครบทั้งแปดไฟล์ รวมทั้งฉบับภาษาที่สองที่ไฟล์นั้นมี
- [ ] `DONE.md` ครอบคลุม #50 ถึง #63
- [ ] ขนาด artifact ที่อ้างไว้ที่ไหนก็ตามตรงกับ artifact จริงบนดิสก์

### นอกขอบเขต

**ด่านตรวจ "ห้ามมีตัวเลขค้าง" แบบทั่วไป** จำนวนที่เขียนเป็นข้อความในเอกสารแปดไฟล์ที่ไม่เกี่ยวกัน
ตรวจด้วยเครื่องไม่ได้ถ้าไม่ประดิษฐ์รูปแบบ markup ขึ้นมา ด่านตรวจตรงนี้จำกัดอยู่ที่ไฟล์เดียว
ที่ *ถูกสร้างอัตโนมัติ* และจึงมีความจริงที่เครื่องรู้ได้

---

## What shipped

**The generator no longer has a count to get wrong.** `${metas.length}` in both language blocks, plus
a `<!-- mod-count: N -->` marker so the gate has something to read.

**The gate, falsified before it was trusted:**

```
wrong count      ✗ docs/MODLIST.md: says it covers 99 mods, but mods/ has 107.
marker deleted   ✗ docs/MODLIST.md: no `<!-- mod-count: N -->` marker …
restored         ✓ lint passed
```

**Re-measured rather than carried forward.** Artifacts are **405 / 341 / 148 MB**, not the figures I
had quoted, and the CurseForge export now references **40** by id and bundles **65** in
`overrides/` — not 57. That split changed with the mod count and nothing had rechecked it, which is
the same failure in miniature.

**Two ledger rows keep their old numbers deliberately** and now say so. A record of what #42 shipped
should not be rewritten to today's figures; it is marked *"as shipped then — 91 / 341 MB today"*.

**`DONE.md` gained the entry covering #50–#63**, which was missing entirely — the roster, the licence
audit, the Visuals Spec registration, V0, V1, V2, and both retracted claims.

**Final sweep is clean**: every remaining `99` in the tree is inside a historical record.

## Testing

`node scripts/validate/verify.mjs` — green, now checking the roster's **stated count** as well as its
contents. Both packs rebuilt so the shipped `MODLIST.md` carries the corrected prose; `sha256sum -c`
3 of 3 OK; the roster inside the instance zip reads `<!-- mod-count: 107 -->`.

Closes #64
