### PR TITLE
fix(compat): blacklist Brimm from Improved Mobs equipment — and what that does not fix

### DIFF
--- a/config/improvedmobs/common.toml
+++ b/config/improvedmobs/common.toml
@@ -199,7 +199,28 @@
 #Configs regarding mobs spawning with equipment
 [equipment]
 	#Blacklist items from whole mods. Add modid to prevent items from that mod being equipped. (For individual items use the equipment.json)
-	"Item Blacklist" = []
+	# `brimm` is Brimm Armors, read from its jar's META-INF/mods.toml, not guessed.
+	#
+	# WHY: Brimm is tactical PLAYER gear. A random zombie in a Ratnik plate
+	# carrier reads wrong and would blur the threat silhouettes Main §24 depends
+	# on. This makes the exclusion INTENTIONAL.
+	#
+	# WHAT IT DOES NOT DO: it does not silence the 45 ERROR lines at boot
+	# ("Error calculating default weights for item ratnik", from Brimm throwing
+	# IllegalStateException on m_7366_). Measured: with the blacklist set, the
+	# boot still logs 45 of them, because getDefaultWeight runs while BUILDING
+	# the pool, before the blacklist filters it.
+	#
+	# It does work for behaviour: the generated equipment.json contains ZERO
+	# brimm entries. Brimm armour was already unequippable via the exception
+	# path; this changes "excluded because a mod throws" into "excluded because
+	# we said so", which is what survives Brimm fixing their bug.
+	#
+	# Shipping a pre-generated equipment.json WOULD suppress the log noise, and
+	# was rejected: it is 47 KB, there is no regeneration option, and it would
+	# freeze the equipment pool against this exact mod list forever. That is a
+	# real cost for cosmetic log output with no gameplay effect.
+	"Item Blacklist" = ["brimm"]
 	#Use blacklist as whitelist
 	"Item Whitelist" = false
 	#Blacklist for items mobs should never be able to use.

--- a/docs/agents/blocked-work.md
+++ b/docs/agents/blocked-work.md
@@ -39,6 +39,10 @@ client.** That single fact blocks most of what follows.
 carries **45 ERROR lines** saying Improved Mobs cannot read Brimm Armors' defence values, so no Brimm
 armour will ever be worn by a mob. **Nothing crashed. Nothing failed. The pack is wrong anyway.**
 
+*(Since #70 that exclusion is deliberate — `brimm` is on Improved Mobs' item blacklist because Brimm
+is player gear. The 45 lines remain, measured: the blacklist filters the pool, not the scan that
+builds it. 50 ERROR lines is the expected baseline, not a regression.)*
+
 That is this repo's characteristic failure mode, and it is written up in
 `Obsidian-minecraft-100day/config-and-kubejs-fail-open.md`: **configs fail open and KubeJS drops
 broken files silently.** A green boot is evidence that the server started, and nothing more.

--- a/docs/compatibility-matrix.md
+++ b/docs/compatibility-matrix.md
@@ -448,6 +448,27 @@ server still running**:
 The first reads like a corrupt save and the second like a firewall problem. Neither is.
 `pkill -f` does **not** match these processes; `Get-Process java | Stop-Process -Force` does.
 
+### Improved Mobs × Brimm: the blacklist fixes the behaviour, not the log (#70)
+
+`[equipment] "Item Blacklist" = ["brimm"]` was set from the modid in Brimm's own `META-INF/mods.toml`.
+**Measured on a boot: the 45 `Error calculating default weights` lines are still there.**
+
+| Claim | Result |
+|---|---|
+| the blacklist removes the ERROR lines | ❌ **false** — still 45 |
+| the blacklist keeps Brimm out of the equipment pool | ✅ true — generated `equipment.json` has **zero** brimm entries |
+
+The stack says why: `EquipmentList.getDefaultWeight` runs while **building** the pool, so every armour
+item is asked for its defence value *before* the blacklist can filter it. Brimm throws on 45 of them,
+Improved Mobs catches, logs, and moves on.
+
+**A pre-generated `equipment.json` would suppress the noise and was rejected.** It is 47 KB, the
+config exposes no regeneration option, and it would pin the equipment pool to this exact mod list
+forever. That is a durable cost for cosmetic log output with no gameplay effect.
+
+So the boot is still 50 ERROR lines, 45 of them this, and **that is now the expected baseline** —
+do not read it as a regression.
+
 **Stop every java process before a boot, and give a second server its own port** — `servertest`
 uses `25577`.
 

