### PR TITLE
feat(build): a CurseForge artifact that carries the four blocked mods, local use only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,7 @@ Thumbs.db
 
 # Client evidence bundles are captures, not sources. Send them, do not commit them.
 build/client-evidence-*.zip
+
+# The local CurseForge build bundles mods we may not redistribute. It is a
+# personal artifact, never a committed or published one.
+build/*-curseforge-local.zip

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,7 +142,8 @@ node scripts/validate/verify.mjs lint     # syntax · placeholders · JEI orphan
 node scripts/validate/verify.mjs test     # node --check over every kubejs/**/*.js
 
 node scripts/build/build-friend-pack.mjs  # THE ARTIFACT A FRIEND GETS — 123 KB, zero jars (ADR 0005)
-node scripts/build/build-instance.mjs     # internal TEST artifact only, 405 MB — never handed out
+node scripts/build/build-instance.mjs     # internal TEST artifact only, 430 MB — never handed out
+node scripts/build/build-curseforge-local.mjs  # CurseForge App import, LOCAL ONLY — bundles the 4 blocked mods
 node scripts/build/build-server.mjs       # the server pack (341 MB, 91 mods — Distribution Spec §12)
 node scripts/build/generate-checksums.mjs # build/SHA256SUMS.txt, and refuses a stale artifact
 node scripts/build/generate-modlist.mjs   # docs/MODLIST.md — 108 mods, source URLs resolved from ids

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -39,6 +39,14 @@ This works offline, and it works when a mod's download page is unreachable.
 
 ## Option B — CurseForge App
 
+**Use `…-alpha-curseforge-local.zip`**, not the plain `…-alpha.zip`. The plain one references four
+mods whose authors disabled third-party downloading, and whether the CurseForge App resolves them is
+untested. The `-local` build carries those four directly, so the import is one step.
+
+**It is named `local` because it must not be shared** — two of those four are All Rights Reserved.
+To give the pack to someone, send the friend pack.
+
+
 1. **Minecraft** → **Create Custom Profile** → **Import**
 2. Select `Industrial-Civilization-Survival-0.1.0-alpha.zip` *(the 130 MB one)*
 3. Wait for it to download the mods, then **Play**.

--- a/docs/adr/0005-thin-distribution-we-do-not-rehost-jars.md
+++ b/docs/adr/0005-thin-distribution-we-do-not-rehost-jars.md
@@ -90,6 +90,26 @@ author.**
    platform rules to anything in `overrides/`. Both are real problems and **neither is a reason to
    delay three or four friends.**
 
+### One scoped exception, added 2026-08-27 (#80)
+
+`scripts/build/build-curseforge-local.mjs` produces
+`…-alpha-curseforge-local.zip`, which **does** bundle the four API-blocked mods, so importing into
+the CurseForge App is one step.
+
+**That is this ADR's rule broken on purpose, and the scope is what makes it coherent.** This ADR
+reasons about *distribution*. That file is built on one machine for that machine, is named `local`,
+and carries a `README.txt` telling anyone who opens it not to share it and to send the friend pack
+instead.
+
+Two of the four could be shared anyway — **TakKit is MIT** and **Client Dynamic Light is MPL-2.0**,
+both of which grant redistribution in their own text. **Flashier Flashlights** and **Player
+Microchip** are All Rights Reserved with an explicit opt-out, and they are the reason the file is not
+simply folded into the normal export.
+
+**The rule still holds where it matters:** `build-friend-pack.mjs` refuses to emit an archive
+containing any jar at all, and the normal CurseForge export still references rather than bundles the
+four.
+
 ## Alternatives considered
 
 - **Keep self-contained and ask the affected authors.** Not rejected — it is simply slower, and it

--- a/docs/distribution-licenses.md
+++ b/docs/distribution-licenses.md
@@ -38,9 +38,10 @@ their licences.** Swapping mods will not fix it; only changing how the pack is d
 
 | Artifact | How mods reach the player | Rehosts a jar? |
 |---|---|---|
