### PR TITLE
feat(docs): close the V0 sweep gap, and hand off the blocked work

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,10 +58,12 @@ In order, and stop pulling detail once you have enough for the task:
 
 1. **`Obsidian-minecraft-100day/Home.md`** — the team memory index. Skim the one-line
    descriptions; open only the notes this task touches.
-2. **`docs/OPEN-WORK-LEDGER.md`** — current open work. 🔴 UNTRACKED rows are MD-only and will
+2. **`docs/agents/blocked-work.md`** — *why* the open work is blocked, and the two claims this
+   repo has already had to retract. Read before the ledger, not instead of it.
+3. **`docs/OPEN-WORK-LEDGER.md`** — current open work. 🔴 UNTRACKED rows are MD-only and will
    not appear in `gh issue list`; they are the highest miss-risk.
-3. **The relevant GitHub issue** — `gh issue view <n> --comments`.
-4. **`DONE.md`** — only if you need the history of a past change. Not by default.
+4. **The relevant GitHub issue** — `gh issue view <n> --comments`.
+5. **`DONE.md`** — only if you need the history of a past change. Not by default.
 
 ---
 
@@ -190,6 +192,8 @@ docs/
                               tag for custom work, with their concrete targets
   compatibility-matrix.md     what has been OBSERVED — versions, sources, boot results
   agents/
+    blocked-work.md           READ FIRST if you are picking up open work — what is blocked,
+                              grouped by what would unblock it, with the evidence already gathered
     domain.md                 domain glossary — WHAT THE WORDS MEAN here
     reading-domain-docs.md    WHICH FILES to read before exploring, and when
     workflow.md               how to plan and implement here, branching, release tags

--- a/docs/OPEN-WORK-LEDGER.md
+++ b/docs/OPEN-WORK-LEDGER.md
@@ -27,12 +27,13 @@ population (W3/W6/W7), the Brimm-vs-TakKit comparison (§15), the JEI active-rec
 Spec §5) and the twelve-test release gate (Distribution Spec §16) are all **measurements**, and a
 dedicated server cannot produce any of them.
 
-**Four rows need no client, and one of them is actionable right now.** That is a different
+**Five rows need no client, and two of them are actionable right now.** That is a different
 statement from *"everything left needs a client"*, and the difference is the point:
 
 | Row | What it actually waits on |
 |---|---|