--- a/index.toml
+++ b/index.toml
@@ -126,7 +126,7 @@ hash = "c922606233ee35e14bb508b6b58c17b35a20e39ece89076795528a859c775946"
 
 [[files]]
 file = "config/improvedmobs/common.toml"
-hash = "a8364ac6a95a957c0a83fa0b7a4f1782cff594969e1e709339f6c55478ff6fb6"
+hash = "108cbd59f3375d48cbef2d3ecdb3b3f886fa1989b64fe39e12db21c49e4839d6"
 
 [[files]]
 file = "config/incontrol/spawn.json"
@@ -771,3 +771,39 @@ metafile = true
 file = "mods/yacl.pw.toml"
 hash = "f3b3d035b89519faccc4ddd8b0b4407ce96c0eb49068fe50a445d43a3baa8bea"
 metafile = true
+
+[[files]]
+file = "resourcepacks/industrial-civilization-connected-textures/assets/ics_ct/textures/block/control_room_window.png"
+hash = "c7f33108275f2ef52f6d8be5ee97b2fa3ecc24780bfa77f6117b09045b76ef38"
+
+[[files]]
+file = "resourcepacks/industrial-civilization-connected-textures/assets/ics_ct/textures/block/control_room_window.png.mcmeta"
+hash = "49b4c1cc9f9260ceea290f3694234ae4eeafd72b440baa44c99d3e62c02f88ea"
+
+[[files]]
+file = "resourcepacks/industrial-civilization-connected-textures/assets/ics_ct/textures/block/factory_glass.png"
+hash = "f9e21af406b8f7ea9b790cd071088c36c028912c94e9cc7f5db97c203f969f12"
+
+[[files]]
+file = "resourcepacks/industrial-civilization-connected-textures/assets/ics_ct/textures/block/factory_glass.png.mcmeta"
+hash = "49b4c1cc9f9260ceea290f3694234ae4eeafd72b440baa44c99d3e62c02f88ea"
+
+[[files]]
+file = "resourcepacks/industrial-civilization-connected-textures/assets/ics_ct/textures/block/industrial_panel.png"
+hash = "39a623f37ef621f10c59802bd3dce048e3429c148f3cce4b02b06cb20525c337"
+
+[[files]]
+file = "resourcepacks/industrial-civilization-connected-textures/assets/ics_ct/textures/block/industrial_panel.png.mcmeta"
+hash = "1949d84d772ac3c89e5d34571d31457222af56ba58fed5245c0f0a94776bce18"
+
+[[files]]
+file = "resourcepacks/industrial-civilization-connected-textures/assets/ics_ct/textures/block/station_glass.png"
+hash = "d2312e44402e2abb0057c24ef3c8866f515c7427031e9fbac76764cd3387b85b"
+
+[[files]]
+file = "resourcepacks/industrial-civilization-connected-textures/assets/ics_ct/textures/block/station_glass.png.mcmeta"
+hash = "49b4c1cc9f9260ceea290f3694234ae4eeafd72b440baa44c99d3e62c02f88ea"
+
+[[files]]
+file = "resourcepacks/industrial-civilization-connected-textures/pack.mcmeta"
+hash = "80006d33962df7d359bbef210570fe3ad6269cf4dc5d712b837069332a5cf3c7"

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "def2f707055968ce88d101c91f24db9380f5b9d72642c017532a4b48e7d1e133"
+hash = "6b15247c298d0cc9ec46b9e9f5461791d3ce35387a0bb06dc37a0d1bb9eb6e07"
 
 [versions]
 forge = "47.4.23"


### PR DESCRIPTION
## Summary

Blacklist Brimm Armors from Improved Mobs' equipment system, on design grounds: **Brimm is tactical
player gear.** A random zombie in a Ratnik plate carrier reads wrong and blurs the threat
silhouettes Main §24 depends on.