-| `…-instance.zip` (405 MB) | all 107 jars inside the zip | **yes, 107** |
-| `…-server.zip` (341 MB) | all 91 jars inside the zip | **yes, 91** |
-| `…-alpha.zip` (CurseForge, 148 MB) | **40** referenced by project/file id · **65** bundled in `overrides/mods/` | **yes, 65** |
+| `…-instance.zip` (430 MB) | all 114 jars inside the zip | **yes, 114** |
+| `…-server.zip` (362 MB) | all 94 jars inside the zip | **yes, 94** |
+| `…-alpha.zip` (CurseForge, 173 MB) | **40** referenced by project/file id · **72** bundled in `overrides/mods/` | **yes, 72** |
+| `…-alpha-curseforge-local.zip` (177 MB) | **36** referenced · **76** bundled, **including the four API-blocked mods** | **yes, 76** — ADR 0005's one scoped exception, **local use only** |
 
 The CurseForge-format export is closest to compliant, and still bundles 65 jars — packwiz puts
 Modrinth-sourced mods in `overrides/` because a CurseForge manifest cannot reference them.
@@ -313,9 +314,10 @@ proposes but has not installed. `docs/khaojee-visual-reference.md` records their
 
 | Artifact | มอดไปถึงผู้เล่นยังไง | rehost jar ไหม |
 |---|---|---|
-| `…-instance.zip` (405 MB) | jar ทั้ง 107 ตัวอยู่ใน zip | **ใช่ 107 ตัว** |
-| `…-server.zip` (341 MB) | jar ทั้ง 91 ตัวอยู่ใน zip | **ใช่ 91 ตัว** |
-| `…-alpha.zip` (CurseForge, 148 MB) | **40** อ้างด้วย project/file id · **65** ใส่ไว้ใน `overrides/mods/` | **ใช่ 65 ตัว** |
+| `…-instance.zip` (430 MB) | jar ทั้ง 114 ตัวอยู่ใน zip | **ใช่ 114 ตัว** |
+| `…-server.zip` (362 MB) | jar ทั้ง 94 ตัวอยู่ใน zip | **ใช่ 94 ตัว** |
+| `…-alpha.zip` (CurseForge, 173 MB) | **40** อ้างด้วย project/file id · **72** ใส่ไว้ใน `overrides/mods/` | **ใช่ 72 ตัว** |
+| `…-alpha-curseforge-local.zip` (177 MB) | **36** อ้างถึง · **76** ฝังไว้ **รวมมอดสี่ตัวที่ถูกปิดกั้น** | **ใช่ 76 ตัว** — ข้อยกเว้นเดียวที่กำหนดขอบเขตไว้ของ ADR 0005 **ใช้เองเท่านั้น** |
 
 ตัว export รูปแบบ CurseForge ใกล้เคียงกับที่ถูกต้องที่สุด และก็ยังใส่ jar มา 65 ตัว —
 packwiz เอามอดที่มาจาก Modrinth ไปไว้ใน `overrides/` เพราะ manifest ของ CurseForge อ้างถึงมันไม่ได้