-| **Redistribution licences (#53)** | **nothing — hand-reading 40 CurseForge project pages** |
+| **Redistribution licences (#53)** | **nothing — but all 107 pages are now read; what is left is a *decision*** |
+| **Decide on Biome Dither / Punchy (#66)** | **nothing — available and undecided** |
 | The three Player Microchip textures (**#35**) | an **artist** |
 | Re-add `cbc_firepower_components` | an **upstream release** supporting CBC ≥ 5.9 |
 | Re-evaluate `TaCZ: Accelerated` | a **benchmark baseline** — which does need a client to profile with |
@@ -89,6 +90,7 @@ tier — is now a decided operating mode rather than a pending task, which is wh
 | **Visuals V0** — reference audit | ✅ | — | **#52**. `docs/khaojee-visual-reference.md` — 24 projects swept by title, versions and licences read from the Modrinth API. Six of the seven adoption-set mods have real Forge 1.20.1 builds |
 | **Visuals V1** — safe visual baseline | ⚠️ **staged, unverified** | **needs a client** | **#56**. Five client mods + Fzzy Config + Kotlin for Forge added and pinned; 99 → 106 mods. Server pack 89 → 91 and still boots green. **Not one §38 criterion is testable without a client** — every visual mod is `side = "client"` and the server boot cannot see them |
 | **Visuals V2** — weather | ⚠️ **staged, unverified** | **needs a client** | **#58**. Particle Rain, MIT, `side = "CLIENT"` by its own declaration. §9's mandatory stress test and §32's ADS/NVG visibility rule are both client measurements |
+| **Pufferfish's Biome Dither** and **Punchy!** — decide | 🔴 | **nothing — available and undecided** | **#66**. Both have Forge 1.20.1 builds and appear in Visuals Spec §3's inventory but in none of §4's buckets. Dither is `server: required` — the **only** server-side project in the visual inventory, and so the only one a dedicated-server boot could test. Both All Rights Reserved, so adding either enlarges #53 |
 | **Visuals V3** — connected textures | 🔴 | **needs a decision, not a client** | **#58**. Fusion is a *library* — it changes nothing without a connected-texture resource pack, and §12 never names one. Choosing it is art direction, and §35 flags resource packs as the category most likely to forbid redistribution while #53 is open |
 | **Visuals V4** — selective Fresh Animations | 🔴 | needs `docs/animation-coverage.md`, which needs a client | Visuals Spec §11 via the Animation Spec. EMF + ETF are Forge mods; **Fresh Animations is a resource pack**. Player Extension stays OFF |
 | **Visuals V5–V8** — decorative and worldgen prototypes | 🔴 | needs a client, and §33 wants worldgen settled before persistent play | BOP and Regions Unexplored both need **TerraBlender** (absent). §15 requires multiple seeds. Particle Interactions has **no 1.20.1 build** and should move to §44 |

--- a/docs/agents/blocked-work.md
+++ b/docs/agents/blocked-work.md
@@ -1,0 +1,372 @@
+<!-- lang:en -->
+# Blocked work — a handoff
+
+**Who this is for.** An agent or person arriving at `xenodeve/minecraft-100day` with no history, asked
+to move something forward. Everything easy is done. What is left is blocked, and this file says on
+*what*, so you do not spend a session rediscovering it.
+
+**Read this before `docs/OPEN-WORK-LEDGER.md`, not instead of it.** The ledger is the list; this is
+the reasoning.
+
+---
+
+## The one-paragraph state
+
+A Minecraft 1.20.1 / Forge modpack, **107 mods**, pinned with hashes. Configs, KubeJS recipes, a
+48-quest campaign and a visual layer are all written and all **verified on a dedicated-server boot
+only**. Three artifacts build reproducibly and checksum clean. **Nobody has ever launched the
+client.** That single fact blocks most of what follows.
+
+---
+
+## Blocked by: nobody has launched a client
+
+**This is the big one.** It gates the release, all balance work, and every visual-layer criterion.
+
+| Work | Why a server boot cannot substitute |
+|---|---|
+| Distribution Spec §16 twelve-test release gate | it is a human protocol on a running game |
+| TTK matrix (Main §24 Phase 2), MSPT under automatic fire (Phase 4) | measurements |
+| Horde MSPT at 50/100/150/200 (§23) | measurement |
+| Wildlife population (Wildlife Spec W3/W6/W7) | measurement |
+| Brimm vs TakKit armour comparison (§15) | Brimm registers stats **in code**; the only way to read them is JEI tooltips |
+| JEI active-recipe check (Crafting Spec §5) | JEI is client-only |
+| Visuals V1/V2 verification, and V4–V10 entirely | **every visual mod is `side = "client"`** |
+
+### What you must not conclude from the green boots
+
+`Done (12.803s)`, 83 recipes, 0 failed — that is real, and it is **narrow**. The same green boot
+carries **45 ERROR lines** saying Improved Mobs cannot read Brimm Armors' defence values, so no Brimm
+armour will ever be worn by a mob. **Nothing crashed. Nothing failed. The pack is wrong anyway.**
+
+That is this repo's characteristic failure mode, and it is written up in
+`Obsidian-minecraft-100day/config-and-kubejs-fail-open.md`: **configs fail open and KubeJS drops
+broken files silently.** A green boot is evidence that the server started, and nothing more.
+
+### What would actually unblock it
+
+A Windows machine with the developer's Microsoft account, importing
+`build/…-instance.zip` per `INSTALL.md` Option A (Prism Launcher → Add Instance → Import from zip),
+launching, creating a world, and posting `latest.log`. **That single artefact unblocks more open work
+than anything else in this repo.**
+
+---
+
+## Blocked by: a licensing question nobody has answered
+
+**Do not ship, publish, or hand this pack to anyone until this is resolved.** `INSTALL.md` and
+`CHANGELOG.md` both say so.
+
+### The shape of the problem — it is not the licence list
+
+The audit started as *"how many mods are All Rights Reserved"* and that was the wrong question. The
+authors who write about modpacks mostly **permit** them, on a condition:
+
+> **Serene Seasons** — "You may include this mod in a Modrinth-hosted modpack **as long as you do not
+> rehost the mod and only use builds uploaded directly by us**…"
+
+> **Entity Culling** — "Feel free to use this mod in your Modrinth and CurseForge-hosted modpacks…
+> **Do not redistribute the JAR files anywhere else!**"
+
+Both permit a **hosted** modpack, where the platform fetches each mod from the author's own upload.
+**ADR 0003 chose self-contained delivery** — every jar inside the zip — because the developer wanted
+to ship patches directly. That is exactly what these terms exclude.
+
+**The conflict is between the distribution model and the condition, not between the mod list and the
+licences. Swapping mods cannot fix it.** No artifact avoids it either: the CurseForge export is
+closest and still bundles 65 jars in `overrides/`, because a CurseForge manifest cannot reference
+Modrinth-sourced mods.
+
+### What is already known, so you do not redo it
+
+`docs/distribution-licenses.md` has all 107, read. **59 permissively licensed · 38 read and silent ·
+3 explicit grants · 2 known conflicts · 1 page with no description field.**
+
+**Silence is the ordinary case and it is not consent.** 38 project pages simply do not discuss
+modpacks; for those the licence alone is operative, and for most of them that licence is All Rights
+Reserved.
+
+Two of the three grants ask only for **credit and a link** — which `docs/MODLIST.md` has supplied
+since #50, before anyone thought of it as compliance.
+
+### Two claims here were already wrong once — do not re-derive them
+
+1. **"Disabling CurseForge API distribution means the author forbids modpacks."** Retracted in #61.
+   All four such mods appear in this pack's own CurseForge manifest by project and file id. The flag
+   separates *third-party launchers* from *CurseForge itself*; it is not a modpack prohibition.
+2. **"16 CurseForge pages could not be read — the platform renders descriptions unreachably."**
+   Retracted in #63. It was a regex bug: a project page carries ~49 `description` fields and the
+   extraction matched the first. 19 of 20 parse fine.
+
+Both went into committed documents unchecked. If you find yourself writing *"the tool cannot reach
+it"*, check that it is not *"my extraction is wrong."*
+
+### The questions only the developer can answer
+
+1. **Does the pack stay self-contained?** Keeping it means asking the affected authors, or dropping
+   their mods. Changing it means a hosted install where each mod downloads from its author — losing
+   the direct-patch property ADR 0003 was chosen for.
+2. **Private or public?** Handing a zip to three named friends is a materially different act from
+   listing on CurseForge or Modrinth, where Distribution Spec §33/§34 want it and where both
+   platforms enforce modpack permissions at upload.
+
+---
+
+## Blocked by: a decision the spec never made
+
+**Visuals V3 — connected textures.** *Visuals Spec §37* says *"Evaluate: Fusion."* But **Fusion is a
+library**: by its own description it *"adds additional resource pack features … to be used in
+resource packs."* It changes nothing on its own, and §12 specifies *"Fusion + compatible
+connected-texture resource pack"* — **without naming the resource pack.**
+
+Choosing it is art direction (§12's use cases are factory glass, control rooms, station windows), and
+§35 singles out connected-texture packs as the category most likely to forbid redistribution — while
+the licensing question above is open.
+
+**And §12's stated reason is wrong.** It prefers Fusion to avoid a Fabric bridge for Continuity.
+**Continuity has a Forge 1.20.1 build** (`continuity-3.0.0+1.20.1.forge.jar`). Fusion may still win
+on merit; V3 is a real comparison, not a forced default. Do not inherit the conclusion.
+
+---
+
+## Blocked by: waiting on someone else
+
+| Work | Waiting on |
+|---|---|
+| Three Player Microchip textures (#35) | **an artist.** 16×16 PNGs; §20 wants the beacon to look like it clips to a plate carrier. Names and recipes are done |
+| Re-add `cbc_firepower_components` | an **upstream release** supporting CBC ≥ 5.9. Watch the project; one `packwiz mr add` when it exists |
+
+---
+
+## Available and undecided — the only work that needs neither
+
+Two projects from the Visuals Spec inventory have Forge 1.20.1 builds and **no decision recorded
+anywhere** (#66):
+
+| Project | Version | Side | Note |
+|---|---|---|---|
+| Pufferfish's Biome Dither | `1.0.0` | **`server: required`, `client: unsupported`** | the **only** server-side project in the whole visual inventory — the one thing a dedicated-server boot could actually test |
+| Punchy! | `2.7d` | `client: required` | — |
+
+Both are All Rights Reserved, so adding either enlarges the licensing question above.
+
+---
+
+## How to work here without tripping over the rig
+
+**Three traps, each of which has cost a boot.** All are in `docs/compatibility-matrix.md`; repeated
+because they read like real bugs.
+
+1. **Stale java holds `session.lock`** → `DirectoryLock` `IOException` that reads exactly like a
+   corrupt save. `pkill -f` does **not** match these; `Get-Process java | Stop-Process -Force` does.
+2. **Stale java holds the port** → `FAILED TO BIND TO PORT`, which reads like a firewall problem.
+   Give a second server its own port; `servertest` uses `25577`.
+3. **`run.sh` is the Unix launcher** and points at `unix_args.txt`, whose classpath uses `:`
+   separators. On Windows the JVM dies with an `InvalidPathException` naming **no mod at all**. Use
+   `win_args.txt`. A Forge server install ships both arg files and only `run.sh`.
+
+**Never guess a project slug.** packwiz records ids, not slugs, and a guessed slug has pointed at the
+wrong project three times here — `smoothplayeranimations`, `create-industry` (which is a *modpack*,
+not TFMG), and `snow-imprints` (whose title is *Soft Imprints*). Search the **bare title** and check
+the `title` field of the hit: an augmented query returned the wrong project for `Continuity`, and
+that failure looks identical to *"the project does not exist."*
+
+**Run `node scripts/validate/verify.mjs` before anything ships.** It checks 165 indexed files, the
+roster's contents **and its stated count**, and that every shipped mod has a recorded licence.
+
+---
+
+## The standard this repo holds itself to
+
+**Evidence before verdict.** *Fixed · works · passes · safe · done* each need the command you ran,
+its output, or the `file:line` you read, named alongside them. Otherwise it is a hypothesis, and
+saying so is not a weakness in the report — it is the report.
+
+Every gate in `verify.mjs` was **falsified before it was trusted** — made to fail on purpose, then
+made to pass. A gate that has never failed is a gate nobody has checked.
+<!-- lang:end -->
+
+<!-- lang:th -->
+# งานที่ติดอยู่ — เอกสารส่งต่อ
+
+**เขียนให้ใคร** agent หรือคนที่เข้ามาที่ `xenodeve/minecraft-100day` โดยไม่มีประวัติ
+แล้วถูกขอให้ผลักงานอะไรสักอย่างต่อ ของง่ายทำหมดแล้ว ที่เหลือติดอยู่ และไฟล์นี้บอกว่าติด*อะไร*
+คุณจะได้ไม่ต้องเสียเวลาทั้งเซสชันไปค้นพบมันใหม่
+
+**อ่านไฟล์นี้ก่อน `docs/OPEN-WORK-LEDGER.md` ไม่ใช่แทนมัน** ledger คือรายการ อันนี้คือเหตุผล
+
+---
+
+## สถานะย่อหน้าเดียว
+
+modpack Minecraft 1.20.1 / Forge, **107 มอด** pin ไว้พร้อม hash config, recipe ของ KubeJS,
+แคมเปญ quest 48 ข้อ และชั้นภาพ เขียนครบแล้วและ**ตรวจสอบบน dedicated server เท่านั้น**
+artifact สามตัว build ซ้ำได้และ checksum สะอาด **ยังไม่เคยมีใครเปิด client เลย**
+ข้อเท็จจริงข้อเดียวนั้นขวางเกือบทุกอย่างที่ตามมา
+
+---
+
+## ติดเพราะ: ยังไม่มีใครเปิด client
+
+**นี่คือตัวใหญ่** มันขวางการปล่อยเวอร์ชัน งาน balance ทั้งหมด และเกณฑ์ทุกข้อของชั้นภาพ
+
+| งาน | ทำไม boot server แทนไม่ได้ |
+|---|---|
+| release gate 12 ข้อของ Distribution Spec §16 | เป็น protocol ที่คนทำบนเกมที่รันอยู่ |
+| TTK matrix (Main §24 Phase 2), MSPT ตอนยิงรัว (Phase 4) | เป็นการวัด |
+| MSPT ของ Horde ที่ 50/100/150/200 (§23) | เป็นการวัด |
+| ประชากรสัตว์ป่า (Wildlife Spec W3/W6/W7) | เป็นการวัด |
+| เปรียบเทียบเกราะ Brimm กับ TakKit (§15) | Brimm ลงทะเบียนค่า**ในโค้ด** ทางเดียวที่อ่านได้คือ tooltip ของ JEI |
+| ตรวจ recipe ที่ active ใน JEI (Crafting Spec §5) | JEI เป็น client อย่างเดียว |
+| การตรวจสอบ Visuals V1/V2 และ V4–V10 ทั้งหมด | **มอดภาพทุกตัวเป็น `side = "client"`** |
+
+### สิ่งที่คุณต้องไม่สรุปจากการ boot ที่เขียว
+
+`Done (12.803s)`, 83 recipes, 0 failed — นั่นจริง และมัน**แคบมาก** boot สีเขียวอันเดียวกันนั้น
+มี **บรรทัด ERROR 45 บรรทัด** บอกว่า Improved Mobs อ่านค่าป้องกันของ Brimm Armors ไม่ได้
+ดังนั้นจะไม่มีมอบตัวไหนสวมเกราะ Brimm เลย **ไม่มีอะไรแครช ไม่มีอะไร fail และ pack ก็ยังผิดอยู่ดี**
+
+นั่นคือรูปแบบความล้มเหลวประจำตัวของ repo นี้ และมันถูกเขียนไว้ใน
+`Obsidian-minecraft-100day/config-and-kubejs-fail-open.md`: **config fail แบบเปิด และ KubeJS
+ทิ้งไฟล์ที่พังไปเงียบ ๆ** boot ที่เขียวเป็นหลักฐานว่า server เริ่มทำงานได้ แค่นั้น
+
+### อะไรที่จะปลดล็อกได้จริง
+
+เครื่อง Windows ที่มีบัญชี Microsoft ของผู้พัฒนา import `build/…-instance.zip` ตาม
+`INSTALL.md` ทางเลือก A (Prism Launcher → Add Instance → Import from zip) เปิดเกม สร้างโลก
+แล้วส่ง `latest.log` มา **ไฟล์เดียวนั้นปลดล็อกงานที่ค้างอยู่ได้มากกว่าอะไรก็ตามใน repo นี้**
+
+---
+
+## ติดเพราะ: คำถามเรื่องสัญญาอนุญาตที่ยังไม่มีใครตอบ
+
+**อย่าส่ง อย่าเผยแพร่ อย่ายื่น pack นี้ให้ใครจนกว่าเรื่องนี้จะจบ** `INSTALL.md` กับ `CHANGELOG.md`
+เขียนไว้ทั้งคู่
+
+### รูปร่างของปัญหา — มันไม่ใช่รายการสัญญาอนุญาต
+
+การ audit เริ่มจาก *"มีกี่ตัวที่เป็น All Rights Reserved"* และนั่นเป็นคำถามที่ผิด
+ผู้เขียนที่เขียนถึง modpack ส่วนใหญ่**อนุญาต** โดยมีเงื่อนไข:
+
+> **Serene Seasons** — "คุณใส่มอดนี้ใน modpack ที่โฮสต์บน Modrinth ได้ **ตราบใดที่คุณไม่ rehost มอด
+> และใช้เฉพาะ build ที่เราอัปโหลดเองโดยตรง**…"
+
+> **Entity Culling** — "ใช้มอดนี้ใน modpack ที่โฮสต์บน Modrinth และ CurseForge ได้เลย…
+> **อย่าแจกจ่ายไฟล์ JAR ซ้ำที่อื่น!**"
+
+ทั้งคู่อนุญาต modpack แบบ**โฮสต์** ซึ่งแพลตฟอร์มดึงมอดแต่ละตัวจากที่ผู้เขียนอัปโหลดไว้เอง
+**ADR 0003 เลือกการส่งมอบแบบมีทุกอย่างในตัว** — jar ทุกตัวอยู่ใน zip —
+เพราะผู้พัฒนาต้องการออก patch ได้ตรง ๆ นั่นคือสิ่งที่เงื่อนไขพวกนี้กันออกพอดี
+
+**ความขัดแย้งอยู่ระหว่างรูปแบบการแจกจ่ายกับเงื่อนไข ไม่ใช่ระหว่างรายชื่อมอดกับสัญญาอนุญาต
+การสลับมอดแก้ไม่ได้** และไม่มี artifact ตัวไหนเลี่ยงได้: ตัว CurseForge ใกล้เคียงที่สุด
+และก็ยังใส่ jar มา 65 ตัวใน `overrides/` เพราะ manifest ของ CurseForge อ้างถึงมอดจาก Modrinth ไม่ได้
+
+### สิ่งที่รู้แล้ว จะได้ไม่ต้องทำซ้ำ
+
+`docs/distribution-licenses.md` มีครบทั้ง 107 ตัว อ่านแล้ว **สัญญาอนุญาตแบบเปิด 59 ·
+อ่านแล้วและเงียบ 38 · ให้สิทธิ์ชัดเจน 3 · ขัดแย้งที่รู้แล้ว 2 · ไม่มีฟิลด์คำอธิบาย 1**
+
+**ความเงียบคือกรณีปกติ และมันไม่ใช่การยินยอม** หน้าโปรเจกต์ 38 หน้าไม่ได้พูดถึง modpack เลย
+สำหรับพวกนั้นสัญญาอนุญาตอย่างเดียวคือสิ่งที่มีผล และส่วนใหญ่คือ All Rights Reserved
+
+สองในสามรายที่ให้สิทธิ์ขอแค่ **เครดิตกับลิงก์** — ซึ่ง `docs/MODLIST.md` ให้มาตั้งแต่ #50
+ก่อนที่จะมีใครคิดถึงมันในฐานะการปฏิบัติตามเงื่อนไข
+
+### สองคำกล่าวที่เคยผิดมาแล้ว — อย่าไปสรุปใหม่
+
+1. **"การปิด CurseForge API distribution แปลว่าผู้เขียนห้าม modpack"** ถอนคืนใน #61
+   มอดทั้งสี่ตัวนั้นอยู่ใน CurseForge manifest ของ pack นี้เองด้วย project และ file id
+   แฟล็กนั้นแยก *launcher ของบุคคลที่สาม* ออกจาก *ตัว CurseForge เอง* ไม่ใช่การห้าม modpack
+2. **"หน้า CurseForge 16 หน้าอ่านไม่ได้ — แพลตฟอร์มแสดงคำอธิบายในรูปแบบที่เข้าไม่ถึง"**
+   ถอนคืนใน #63 มันเป็นบั๊กของ regex: หน้าโปรเจกต์มีฟิลด์ `description` ราว 49 ฟิลด์
+   และการดึงข้อมูลไปจับเอาอันแรก 19 จาก 20 หน้า parse ได้ปกติ
+
+ทั้งคู่เข้าไปอยู่ในเอกสารที่ commit แล้วโดยไม่ได้ตรวจ ถ้าคุณกำลังจะเขียนว่า *"เครื่องมือเข้าไม่ถึง"*
+ให้ตรวจก่อนว่ามันไม่ใช่ *"การดึงข้อมูลของผมผิด"*
+
+### คำถามที่มีแต่ผู้พัฒนาตอบได้
+
+1. **pack จะยังเป็นแบบมีทุกอย่างในตัวต่อไปไหม** ถ้าใช่ ต้องไปขอผู้เขียนที่เกี่ยวข้อง หรือถอดมอดออก
+   ถ้าเปลี่ยน ก็ต้องเป็นการติดตั้งแบบโฮสต์ที่มอดแต่ละตัวดาวน์โหลดจากผู้เขียน —
+   ซึ่งเสียคุณสมบัติการ patch ตรง ๆ ที่ ADR 0003 ถูกเลือกมาเพราะมัน
+2. **ส่วนตัวหรือสาธารณะ** การส่ง zip ให้เพื่อนสามคนที่รู้จักชื่อ ต่างจากการลงบน CurseForge
+   หรือ Modrinth อย่างมีนัยสำคัญ ซึ่ง Distribution Spec §33/§34 อยากให้ไป
+   และทั้งสองแพลตฟอร์มบังคับใช้สิทธิ์ modpack ตอนอัปโหลด
+
+---
+
+## ติดเพราะ: การตัดสินใจที่ spec ไม่เคยทำ
+
+**Visuals V3 — connected textures** *Visuals Spec §37* บอกว่า *"ประเมิน: Fusion"*
+แต่ **Fusion เป็น library**: คำอธิบายของมันเองบอกว่ามัน *"เพิ่มความสามารถของ resource pack …
+เพื่อให้ resource pack เอาไปใช้"* มันไม่เปลี่ยนอะไรด้วยตัวเอง และ §12 ระบุว่า *"Fusion +
+connected-texture resource pack ที่เข้ากันได้"* — **โดยไม่ระบุว่า resource pack ตัวไหน**
+
+การเลือกมันเป็นการตัดสินเชิงศิลป์ (กรณีใช้งานของ §12 คือกระจกโรงงาน ห้องควบคุม หน้าต่างสถานี)
+และ §35 แยก connected-texture pack ออกมาเป็นหมวดที่มีโอกาสห้ามแจกจ่ายซ้ำมากที่สุด —
+ในขณะที่คำถามเรื่องสัญญาอนุญาตข้างบนยังเปิดอยู่
+
+**และเหตุผลที่ §12 ให้ไว้ผิด** มันเลือก Fusion เพื่อเลี่ยง Fabric bridge สำหรับ Continuity
+**Continuity มี build สำหรับ Forge 1.20.1** (`continuity-3.0.0+1.20.1.forge.jar`)
+Fusion อาจยังชนะด้วยคุณสมบัติของมันเอง V3 เป็นการเปรียบเทียบจริง ไม่ใช่ค่าเริ่มต้นที่ถูกบังคับ
+อย่ารับข้อสรุปไปเลย
+
+---
+
+## ติดเพราะ: รอคนอื่น
+
+| งาน | รออะไร |
+|---|---|
+| texture ของ Player Microchip สามไฟล์ (#35) | **คนทำงานศิลป์** PNG ขนาด 16×16; §20 อยากให้ beacon ดูเหมือนหนีบอยู่กับเสื้อเกราะ ชื่อกับ recipe เสร็จแล้ว |
+| เพิ่ม `cbc_firepower_components` กลับ | **release จากต้นน้ำ** ที่รองรับ CBC ≥ 5.9 เฝ้าโปรเจกต์ไว้ พอมีก็ `packwiz mr add` ครั้งเดียว |
+
+---
+
+## ใช้ได้และยังไม่ถูกตัดสิน — งานเดียวที่ไม่ต้องรออะไรเลย
+
+โปรเจกต์สองตัวจาก inventory ของ Visuals Spec มี build สำหรับ Forge 1.20.1 และ
+**ไม่มีการตัดสินบันทึกไว้ที่ไหนเลย** (#66):
+
+| โปรเจกต์ | เวอร์ชัน | Side | หมายเหตุ |
+|---|---|---|---|
+| Pufferfish's Biome Dither | `1.0.0` | **`server: required`, `client: unsupported`** | เป็นโปรเจกต์ฝั่ง server **ตัวเดียว**ใน inventory ภาพทั้งหมด — สิ่งเดียวที่การ boot dedicated server ทดสอบได้จริง |
+| Punchy! | `2.7d` | `client: required` | — |
+
+ทั้งคู่เป็น All Rights Reserved การเพิ่มตัวไหนก็ตามจึงขยายคำถามเรื่องสัญญาอนุญาตข้างบน
+
+---
+
+## วิธีทำงานที่นี่โดยไม่สะดุดกับ rig
+
+**สามกับดัก แต่ละอันเคยทำให้เสียการ boot ไปแล้ว** ทั้งหมดอยู่ใน `docs/compatibility-matrix.md`
+เขียนซ้ำตรงนี้เพราะมันหน้าตาเหมือนบั๊กจริง ๆ
+
+1. **java ค้างถือ `session.lock`** → `DirectoryLock` `IOException` ที่อ่านแล้วเหมือน save พัง
+   `pkill -f` **ไม่**จับพวกนี้ ต้องใช้ `Get-Process java | Stop-Process -Force`
+2. **java ค้างถือ port** → `FAILED TO BIND TO PORT` ซึ่งอ่านแล้วเหมือนปัญหา firewall
+   ให้ server ตัวที่สองใช้ port ของตัวเอง `servertest` ใช้ `25577`
+3. **`run.sh` เป็นตัวเปิดสำหรับ Unix** และชี้ไปที่ `unix_args.txt` ซึ่ง classpath ใช้ตัวคั่น `:`
+   บน Windows ตัว JVM ตายด้วย `InvalidPathException` ที่**ไม่เอ่ยชื่อมอดสักตัว** ให้ใช้
+   `win_args.txt` การติดตั้ง Forge server แถมไฟล์ arg มาทั้งสองไฟล์แต่มีแค่ `run.sh`
+
+**ห้ามเดา slug ของโปรเจกต์** packwiz บันทึก id ไม่ใช่ slug และ slug ที่เดาชี้ไปผิดโปรเจกต์มาแล้ว
+สามครั้งที่นี่ — `smoothplayeranimations`, `create-industry` (ซึ่งเป็น *modpack* ไม่ใช่ TFMG)
+และ `snow-imprints` (ที่ชื่อจริงคือ *Soft Imprints*) ให้ค้นด้วย**ชื่อเปล่า ๆ**
+และตรวจฟิลด์ `title` ของผลลัพธ์: คำค้นที่เติมคำเข้าไปให้ผลผิดโปรเจกต์สำหรับ `Continuity`
+และความล้มเหลวแบบนั้นหน้าตาเหมือน *"โปรเจกต์นี้ไม่มีอยู่"* เป๊ะ ๆ
+
+**รัน `node scripts/validate/verify.mjs` ก่อนส่งอะไรก็ตาม** มันตรวจไฟล์ใน index 165 ไฟล์
+เนื้อหาของ roster **และจำนวนที่ roster ประกาศเอง** และว่ามอดทุกตัวที่ส่งไปมีสัญญาอนุญาตบันทึกไว้
+
+---
+
+## มาตรฐานที่ repo นี้ยึดกับตัวเอง
+
+**หลักฐานมาก่อนคำตัดสิน** *แก้แล้ว · ใช้ได้ · ผ่าน · ปลอดภัย · เสร็จ* แต่ละคำต้องมีคำสั่งที่คุณรัน
+ผลลัพธ์ของมัน หรือ `file:line` ที่คุณอ่าน ระบุมาคู่กัน ถ้าไม่มีก็คือสมมติฐาน
+และการบอกแบบนั้นไม่ใช่จุดอ่อนของรายงาน — มันคือรายงาน
+
+ทุกด่านตรวจใน `verify.mjs` ถูก **falsify ก่อนที่จะเชื่อถือ** — ทำให้มัน fail โดยตั้งใจ
+แล้วค่อยทำให้มันผ่าน ด่านตรวจที่ไม่เคย fail คือด่านตรวจที่ยังไม่มีใครตรวจ
+<!-- lang:end -->

--- a/docs/khaojee-visual-reference.md
+++ b/docs/khaojee-visual-reference.md
@@ -10,7 +10,7 @@ need, and what is its licence* — which is exactly the scope *Visuals Spec §37
 
 - **Reference modpack:** <https://modrinth.com/modpack/khaojee-enchanted-visuals>
 - **Reference video:** <https://youtu.be/cxahj-PuLb0>
-- **Swept:** 2026-08-27 · 24 projects
+- **Swept:** 2026-08-27 · **all 34** of §3's inventory (24 in the first pass, 10 in #66)
 - **Related:** issue #52, and the licence risk this audit surfaced — issue #53
 
 ## Method, so it can be redone
@@ -103,6 +103,64 @@ argument: on Forge 1.20.1 there is nothing to install.
   Entity Culling, ImmediatelyFast, ServerCore.
 - **Animation** — SPA, NEA, BAC, Smooth Movement.
 
+## The ten §3 listed and §4 never bucketed (#66)
+
+**V0 swept 24 of §3's 34.** It followed §4's ADOPT / PROTOTYPE / REJECT lists, and §4 does not
+mention every project §3 inventories. These are the other ten. **The first sweep did not say it was
+partial**, which is the defect being corrected here.
+
+### §12's premise is wrong: Continuity has a Forge build
+
+§12 reads *"Do not add Fabric compatibility infrastructure only for Continuity."* That is a decision
+resting on a false assumption:
+
+```
+3.0.0+1.20.1.forge     forge          continuity-3.0.0+1.20.1.forge.jar
+3.0.0+1.20.1           fabric,quilt   continuity-3.0.0+1.20.1.jar
+```
+
+**No bridge is needed for Continuity.** Fusion may still win on merit — it is maintained for both
+loaders and §12's use cases are industrial glass and station windows — but **V3 is a comparison
+between two Forge-native options**, not a platform-forced default. Whoever picks up V3 should compare
+them, not inherit the conclusion.
+
+### Available on Forge 1.20.1, and never decided about
+
+| Project | Slug | Version | Side | Licence | Status |
+|---|---|---|---|---|---|
+| Pufferfish's Biome Dither | `biome-dither` | `1.0.0` | **`client: unsupported` · `server: required`** | ⚠️ All Rights Reserved | **UNDECIDED** — the only server-side project in this inventory |
+| Punchy! | `punchy` | `2.7d` | `client: required` · `server: unsupported` | ⚠️ All Rights Reserved | **UNDECIDED** |
+| Better Biome Reblend | `better-biome-reblend` | `1.5.3` | — | LGPL-3.0-only | **SUPERSEDED** — §4 wrote *"Better Biome Blend / equivalent"*; we installed Better Biome **Blend**, a different project. Recorded so nobody re-finds it and assumes it was missed |
+
+Dither being **server-side** is worth flagging: every other visual project here is client-only, so it
+is the one entry in the whole inventory that a dedicated-server boot could actually test.
+
+### Not mods — resource packs, or nothing at all
+
+| Project | Slug | Reality | Licence |
+|---|---|---|---|
+| Connected Paths | `connected-paths` | resource pack (`minecraft`) | ⚠️ **CC-BY-NC-SA-4.0** — non-commercial **and** share-alike |
+| Rainbow's Foliage | `rainbows-foliage-polytone` | resource pack, and a **Polytone** pack — useless unless Polytone is adopted first (§19, still PROTOTYPE) | ⚠️ All Rights Reserved |
+| Just Expressions | `just-expressions` | resource pack | ⚠️ custom |
+| Fresh Animations: Player Extension | `fresh-animations-player-extension` | resource pack — confirms §11's *OFF* decision was about the right kind of thing | ⚠️ All Rights Reserved |
+| Client Backpack | `client-backpack` | **no 1.20.1 file at all** | CC-BY-NC-SA-4.0 |
+| Connected Texture+ | — | **no Modrinth match.** Like Musgo: *unresolved*, not absent. **Do not guess a slug** | unknown |
+
+**CC-BY-NC-SA on two of them is worth noticing** while #53 is open: `NC` is the only licence class in
+this whole audit that restricts *commercial* use, and `SA` would propagate its terms to anything it
+is combined with.
+
+### A caveat about the search rule itself
+
+The rule is *search by title, never compose a slug*. It held again — but it is **not infallible**.
+Searching `Continuity connected textures` returned **More Connected Textures**, a different project,
+as the top hit. The bare title `Continuity` found it immediately.
+
+**So: search the bare title, and check `title` on the hit before trusting it.** An augmented query
+can outrank the exact name, and the failure looks identical to "the project does not exist" — which
+is precisely how `Musgo` and `Connected Texture+` are currently recorded, and why both stay
+*unresolved* rather than *absent*.
+
 ## What V0 does not decide
 
 **Whether any of this works.** *Visuals Spec §41* rule 11 is *"Do not claim compatibility without
@@ -130,7 +188,7 @@ read all 107.
 
 - **modpack อ้างอิง:** <https://modrinth.com/modpack/khaojee-enchanted-visuals>
 - **วิดีโออ้างอิง:** <https://youtu.be/cxahj-PuLb0>
-- **กวาดเมื่อ:** 2026-08-27 · 24 โปรเจกต์
+- **กวาดเมื่อ:** 2026-08-27 · **ครบทั้ง 34** ตัวใน inventory ของ §3 (24 ตัวในรอบแรก, 10 ตัวใน #66)
 - **เกี่ยวข้อง:** issue #52 และความเสี่ยงเรื่องสัญญาอนุญาตที่ audit นี้เปิดโปงออกมา — issue #53
 
 ## วิธีทำ เพื่อให้ทำซ้ำได้
@@ -221,6 +279,63 @@ spec เลื่อนพวกนี้ออกไปด้วยเหตุ
 - **ประสิทธิภาพ** — ครบทั้งหกตัวที่ §24 บังคับ: Embeddium, ModernFix, FerriteCore,
   Entity Culling, ImmediatelyFast, ServerCore
 - **แอนิเมชัน** — SPA, NEA, BAC, Smooth Movement
+
+## สิบตัวที่ §3 ลงไว้และ §4 ไม่เคยจัดกลุ่ม (#66)
+
+**V0 กวาดไป 24 จาก 34 ของ §3** มันเดินตามรายการ ADOPT / PROTOTYPE / REJECT ของ §4
+และ §4 ไม่ได้เอ่ยถึงทุกโปรเจกต์ที่ §3 ลงไว้ นี่คืออีกสิบตัว **การกวาดรอบแรกไม่ได้บอกว่ามันไม่ครบ**
+ซึ่งคือข้อบกพร่องที่กำลังแก้ตรงนี้
+
+### หลักการของ §12 ผิด: Continuity มี build สำหรับ Forge
+
+§12 เขียนว่า *"อย่าเพิ่มโครงสร้างความเข้ากันได้ของ Fabric เพียงเพื่อ Continuity"*
+นั่นคือการตัดสินใจที่ตั้งอยู่บนสมมติฐานที่ผิด:
+
+```
+3.0.0+1.20.1.forge     forge          continuity-3.0.0+1.20.1.forge.jar
+3.0.0+1.20.1           fabric,quilt   continuity-3.0.0+1.20.1.jar
+```
+
+**ไม่ต้องใช้ bridge ใด ๆ สำหรับ Continuity** Fusion อาจยังชนะด้วยคุณสมบัติของมันเอง —
+มันดูแลให้ทั้งสอง loader และกรณีใช้งานของ §12 คือกระจกอุตสาหกรรมกับหน้าต่างสถานี — แต่
+**V3 คือการเปรียบเทียบระหว่างสองตัวเลือกที่เป็น Forge โดยกำเนิด** ไม่ใช่ค่าเริ่มต้นที่แพลตฟอร์มบังคับ
+ใครที่มาทำ V3 ต่อควรเปรียบเทียบเอง ไม่ใช่รับข้อสรุปไปเลย
+
+### ใช้ได้บน Forge 1.20.1 และไม่เคยมีใครตัดสิน
+
+| โปรเจกต์ | Slug | เวอร์ชัน | Side | สัญญาอนุญาต | สถานะ |
+|---|---|---|---|---|---|
+| Pufferfish's Biome Dither | `biome-dither` | `1.0.0` | **`client: unsupported` · `server: required`** | ⚠️ All Rights Reserved | **ยังไม่ตัดสิน** — เป็นโปรเจกต์ฝั่ง server ตัวเดียวใน inventory นี้ |
+| Punchy! | `punchy` | `2.7d` | `client: required` · `server: unsupported` | ⚠️ All Rights Reserved | **ยังไม่ตัดสิน** |
+| Better Biome Reblend | `better-biome-reblend` | `1.5.3` | — | LGPL-3.0-only | **ถูกแทนที่แล้ว** — §4 เขียนว่า *"Better Biome Blend / equivalent"* เราติดตั้ง Better Biome **Blend** ซึ่งเป็นคนละโปรเจกต์ บันทึกไว้เพื่อไม่ให้ใครไปเจอใหม่แล้วคิดว่าเราพลาด |
+
+การที่ Dither เป็น **ฝั่ง server** ควรถูกเน้น: โปรเจกต์ภาพอื่นทุกตัวในนี้เป็น client อย่างเดียว
+มันจึงเป็นรายการเดียวใน inventory ทั้งหมดที่การ boot dedicated server ทดสอบได้จริง
+
+### ไม่ใช่มอด — เป็น resource pack หรือไม่มีอะไรเลย
+
+| โปรเจกต์ | Slug | ความจริง | สัญญาอนุญาต |
+|---|---|---|---|
+| Connected Paths | `connected-paths` | resource pack (`minecraft`) | ⚠️ **CC-BY-NC-SA-4.0** — ห้ามเชิงพาณิชย์ **และ** ต้องเผยแพร่ต่อด้วยสัญญาเดียวกัน |
+| Rainbow's Foliage | `rainbows-foliage-polytone` | resource pack และเป็น pack ของ **Polytone** — ไร้ประโยชน์ถ้าไม่รับ Polytone มาก่อน (§19 ยังเป็น PROTOTYPE) | ⚠️ All Rights Reserved |
+| Just Expressions | `just-expressions` | resource pack | ⚠️ custom |
+| Fresh Animations: Player Extension | `fresh-animations-player-extension` | resource pack — ยืนยันว่าการตัดสินใจ *ปิด* ของ §11 มองถูกประเภท | ⚠️ All Rights Reserved |
+| Client Backpack | `client-backpack` | **ไม่มีไฟล์ 1.20.1 เลย** | CC-BY-NC-SA-4.0 |
+| Connected Texture+ | — | **ไม่เจอบน Modrinth** เหมือน Musgo: *ยังหาไม่เจอ* ไม่ใช่ไม่มี **ห้ามเดา slug** | ไม่ทราบ |
+
+**CC-BY-NC-SA บนสองตัวนั้นควรสังเกต** ในขณะที่ #53 ยังเปิดอยู่: `NC` เป็นสัญญาอนุญาตประเภทเดียว
+ในการ audit ทั้งหมดที่จำกัดการใช้*เชิงพาณิชย์* และ `SA` จะแพร่เงื่อนไขของมันไปยังทุกอย่างที่เอามารวมด้วย
+
+### ข้อควรระวังเกี่ยวกับกฎการค้นเอง
+
+กฎคือ *ค้นจากชื่อ ห้ามประกอบ slug* มันยังใช้ได้ — แต่มัน **ไม่ได้ไร้ที่ติ**
+การค้นด้วย `Continuity connected textures` ได้ **More Connected Textures** ซึ่งเป็นคนละโปรเจกต์
+ขึ้นมาเป็นอันดับหนึ่ง พอค้นด้วยชื่อเปล่า ๆ ว่า `Continuity` ก็เจอทันที
+
+**ดังนั้น: ค้นด้วยชื่อเปล่า ๆ และตรวจ `title` ของผลลัพธ์ก่อนเชื่อ** คำค้นที่เติมคำเข้าไป
+อาจชนะชื่อที่ตรงเป๊ะได้ และความล้มเหลวแบบนั้นหน้าตาเหมือนกับ "โปรเจกต์นี้ไม่มีอยู่" เป๊ะ ๆ —
+ซึ่งคือวิธีที่ `Musgo` กับ `Connected Texture+` ถูกบันทึกไว้ตอนนี้พอดี
+และเป็นเหตุผลที่ทั้งคู่ยังเป็น *ยังหาไม่เจอ* ไม่ใช่ *ไม่มี*
 
 ## สิ่งที่ V0 ไม่ได้ตัดสิน
 


### PR DESCRIPTION
## Summary

Two things:

1. **Close the V0 gap.** §3 lists **34** projects; V0 swept **24** — the ones §4 had bucketed. The
   other 10 were never version-checked, and 7 of them have no decision recorded anywhere.
2. **Write a handoff document for an external agent**, because most of what remains is blocked on
   things this repo cannot produce, and the next person to look at it should not have to re-derive
   why.

## What the second sweep found

### §12's premise is factually wrong

The spec says:

> Our policy: `Do not add Fabric compatibility infrastructure only for Continuity.`
> Preferred route: `Fusion + compatible connected-texture resource pack`

**Continuity has a Forge 1.20.1 build.**

```
3.0.0+1.20.1.forge     forge          continuity-3.0.0+1.20.1.forge.jar
3.0.0+1.20.1           fabric,quilt   continuity-3.0.0+1.20.1.jar
```

No bridge is needed for Continuity. **Fusion may still be the better choice — but not for the reason
§12 gives**, and V3 is now a real comparison between two Forge-native options rather than a
platform-forced default.

### Two genuinely available mods nobody ever decided about

| Mod | Forge 1.20.1 | Side | Licence |
|---|---|---|---|
| **Pufferfish's Biome Dither** | `1.0.0` | **`client: unsupported`, `server: required`** — a server-side mod, unusual for this list | All Rights Reserved |
| **Punchy!** | `2.7d` | `client: required`, `server: unsupported` | All Rights Reserved |

Both are in §3's inventory, neither appears in §4's ADOPT / PROTOTYPE / REJECT lists, and neither was
swept by V0. They are **available and undecided** — the only two in that state.

**Better Biome Reblend** also turns out to be a real Forge 1.20.1 mod (`1.5.3`, LGPL-3.0). §4 wrote
*"Better Biome Blend / equivalent"* and we installed Better Biome **Blend** (Unlicense). They are
different projects; the one we have is fine, and this records that the alternative exists.

### The rest are not mods

| Project | Reality | Licence |
|---|---|---|
| Connected Paths | resource pack (`minecraft`) | **CC-BY-NC-SA-4.0** — non-commercial, share-alike |
| Rainbow's Foliage | resource pack, and a **Polytone** pack — depends on Polytone being adopted first | All Rights Reserved |
| Just Expressions | resource pack | custom |
| Fresh Animations: Player Extension | resource pack — confirms §11's OFF decision | All Rights Reserved |
| Client Backpack | **no 1.20.1 file at all** | CC-BY-NC-SA-4.0 |
| Connected Texture+ | **no Modrinth match** — like Musgo, *unresolved*, not absent | — |

### And a caveat about the search method itself

Searching for *"Continuity connected textures"* returned **More Connected Textures**, a different
project, as the top hit. The title-search rule is safer than composing a slug, **but it is not
infallible** — an augmented query can outrank the exact title. Searching the bare title `Continuity`
found it immediately. Worth recording next to the slug rule it supports.

## The handoff document

`docs/agents/blocked-work.md` — written for an agent or person arriving with no history:

- what is blocked, grouped by **what would actually unblock it** rather than by feature
- the evidence already gathered, so nothing is re-derived
- what must **not** be assumed, and which claims in this repo have already been retracted once
- the two questions only the developer can answer

## Acceptance criteria

- [ ] All 34 of §3's inventory accounted for in `docs/khaojee-visual-reference.md`
- [ ] §12's Continuity premise corrected, with the file listing as evidence
- [ ] Pufferfish's Biome Dither and Punchy recorded as available-and-undecided
- [ ] The title-search caveat recorded next to the slug rule
- [ ] `docs/agents/blocked-work.md` exists and is self-contained
- [ ] `verify` green

## Out of scope

**Deciding about Dither or Punchy.** Both are §35 judgement calls plus a client measurement; the
sweep says they are *available*, not that they should be added.

**Re-opening V3.** The Continuity finding changes the *reason* V3 is open, not its status — it still
needs a resource-pack choice and #53 is still unresolved.

---

## สรุปภาษาไทย

### สรุป

สองเรื่อง:

1. **ปิดช่องโหว่ของ V0** §3 ลงรายการไว้ **34** โปรเจกต์ V0 กวาดไป **24** — เฉพาะที่ §4 จัดกลุ่มไว้
   อีก 10 ตัวไม่เคยถูกตรวจเวอร์ชัน และ 7 ตัวในนั้นไม่มีการตัดสินบันทึกไว้ที่ไหนเลย
2. **เขียนเอกสารส่งต่อสำหรับ agent ภายนอก** เพราะสิ่งที่เหลือส่วนใหญ่ติดสิ่งที่ repo นี้ผลิตเองไม่ได้
   และคนถัดไปไม่ควรต้องมานั่งไล่หาเหตุผลใหม่

### สิ่งที่การกวาดรอบสองพบ

#### หลักการของ §12 ผิดข้อเท็จจริง

spec เขียนว่า:

> นโยบายของเรา: `อย่าเพิ่มโครงสร้างความเข้ากันได้ของ Fabric เพียงเพื่อ Continuity`
> เส้นทางที่เลือก: `Fusion + connected-texture resource pack ที่เข้ากันได้`

**Continuity มี build สำหรับ Forge 1.20.1**

```
3.0.0+1.20.1.forge     forge          continuity-3.0.0+1.20.1.forge.jar
3.0.0+1.20.1           fabric,quilt   continuity-3.0.0+1.20.1.jar
```

ไม่ต้องใช้ bridge ใด ๆ สำหรับ Continuity เลย **Fusion อาจยังเป็นตัวเลือกที่ดีกว่า —
แต่ไม่ใช่ด้วยเหตุผลที่ §12 ให้ไว้** และตอนนี้ V3 กลายเป็นการเปรียบเทียบจริงระหว่างสองตัวเลือก
ที่เป็น Forge โดยกำเนิด ไม่ใช่ค่าเริ่มต้นที่ถูกแพลตฟอร์มบังคับ

#### สองมอดที่ใช้ได้จริงและไม่เคยมีใครตัดสิน

| มอด | Forge 1.20.1 | Side | สัญญาอนุญาต |
|---|---|---|---|
| **Pufferfish's Biome Dither** | `1.0.0` | **`client: unsupported`, `server: required`** — เป็นมอดฝั่ง server ซึ่งแปลกสำหรับรายการนี้ | All Rights Reserved |
| **Punchy!** | `2.7d` | `client: required`, `server: unsupported` | All Rights Reserved |

ทั้งคู่อยู่ใน inventory ของ §3 ไม่มีตัวไหนอยู่ในรายการ ADOPT / PROTOTYPE / REJECT ของ §4
และไม่มีตัวไหนถูก V0 กวาด พวกมัน**ใช้ได้และยังไม่ถูกตัดสิน** — เป็นสองตัวเดียวที่อยู่ในสถานะนี้

**Better Biome Reblend** ก็เป็นมอด Forge 1.20.1 จริงเหมือนกัน (`1.5.3`, LGPL-3.0) §4 เขียนว่า
*"Better Biome Blend / equivalent"* และเราติดตั้ง Better Biome **Blend** (Unlicense)
มันเป็นคนละโปรเจกต์กัน ตัวที่เรามีใช้ได้ดีอยู่แล้ว และนี่คือการบันทึกว่าตัวเลือกอื่นมีอยู่

#### ที่เหลือไม่ใช่มอด

| โปรเจกต์ | ความจริง | สัญญาอนุญาต |
|---|---|---|
| Connected Paths | resource pack (`minecraft`) | **CC-BY-NC-SA-4.0** — ห้ามเชิงพาณิชย์ ต้องเผยแพร่ต่อด้วยสัญญาเดียวกัน |
| Rainbow's Foliage | resource pack และเป็น pack ของ **Polytone** — ต้องรับ Polytone มาก่อน | All Rights Reserved |
| Just Expressions | resource pack | custom |
| Fresh Animations: Player Extension | resource pack — ยืนยันการตัดสินใจปิดของ §11 | All Rights Reserved |
| Client Backpack | **ไม่มีไฟล์ 1.20.1 เลย** | CC-BY-NC-SA-4.0 |
| Connected Texture+ | **ไม่เจอบน Modrinth** — เหมือน Musgo คือ *ยังหาไม่เจอ* ไม่ใช่ไม่มี | — |

#### และข้อควรระวังเกี่ยวกับวิธีค้นเอง

การค้นด้วย *"Continuity connected textures"* ได้ **More Connected Textures** ซึ่งเป็นคนละโปรเจกต์
ขึ้นมาเป็นอันดับหนึ่ง กฎที่ให้ค้นจากชื่อปลอดภัยกว่าการประกอบ slug **แต่มันไม่ได้ไร้ที่ติ** —
คำค้นที่เติมคำเข้าไปอาจชนะชื่อที่ตรงเป๊ะได้ พอค้นด้วยชื่อเปล่า ๆ ว่า `Continuity` ก็เจอทันที
ควรบันทึกไว้ข้างกฎเรื่อง slug ที่มันสนับสนุน

### เอกสารส่งต่อ

`docs/agents/blocked-work.md` — เขียนสำหรับ agent หรือคนที่เข้ามาโดยไม่มีประวัติ:

- อะไรติดอยู่ จัดกลุ่มตาม**สิ่งที่จะปลดล็อกมันได้จริง** ไม่ใช่ตามฟีเจอร์
- หลักฐานที่รวบรวมไว้แล้ว จะได้ไม่ต้องหาใหม่
- อะไรที่ **ห้าม**สมมติ และคำกล่าวไหนใน repo นี้ที่เคยถูกถอนคืนมาแล้ว
- สองคำถามที่มีแต่ผู้พัฒนาเท่านั้นที่ตอบได้

### เกณฑ์การปิดงาน

- [ ] inventory ทั้ง 34 ตัวของ §3 ถูกบันทึกครบใน `docs/khaojee-visual-reference.md`
- [ ] แก้หลักการเรื่อง Continuity ของ §12 พร้อมรายการไฟล์เป็นหลักฐาน
- [ ] บันทึก Pufferfish's Biome Dither กับ Punchy ว่าใช้ได้และยังไม่ถูกตัดสิน
- [ ] บันทึกข้อควรระวังเรื่องการค้นด้วยชื่อไว้ข้างกฎเรื่อง slug
- [ ] มี `docs/agents/blocked-work.md` และมันอ่านจบได้ในตัวเอง
- [ ] `verify` เขียว

### นอกขอบเขต

**การตัดสินใจเรื่อง Dither หรือ Punchy** ทั้งคู่เป็นการตัดสินตาม §35 บวกกับการวัดบน client
การกวาดบอกว่ามัน*ใช้ได้* ไม่ได้บอกว่าควรเพิ่ม

**การเปิด V3 ใหม่** สิ่งที่พบเรื่อง Continuity เปลี่ยน*เหตุผล*ที่ V3 ยังเปิดอยู่ ไม่ได้เปลี่ยนสถานะ —
มันยังต้องเลือก resource pack และ #53 ก็ยังไม่ได้ข้อสรุป