Secondary hope: it might also silence the 45 `Error calculating default weights` lines every boot
produces.

## Result: it fixes the behaviour and does NOT fix the log

The modid is **`brimm`**, read from the jar's own `META-INF/mods.toml` — not guessed. Set as
`[equipment] "Item Blacklist" = ["brimm"]`, rebuilt, booted.

| Claim | Measured |
|---|---|
| keeps Brimm out of the equipment pool | ✅ generated `equipment.json` has **zero** brimm entries |
| removes the 45 ERROR lines | ❌ **still 45** |

The stack says why:

```
io.github.flemmli97.improvedmobs.config.EquipmentList.getDefaultWeight(EquipmentList.java:254)
  <- blackoutInteractive...SimpleArmorMaterial.m_7366_(SimpleArmorMaterial.java:59)
```

`getDefaultWeight` runs while **building** the pool, so every armour item is asked for its defence
value *before* the blacklist can filter it. Brimm throws on 45 of them; Improved Mobs catches, logs,
and continues.

**The acceptance criterion as originally framed failed, and that is the finding.** Boot:
`Done (15.386s)`, 83 recipes, 0 failed, **50 ERROR lines — 45 of them this**.

## The equipment.json route was evaluated and rejected

Pre-shipping a generated `equipment.json` would very likely suppress the noise, because the errors
happen while generating that file. It was rejected:

- it is **47 KB** of generated content the pack would then own permanently
- the config exposes **no regeneration option**
- it would **pin the equipment pool to this exact 108-mod list forever** — any mod added later
  contributes no equipment, silently

That is a durable, invisible cost for **cosmetic log output with no gameplay effect**. Not worth it.

## What actually changed, and why it is still worth doing

Brimm armour was *already* unequippable — via the exception path. The blacklist changes **"excluded
because a mod throws"** into **"excluded because we decided"**, which is the version that survives
Brimm fixing their bug. The reasoning is written into the config file itself, including what it does
**not** do, so the next person does not re-run this experiment.

`docs/compatibility-matrix.md` now records **50 ERROR lines as the expected baseline**, so nobody
reads it as a regression. `docs/agents/blocked-work.md` cites those 45 lines as its worked example of
"a green boot is not a correct pack" — updated so the example stays accurate.

## Acceptance criteria

- [x] modid read from the jar, never guessed
- [x] blacklist set in the pack-owned config
- [x] booted, and the result **measured** rather than assumed
- [x] the failed criterion recorded as a failure, not quietly dropped
- [x] the equipment.json alternative evaluated with its cost stated
- [x] `verify` green

## Out of scope

**Patching Brimm.** Its `SimpleArmorMaterial` throws for helmet slots; that is upstream's bug and the
licence is a custom one.

**Making mobs wear Brimm.** Explicitly not wanted — see the design reasoning above.

---

## สรุปภาษาไทย

### สรุป

บล็อก Brimm Armors ออกจากระบบ equipment ของ Improved Mobs ด้วยเหตุผลเชิงออกแบบ:
**Brimm คือชุดยุทธวิธีของผู้เล่น** ซอมบี้สุ่มที่ใส่ Ratnik plate carrier อ่านแล้วผิดที่ผิดทาง
และทำให้เงาของภัยคุกคามที่ Main §24 พึ่งพาอยู่พร่าเลือน

ความหวังรอง: มันอาจดับ 45 บรรทัด `Error calculating default weights` ที่ทุก boot สร้างขึ้นด้วย

### ผล: มันแก้พฤติกรรมได้ และ**ไม่**แก้ log

modid คือ **`brimm`** อ่านจาก `META-INF/mods.toml` ของ jar เอง ไม่ได้เดา ตั้งเป็น
`[equipment] "Item Blacklist" = ["brimm"]` แล้ว rebuild แล้ว boot

| คำกล่าว | ที่วัดได้ |
|---|---|
| กัน Brimm ออกจาก equipment pool | ✅ `equipment.json` ที่สร้างขึ้นมี brimm **ศูนย์** รายการ |
| ลบ 45 บรรทัด ERROR | ❌ **ยังคง 45** |