--- a/scripts/build/build-curseforge-local.mjs
+++ b/scripts/build/build-curseforge-local.mjs
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+// A CurseForge-format pack that carries the four mods whose authors disabled
+// third-party downloading, so importing it into the CurseForge App is one step.
+//
+// ---------------------------------------------------------------------------
+// THIS DELIBERATELY BREAKS ADR 0005, AND THE SCOPE IS THE POINT.
+//
+// ADR 0005 stopped shipping other people's jars. This bundles four of them. The
+// difference is who receives it:
+//
+//   -friend.zip            friends, and anyone else   ->  zero third-party jars
+//   -instance.zip          internal test only         ->  all of them
+//   -curseforge-local.zip  THIS MACHINE               ->  all of them, incl. the four
+//
+// ADR 0005 reasons about *distribution*. A file built here for use here is not
+// distribution. The name says `local`, and the README inside says why.
+//
+// Two of the four are unproblematic — TakKit is MIT and Client Dynamic Light is
+// MPL-2.0, both of which grant redistribution in their own text. The other two,
+// Flashier Flashlights and Player Microchip, are All Rights Reserved with an
+// explicit opt-out. They are the reason this file is not simply the normal
+// export.
+// ---------------------------------------------------------------------------
+
+import { readFileSync, writeFileSync, mkdirSync, existsSync, statSync, rmSync, copyFileSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { execFileSync } from 'node:child_process'
+import { readPack, readMetas } from './lib/pack.mjs'
+
+const ROOT = process.cwd()
+const pack = readPack(ROOT)
+const NAME = pack.name.replace(/[^A-Za-z0-9]+/g, '-')
+const SRC = join(ROOT, 'build', `${NAME}-${pack.version}.zip`)
+const OUT = join(ROOT, 'build', `${NAME}-${pack.version}-curseforge-local.zip`)
+const STAGE = join(ROOT, 'build', '.cf-local')
+
+/** The four, with the licence that decides how each one reads. Slugs match the
+ *  metafile basenames; nothing here is guessed. */
+const BLOCKED = [
+  ['takkit', 'TakKit', 'MIT — the licence grants redistribution'],
+  ['client-dynamic-light', 'Client Dynamic Light', 'MPL-2.0 — the licence grants redistribution'],
+  ['flashier-flashlights', 'Flashier Flashlights', 'All Rights Reserved — no grant, and an explicit opt-out'],
+  ['player-microchip', 'Player Microchip (Tracker)', 'All Rights Reserved — no grant, and an explicit opt-out'],
+]
+
+if (!existsSync(SRC)) {
+  console.error(`${SRC} is missing.`)
+  console.error('Run: packwiz curseforge export -o "build/<name>-<version>.zip"')
+  process.exit(1)
+}
+
+if (existsSync(STAGE)) rmSync(STAGE, { recursive: true, force: true })
+mkdirSync(STAGE, { recursive: true })
+
+// -- unpack the normal export ----------------------------------------------
+execFileSync('powershell', ['-NoProfile', '-Command',
+  `$ErrorActionPreference='Stop';` +
+  `Add-Type -AssemblyName System.IO.Compression.FileSystem;` +
+  `[System.IO.Compression.ZipFile]::ExtractToDirectory('${SRC}','${STAGE}')`,
+], { stdio: 'pipe' })
+console.log(`unpacked ${NAME}-${pack.version}.zip`)
+
+// -- copy each blocked jar out of the build cache --------------------------
+const CACHE = join(ROOT, 'build', '.jar-cache')
+const metas = readMetas(ROOT)
+const modsDir = join(STAGE, 'overrides', 'mods')
+mkdirSync(modsDir, { recursive: true })
+
+const added = []
+for (const [slug, label, licence] of BLOCKED) {
+  const metaPath = join(ROOT, 'mods', `${slug}.pw.toml`)
+  if (!existsSync(metaPath)) { console.error(`  ! ${slug}: no metafile`); process.exit(1) }
+  const filename = (readFileSync(metaPath, 'utf8').match(/^filename\s*=\s*"([^"]*)"/m) || [])[1]
+  const cached = join(CACHE, filename)
+  if (!existsSync(cached)) {
+    console.error(`  ! ${label}: ${filename} not in build/.jar-cache/`)
+    console.error('    Run a build that fetches jars first: node scripts/build/build-instance.mjs')
+    process.exit(1)
+  }
+  copyFileSync(cached, join(modsDir, filename))
+  added.push({ slug, label, filename, licence })
+  console.log(`  bundled ${label} — ${licence}`)
+}
+
+// -- drop their manifest entries, so the App does not refetch what is here --
+const manifestPath = join(STAGE, 'manifest.json')
+const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'))
+const blockedIds = new Set(BLOCKED.map(([slug]) => {
+  const src = readFileSync(join(ROOT, 'mods', `${slug}.pw.toml`), 'utf8')
+  return Number((src.match(/^\s*project-id\s*=\s*(\d+)/m) || [])[1])
+}).filter(Boolean))
+
+const before = manifest.files.length
+manifest.files = manifest.files.filter(f => !blockedIds.has(f.projectID))
+writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + '\n')
+console.log(`manifest: ${before} → ${manifest.files.length} referenced (${before - manifest.files.length} now bundled)`)
+
+// -- the warning the importer sees -----------------------------------------
+writeFileSync(join(STAGE, 'README.txt'), [
+  `${pack.name} — ${pack.version} — CurseForge format, LOCAL USE ONLY`,
+  '',
+  'DO NOT SHARE THIS FILE.',
+  '',
+  '  It contains four mods whose authors switched off third-party downloading.',
+  '  It exists so that importing into the CurseForge App is one step on the',
+  '  machine that built it. It is not the artifact anyone else receives.',
+  '',
+  '  To give this pack to someone, send the friend pack instead. It contains no',
+  '  third-party mod files at all, and the build refuses to emit one that does.',
+  '',
+  'THE FOUR, AND WHY THEY ARE NOT ONE CASE',
+  '',
+  ...added.flatMap(a => [`  ${a.label}`, `    ${a.filename}`, `    ${a.licence}`, '']),
+  '  TakKit and Client Dynamic Light could be shared — their own licences say so.',
+  '  The other two could not. That is the whole reason this file is named local.',
+  '',
+  'WHAT IS NOT VERIFIED',
+  '',
+  '  Nobody has launched a client. Every check so far is a dedicated-server boot.',
+  '  Treat any world you create as a test world: the biome generation has not',
+  '  been tested against the criteria the design documents set.',
+  '',
+].join('\n'))
+
+// -- repack, entries with `/` ----------------------------------------------
+if (existsSync(OUT)) rmSync(OUT)
+execFileSync('powershell', ['-NoProfile', '-Command', `
+$ErrorActionPreference = 'Stop'
+Add-Type -AssemblyName System.IO.Compression
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+$stage = '${STAGE}'
+$out   = '${OUT}'
+$zip = [System.IO.Compression.ZipFile]::Open($out, [System.IO.Compression.ZipArchiveMode]::Create)
+try {
+  Get-ChildItem -Path $stage -Recurse -File | ForEach-Object {
+    $rel = $_.FullName.Substring($stage.Length + 1).Replace('\\', '/')
+    [System.IO.Compression.ZipFileExtensions]::CreateEntryFromFile($zip, $_.FullName, $rel, [System.IO.Compression.CompressionLevel]::Optimal) | Out-Null
+  }
+} finally { $zip.Dispose() }
+`], { stdio: 'pipe' })
+
+// -- read the archive back; do not trust that the copies landed ------------
+const listing = execFileSync('powershell', ['-NoProfile', '-Command',
+  `Add-Type -AssemblyName System.IO.Compression.FileSystem;` +
+  `$z=[System.IO.Compression.ZipFile]::OpenRead('${OUT}');` +
+  `$z.Entries | ForEach-Object { $_.FullName }; $z.Dispose()`,
+], { encoding: 'utf8' }).split(/\r?\n/).filter(Boolean)
+
+const problems = []
+for (const a of added) {
+  if (!listing.includes(`overrides/mods/${a.filename}`)) problems.push(`${a.label} did not make it into the archive`)
+}
+if (listing.some(e => e.includes('\\'))) problems.push('entry names contain a backslash')
+if (!listing.includes('manifest.json')) problems.push('manifest.json missing')
+if (!listing.includes('README.txt')) problems.push('README.txt missing')
+
+const jars = listing.filter(e => e.toLowerCase().endsWith('.jar')).length
+if (problems.length) {
+  console.error('\n✗ local CurseForge pack is malformed:')
+  for (const p of problems) console.error(`  ${p}`)
+  process.exit(1)
+}
+
+rmSync(STAGE, { recursive: true, force: true })
+const size = statSync(OUT).size
+console.log(`\narchive verified — ${jars} jars bundled, all four blocked mods present, no backslash entries`)
+console.log(`\n✓ build/${NAME}-${pack.version}-curseforge-local.zip  (${(size / 1048576).toFixed(0)} MB, ${metas.length} mods)`)
+console.log('  CurseForge App → Create Custom Profile → Import. LOCAL USE ONLY — do not share it.')

--- a/scripts/build/generate-checksums.mjs
+++ b/scripts/build/generate-checksums.mjs
@@ -38,8 +38,15 @@ if (!existsSync(BUILD)) {
   process.exit(1)
 }
 
+// `-curseforge-local.zip` is excluded on purpose. SHA256SUMS.txt is a manifest
+// for people who received a download; that artifact is never handed to anyone —
+// it bundles the four mods whose authors disabled third-party distribution, and
+// ADR 0005 scopes it to the machine that built it. Listing it here would put a
+// file that must not be shared into the document people use to check what they
+// were sent.
 const artifacts = readdirSync(BUILD)
   .filter(f => f.endsWith('.zip') || f.endsWith('.mrpack'))
+  .filter(f => !f.endsWith('-curseforge-local.zip'))
   .sort()
 
 if (!artifacts.length) {


### PR DESCRIPTION
## Summary

The CurseForge export references all 114 mods, but four of them have third-party downloading disabled
by their authors. Whether the CurseForge App resolves them is **untested** — if it does not, the
import stops four mods short and the player has to fetch them by hand.

Make a CurseForge-format artifact that carries those four directly, so import is one step.

## This deliberately breaks ADR 0005, and the scope is the whole point

ADR 0005 stopped shipping other people's jars. Bundling these four is exactly the thing it stopped.
**The difference is who receives it.**

| Artifact | Audience | Third-party jars |
|---|---|---|
| `-friend.zip` | friends, and anyone else | **zero** — enforced by the build |
| `-instance.zip` | internal test only | all 114 |
| `-curseforge-local.zip` *(new)* | **the developer's own machine** | 114, including the four |

ADR 0005's reasoning was about *distribution*. An artifact built on this machine, for this machine,
is not distribution — and the new file says so in its own name and in a README the importer sees.

## The four are not one case

| Mod | Licence | Bundling it |
|---|---|---|
| TakKit | **MIT** | permitted by the licence text itself |
| Client Dynamic Light | **MPL-2.0** | permitted by the licence text itself |
| Flashier Flashlights | **All Rights Reserved** | no grant, plus an explicit third-party opt-out |
| Player Microchip | **All Rights Reserved** | same |

Two of four are unproblematic. The other two are the reason the file is named `-local` and carries a
warning rather than being folded into the normal export.

## Acceptance criteria

- [ ] `scripts/build/build-curseforge-local.mjs` produces `…-alpha-curseforge-local.zip`
- [ ] All four jars present under `overrides/mods/`, verified by re-reading the archive
- [ ] Their manifest entries removed, so the CurseForge App does not try to fetch what is already
      there
- [ ] A `README.txt` inside naming the four, their licences, and that the file must not be shared
- [ ] The distribution table in `docs/distribution-licenses.md` gains the row
- [ ] ADR 0005 records the exception and its scope
- [ ] `CLAUDE.md` commands updated
- [ ] `verify` green

## Out of scope

**Changing the normal CurseForge export.** It stays as it is — manifest references, no bundled
opt-out mods — because that one is shareable.

**Testing whether the CurseForge App resolves the four on its own.** That needs the App. If it turns
out it does, this artifact becomes unnecessary rather than wrong.

---

## สรุปภาษาไทย

### สรุป

CurseForge export อ้างถึงมอดครบทั้ง 114 ตัว แต่สี่ตัวในนั้นเจ้าของปิดการโหลดผ่านระบบภายนอกไว้
CurseForge App จะดึงมันได้หรือไม่ **ยังไม่ได้ทดสอบ** — ถ้าไม่ได้ การ import จะขาดไปสี่ตัว
และผู้เล่นต้องไปโหลดเอง

ทำไฟล์รูปแบบ CurseForge ที่พาสี่ตัวนั้นไปด้วยเลย import ครั้งเดียวจบ

### เรื่องนี้ขัดกับ ADR 0005 โดยตั้งใจ และขอบเขตคือประเด็นทั้งหมด

ADR 0005 เลิกส่ง jar ของคนอื่น การฝังสี่ตัวนี้คือสิ่งที่มันเลิกทำพอดี **ต่างกันที่ใครเป็นผู้รับ**

| Artifact | ผู้รับ | jar ของบุคคลที่สาม |
|---|---|---|
| `-friend.zip` | เพื่อน และคนอื่น ๆ | **ศูนย์** — บังคับโดยตัว build |
| `-instance.zip` | ทดสอบภายในเท่านั้น | ครบ 114 |
| `-curseforge-local.zip` *(ใหม่)* | **เครื่องของผู้พัฒนาเอง** | 114 รวมสี่ตัวนั้น |

เหตุผลของ ADR 0005 คือเรื่อง*การแจกจ่าย* ไฟล์ที่สร้างบนเครื่องนี้เพื่อเครื่องนี้ไม่ใช่การแจกจ่าย
และไฟล์ใหม่ก็บอกเรื่องนั้นไว้ทั้งในชื่อของมันเองและใน README ที่คนกด import จะเห็น

### สี่ตัวนี้ไม่ใช่กรณีเดียวกัน

| มอด | สัญญาอนุญาต | การฝังมัน |
|---|---|---|
| TakKit | **MIT** | ตัวสัญญาอนุญาตอนุญาตเอง |
| Client Dynamic Light | **MPL-2.0** | ตัวสัญญาอนุญาตอนุญาตเอง |
| Flashier Flashlights | **All Rights Reserved** | ไม่มีการให้สิทธิ์ บวกกับการปิดกั้นบุคคลที่สามอย่างชัดเจน |
| Player Microchip | **All Rights Reserved** | เหมือนกัน |

สองในสี่ไม่มีปัญหาเลย อีกสองตัวคือเหตุผลที่ไฟล์นี้ชื่อลงท้ายว่า `-local` และมีคำเตือนติดมา
แทนที่จะรวมเข้าไปใน export ปกติ

### เกณฑ์การปิดงาน

- [ ] `scripts/build/build-curseforge-local.mjs` สร้าง `…-alpha-curseforge-local.zip`
- [ ] jar ทั้งสี่อยู่ใต้ `overrides/mods/` ตรวจด้วยการอ่านไฟล์กลับ
- [ ] ลบรายการของมันออกจาก manifest เพื่อไม่ให้ CurseForge App ไปดึงของที่มีอยู่แล้วซ้ำ
- [ ] มี `README.txt` ข้างในระบุชื่อสี่ตัว สัญญาอนุญาตของแต่ละตัว และว่าห้ามเอาไฟล์นี้ไปแจก
- [ ] ตารางการแจกจ่ายใน `docs/distribution-licenses.md` เพิ่มแถวใหม่
- [ ] ADR 0005 บันทึกข้อยกเว้นและขอบเขตของมัน
- [ ] อัปเดตคำสั่งใน `CLAUDE.md`
- [ ] `verify` เขียว

### นอกขอบเขต

**การเปลี่ยน CurseForge export ปกติ** มันอยู่เหมือนเดิม — อ้างผ่าน manifest ไม่ฝังมอดที่ปิดกั้นไว้
เพราะตัวนั้นแจกได้

**การทดสอบว่า CurseForge App ดึงสี่ตัวนั้นได้เองไหม** ต้องใช้ตัว App ถ้าปรากฏว่ามันทำได้
ไฟล์นี้ก็จะกลายเป็นของไม่จำเป็น ไม่ใช่ของผิด