stack บอกเหตุผล:

```
io.github.flemmli97.improvedmobs.config.EquipmentList.getDefaultWeight(EquipmentList.java:254)
  <- blackoutInteractive...SimpleArmorMaterial.m_7366_(SimpleArmorMaterial.java:59)
```

`getDefaultWeight` รันตอน**สร้าง** pool ดังนั้นทุกชิ้นเกราะถูกถามค่าป้องกัน*ก่อน*ที่ blacklist
จะกรองได้ Brimm โยน exception 45 ชิ้น Improved Mobs จับ log แล้วไปต่อ

**เกณฑ์การปิดงานตามที่ตั้งไว้เดิมไม่ผ่าน และนั่นคือสิ่งที่พบ** Boot:
`Done (15.386s)`, 83 recipes, 0 failed, **50 บรรทัด ERROR — 45 บรรทัดเป็นอันนี้**

### ทางเลือก equipment.json ถูกประเมินและถูกปฏิเสธ

การส่ง `equipment.json` ที่สร้างไว้ล่วงหน้าน่าจะดับเสียงรบกวนได้ เพราะ error เกิดตอนสร้างไฟล์นั้นพอดี
แต่ถูกปฏิเสธ:

- มันคือเนื้อหาที่สร้างขึ้น **47 KB** ที่ pack จะต้องเป็นเจ้าของไปตลอด
- config ไม่มีตัวเลือกให้ **สร้างใหม่**
- มันจะ **ตรึง equipment pool ไว้กับรายชื่อ 108 มอดชุดนี้ตลอดไป** มอดที่เพิ่มทีหลัง
  จะไม่ส่ง equipment เข้ามาเลยแบบเงียบ ๆ

นั่นคือต้นทุนที่ถาวรและมองไม่เห็น แลกกับ **log ที่เป็นแค่ความสวยงามและไม่มีผลต่อ gameplay** ไม่คุ้ม

### สิ่งที่เปลี่ยนจริง และทำไมยังคุ้มที่จะทำ

เกราะ Brimm *เดิมก็* สวมไม่ได้อยู่แล้ว — ผ่านทาง exception การ blacklist เปลี่ยนจาก
**"ถูกกันออกเพราะมอดโยน exception"** เป็น **"ถูกกันออกเพราะเราตัดสินใจ"**
ซึ่งเป็นเวอร์ชันที่จะอยู่รอดเมื่อ Brimm แก้บั๊กของเขา เหตุผลถูกเขียนไว้ในไฟล์ config เอง
รวมทั้งสิ่งที่มัน **ไม่ได้** ทำ เพื่อให้คนถัดไปไม่ต้องมาทดลองซ้ำ

`docs/compatibility-matrix.md` ตอนนี้บันทึกว่า **50 บรรทัด ERROR คือเส้นฐานที่คาดไว้**
จะได้ไม่มีใครอ่านว่าเป็นการถอยหลัง ส่วน `docs/agents/blocked-work.md` ใช้ 45 บรรทัดนั้น
เป็นตัวอย่างของ "boot เขียวไม่เท่ากับ pack ถูกต้อง" — อัปเดตแล้วให้ตัวอย่างยังตรง

### เกณฑ์การปิดงาน

- [x] อ่าน modid จาก jar ไม่เดา
- [x] ตั้ง blacklist ใน config ที่ pack เป็นเจ้าของ
- [x] boot แล้ว และ **วัดผล** แทนที่จะสมมติ
- [x] บันทึกเกณฑ์ที่ไม่ผ่านว่าไม่ผ่าน ไม่ได้ทิ้งไปเงียบ ๆ
- [x] ประเมินทางเลือก equipment.json พร้อมระบุต้นทุน
- [x] `verify` เขียว

### นอกขอบเขต

**การแก้ Brimm** `SimpleArmorMaterial` ของมันโยน exception สำหรับช่องหมวก นั่นเป็นบั๊กของต้นน้ำ
และสัญญาอนุญาตของมันเป็นแบบ custom

**การทำให้มอบใส่ Brimm ได้** ไม่ต้องการอย่างชัดเจน ดูเหตุผลเชิงออกแบบข้างบน
