### PR TITLE
docs: say which artifacts may be uploaded, and write the readme friends will read

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -25,6 +25,9 @@ This is not a limitation of this pack; the official launcher has no modpack supp
 
 ---
 
+> **Sharing this pack?** Upload **only** `…-friend.zip`, with `build/README.md` beside it.
+> Every other artifact bundles other people's jars — see `docs/distribution-licenses.md`.
+
 ## Option A — Prism Launcher, self-contained *(recommended — one step)*
 
 1. **Add Instance** → **Import from zip**

--- a/docs/distribution-licenses.md
+++ b/docs/distribution-licenses.md
@@ -43,7 +43,19 @@ their licences.** Swapping mods will not fix it; only changing how the pack is d
 | `…-alpha.zip` (CurseForge, 173 MB) | **40** referenced by project/file id · **72** bundled in `overrides/mods/` | **yes, 72** |
 | `…-alpha-curseforge-local.zip` (177 MB) | **36** referenced · **76** bundled, **including the four API-blocked mods** | **yes, 76** — ADR 0005's one scoped exception, **local use only** |
 
-The CurseForge-format export is closest to compliant, and still bundles 65 jars — packwiz puts
+**Only `-friend.zip` may be uploaded anywhere.** That is the practical form of everything above, and
+it is easy to undo by accident — putting all five artifacts in one shared folder republishes 114
+jars.
+
+| Artifact | Third-party jars | May be shared |
+|---|---|---|
+| `…-friend.zip` | **0** | **yes** — and it serves both client and server, via `-s server` |
+| `…-instance.zip` | 114 | no — internal test artifact |
+| `…-server.zip` | 94 | no — use the friend pack with `-s server` instead |
+| `…-alpha.zip` (CurseForge) | 72 | no |
+| `…-curseforge-local.zip` | 76 | **never** — two of its mods are ARR with an explicit opt-out |
+
+The CurseForge-format export is closest to compliant, and still bundles 72 jars — packwiz puts
 Modrinth-sourced mods in `overrides/` because a CurseForge manifest cannot reference them.
 
 ## Four authors switched off third-party distribution
@@ -319,7 +331,18 @@ proposes but has not installed. `docs/khaojee-visual-reference.md` records their
 | `…-alpha.zip` (CurseForge, 173 MB) | **40** อ้างด้วย project/file id · **72** ใส่ไว้ใน `overrides/mods/` | **ใช่ 72 ตัว** |
 | `…-alpha-curseforge-local.zip` (177 MB) | **36** อ้างถึง · **76** ฝังไว้ **รวมมอดสี่ตัวที่ถูกปิดกั้น** | **ใช่ 76 ตัว** — ข้อยกเว้นเดียวที่กำหนดขอบเขตไว้ของ ADR 0005 **ใช้เองเท่านั้น** |
 
-ตัว export รูปแบบ CurseForge ใกล้เคียงกับที่ถูกต้องที่สุด และก็ยังใส่ jar มา 65 ตัว —
+**มีแค่ `-friend.zip` เท่านั้นที่อัปโหลดที่ไหนก็ได้** นั่นคือรูปแบบที่ใช้จริงของทุกอย่างข้างบน
+และมันพลาดได้ง่ายมาก — การเอา artifact ทั้งห้าไปใส่โฟลเดอร์แชร์เดียวกันคือการเผยแพร่ jar 114 ตัวซ้ำ
+
+| Artifact | jar ของบุคคลที่สาม | แชร์ได้ไหม |
+|---|---|---|
+| `…-friend.zip` | **0** | **ได้** — และใช้ได้ทั้ง client และ server ผ่าน `-s server` |
+| `…-instance.zip` | 114 | ไม่ได้ — เป็น artifact สำหรับทดสอบภายใน |
+| `…-server.zip` | 94 | ไม่ได้ — ใช้ friend pack กับ `-s server` แทน |
+| `…-alpha.zip` (CurseForge) | 72 | ไม่ได้ |
+| `…-curseforge-local.zip` | 76 | **ห้ามเด็ดขาด** — สองตัวในนั้นเป็น ARR และเจ้าของปิดกั้นไว้ |
+
+ตัว export รูปแบบ CurseForge ใกล้เคียงกับที่ถูกต้องที่สุด และก็ยังใส่ jar มา 72 ตัว —
 packwiz เอามอดที่มาจาก Modrinth ไปไว้ใน `overrides/` เพราะ manifest ของ CurseForge อ้างถึงมันไม่ได้
 
 ## ผู้เขียนสี่คนปิดการแจกจ่ายผ่านบุคคลที่สาม

--- a/docs/friend-download-readme.md
+++ b/docs/friend-download-readme.md
@@ -1,0 +1,144 @@
+# Industrial Civilization Survival — วิธีติดตั้ง
+
+Minecraft **1.20.1** · Forge **47.4.23** · มอด **114** ตัว
+
+โหลดไฟล์เดียวพอ: **`Industrial-Civilization-Survival-0.1.0-alpha-friend.zip`** (127 KB)
+
+---
+
+## ทำไมมันเล็กแค่นี้
+
+เพราะข้างในไม่มีตัวมอด มีแต่ config, สคริปต์, เควส และ**รายชื่อว่าต้องใช้มอดตัวไหนเวอร์ชันอะไร**
+ตอนติดตั้งโปรแกรมจะไปโหลดมอดจากคนทำมอดเองทีละตัว
+
+ทำแบบนี้เพราะผู้เขียนมอดหลายคนอนุญาตให้เอาไปใส่ pack ได้ แต่ขอว่าอย่าเอาไฟล์ของเขาไปแจกต่อ
+
+ผลพลอยได้คือเวลามีอัปเดต จะโหลดกันแค่ไม่กี่ร้อย KB ไม่ใช่ 400 MB ทุกครั้ง
+
+---
+
+## สิ่งที่ต้องมีก่อน
+
+- **Prism Launcher** — โหลดฟรีที่ <https://prismlauncher.org>
+- **Java 17** — Prism จะบอกเองถ้าไม่มี กดตามได้เลย
+- **RAM 8 GB** ให้ Minecraft (114 มอด กินพอสมควร)
+
+---
+
+## ติดตั้ง
+
+**1. สร้าง instance ใน Prism**
+
+Add Instance → Custom → เลือก Minecraft **1.20.1** → Mod Loader เลือก **Forge 47.4.23**
+
+**2. เปิดโฟลเดอร์ของ instance**
+
+คลิกขวาที่ instance → **Folder** จะเปิดโฟลเดอร์ขึ้นมา เข้าไปที่ `.minecraft` ข้างใน
+
+**3. แตกไฟล์ zip ลงไปตรงนั้น**
+
+แตก `...-friend.zip` แล้วเอาของข้างในทั้งหมดวางใน `.minecraft` จะได้หน้าตาแบบนี้
+
+```
+.minecraft/
+    pack.toml
+    index.toml
+    mods/          ← ตอนนี้มีแต่ไฟล์ .pw.toml ยังไม่มี .jar
+    config/
+    kubejs/
+    defaultconfigs/
+    resourcepacks/
+```
+
+**4. โหลดตัวติดตั้งมอด**
+
+โหลด `packwiz-installer-bootstrap.jar` จาก
+<https://github.com/packwiz/packwiz-installer-bootstrap/releases>
+แล้วเอาไปวางใน `.minecraft` ที่เดียวกัน
+
+**5. ตั้งให้มันทำงานก่อนเปิดเกม**
+
+ใน Prism → คลิกขวาที่ instance → **Edit** → **Settings** → ติ๊ก **Custom commands**
+แล้วใส่ในช่อง **Pre-launch command**
+
+```
+"$INST_JAVA" -jar packwiz-installer-bootstrap.jar pack.toml
+```
+
+**6. กด Launch**
+
+ครั้งแรกจะโหลดมอดสักพัก ครั้งต่อ ๆ ไปจะเช็คแค่ว่ามีอะไรเปลี่ยนไหม
+
+---
+
+## มอด 4 ตัวที่ต้องโหลดเอง ครั้งเดียวจบ
+
+คนทำมอดสี่ตัวนี้ปิดการโหลดอัตโนมัติไว้ ตัวติดตั้งจึงดึงให้ไม่ได้ โหลดเองแล้วเอา `.jar`
+ไปวางใน `.minecraft/mods/` **ทำครั้งเดียว** อัปเดตหลังจากนั้นไม่ต้องทำอีก
+
+| มอด | ลิงก์ |
+|---|---|
+| TakKit | <https://www.curseforge.com/minecraft/mc-mods/takkit> |
+| Flashier Flashlights | <https://www.curseforge.com/minecraft/mc-mods/flashier-flashlights> |
+| Client Dynamic Light | <https://www.curseforge.com/minecraft/mc-mods/client-dynamic-light> |
+| Player Microchip | <https://www.curseforge.com/minecraft/mc-mods/player-microchip> |
+
+เลือกเวอร์ชันสำหรับ **1.20.1 Forge**
+
+---
+
+## เปิด server ก็ใช้ไฟล์เดียวกันนี้
+
+ไม่ต้องโหลดไฟล์อื่น
+
+1. ติดตั้ง **Forge 47.4.23** แบบ server จาก <https://files.minecraftforge.net> (เลือก Installer → Install server)
+2. แตก zip ตัวเดียวกันลงในโฟลเดอร์ server
+3. เอา `packwiz-installer-bootstrap.jar` ไปวางไว้ด้วย
+4. รันคำสั่งนี้ก่อนเปิด server หนึ่งครั้ง
+
+```
+java -jar packwiz-installer-bootstrap.jar -g -s server pack.toml
+```
+
+`-s server` บอกให้มันข้ามมอดที่ทำงานเฉพาะฝั่งผู้เล่น เช่นมอดภาพกับมอดเสียง จะเหลือ 94 ตัว
+
+5. เปิด server ตามปกติ
+
+**ทุกคนต้องใช้เวอร์ชันเดียวกัน** เทียบไฟล์ `pack-version.txt` ได้ ถ้าเลขไม่ตรงกันคือปัญหาอยู่ตรงนั้น อย่าเพิ่งไปหาที่อื่น
+
+---
+
+## เรื่องที่ต้องรู้ก่อนเล่น
+
+**pack นี้ยังไม่เคยมีใครเล่นจริง** ที่ตรวจไปทั้งหมดเป็นการเปิด server เช็คว่าไฟล์ config อ่านได้
+สูตรคราฟต์ลงทะเบียนได้ เควสโหลดได้ — **ไม่ได้แปลว่ามันสนุกหรือสมดุล** ตัวเลขดาเมจ ความยาก
+อัตราการเกิดมอนสเตอร์ ทั้งหมดเป็นค่าที่ตั้งจากเอกสารออกแบบ ยังไม่มีใครวัดในเกมจริง
+
+**สร้างโลกทดสอบก่อน** ระบบสร้างโลกใช้ Biomes O' Plenty ซึ่งยังไม่ได้ทดสอบว่าหาน้ำมันหรือหาที่ตั้งเมืองง่ายแค่ไหน
+ถ้าเจอปัญหาแล้วต้องแก้ อาจต้องเริ่มโลกใหม่
+
+**เจอบั๊กบอกได้เลย** โดยเฉพาะถ้าเปิดไม่ติด ส่งไฟล์ `.minecraft/logs/latest.log` มาให้ดู
+
+---
+
+## มีอะไรอยู่ในนี้บ้าง
+
+`MODLIST.md` ที่มากับไฟล์ ลงชื่อมอดทั้ง 114 ตัวพร้อมลิงก์ไปหน้าของคนทำ
+
+คร่าว ๆ คือ Create + เครื่องจักรอุตสาหกรรม, ปืนจาก TaCZ ที่ต้องผลิตกระสุนเอง, มอนสเตอร์ที่โหดขึ้นและมาเป็นกลุ่ม,
+เมือง NPC จาก MineColonies, มังกรจาก Ice & Fire, สัตว์ป่าจริงจัง, และเควส 48 ข้อ 12 บท
+
+---
+
+## ติดตั้งไม่ผ่าน?
+
+**Prism บอกว่าไม่มี Java** — กดปุ่มที่มันแนะนำ มันจัดการให้เอง
+
+**pre-launch command ไม่ทำงาน** — เช็คว่า `packwiz-installer-bootstrap.jar` อยู่ใน `.minecraft`
+ที่เดียวกับ `pack.toml` ไม่ใช่โฟลเดอร์นอก
+
+**โหลดมอดไม่ครบ 4 ตัว** — อันนั้นคือสี่ตัวข้างบน ต้องโหลดเอง
+
+**เกมค้างตอนโหลด** — ให้ RAM 8 GB ใน Prism → Edit → Settings → Memory
+
+**เปิดแล้วเด้ง** — ส่ง `.minecraft/logs/latest.log` มา อย่าเดาเอง ในนั้นบอกไว้หมด

--- a/scripts/build/build-friend-pack.mjs
+++ b/scripts/build/build-friend-pack.mjs
@@ -138,6 +138,19 @@ writeFileSync(join(STAGE, 'README.txt'), [
   '',
   ...MANUAL.map(([n, slug]) => `    ${n}\n      https://www.curseforge.com/minecraft/mc-mods/${slug}`),
   '',
+  'RUNNING A SERVER FROM THIS SAME FILE',
+  '',
+  '  No other download. Install Forge ' + FORGE + ' as a dedicated server, unzip',
+  '  this over it, put the bootstrap jar beside pack.toml, and run once:',
+  '',
+  '    java -jar packwiz-installer-bootstrap.jar -g -s server pack.toml',
+  '',
+  '  -s server skips the client-only mods (graphics, sound, HUD). Then start the',
+  '  server normally.',
+  '',
+  '  Everyone must be on the same version. Compare pack-version.txt; if the',
+  '  numbers differ, that IS the problem - do not debug anything else first.',
+  '',
   'UPDATING',
   '',
   '  Replace this archive\'s contents and launch. The pre-launch step reconciles',
@@ -194,6 +207,17 @@ if (problems.length) {
   for (const p of problems) console.error(`  ${p}`)
   process.exit(1)
 }
+
+// The readme that sits BESIDE the archive, for whoever is handed the link. The
+// one inside the zip is for someone who already downloaded it; this one is for
+// someone looking at a folder and deciding what to click.
+const driveReadme = join(ROOT, 'docs', 'friend-download-readme.md')
+if (!existsSync(driveReadme)) {
+  console.error('docs/friend-download-readme.md is missing — the upload has no instructions')
+  process.exit(1)
+}
+copyFileSync(driveReadme, join(ROOT, 'build', 'README.md'))
+console.log('wrote build/README.md — upload this next to the archive')
 
 const size = statSync(outAbs).size
 console.log(`\narchive verified — ${listing.length} entries, ${jars.length} jars, no backslash entries`)


### PR DESCRIPTION
## Summary

The developer is about to upload the build artifacts to Google Drive for friends. **Four of the five
must not go there**, and nothing in the repo says so at the point where that decision gets made.

| Artifact | Third-party jars | May be uploaded |
|---|---|---|
| `-friend.zip` | **0** | **yes** |
| `-instance.zip` | 114 | no |
| `-server.zip` | 94 | no |
| `-alpha.zip` (CurseForge) | 72 | no |
| `-curseforge-local.zip` | 76 | **never** |

ADR 0005 made the friend pack so the pack could be shared without redistributing anyone's jars. It
did not say what happens to the **other four**, and the obvious action — put them all in a folder —
undoes it.

## The server pack needs no replacement

`-server.zip` bundles 94 jars, so it cannot be shared either. **It does not need a thin twin**: the
friend pack carries the full manifest with each mod's `side`, and `packwiz-installer` takes
`-s server`. One archive serves both, and its `README.txt` should say so — right now it only
describes the Prism client path.

## What to write

**`docs/friend-download-readme.md`**, copied to `build/README.md` by the friend-pack build so it sits
beside the archive ready to upload. Written **for the friends**, not for the developer:

- one file to download, and why it is only 127 KB
- install, in the order someone actually does it
- the four mods they fetch by hand, with links
- how to run a server from the same archive
- what is not verified, stated plainly rather than buried

## Acceptance criteria

- [ ] `docs/friend-download-readme.md` exists, written for a player
- [ ] `build-friend-pack.mjs` emits it as `build/README.md`
- [ ] The archive's own `README.txt` covers the server path
- [ ] A short note in `INSTALL.md` and `docs/distribution-licenses.md` saying which artifacts may be
      uploaded and which may not
- [ ] `verify` green

## Out of scope

**A thin server pack.** The friend pack already is one.

**Hosting anything.** Uploading is the developer's action on their own Drive.

---

## สรุปภาษาไทย

### สรุป

ผู้พัฒนากำลังจะอัปโหลด artifact ขึ้น Google Drive ให้เพื่อน **สี่ในห้าไฟล์ขึ้นไปไม่ได้**
และไม่มีอะไรใน repo บอกเรื่องนี้ตรงจุดที่ต้องตัดสินใจ

| Artifact | jar ของบุคคลที่สาม | อัปโหลดได้ไหม |
|---|---|---|
| `-friend.zip` | **0** | **ได้** |
| `-instance.zip` | 114 | ไม่ได้ |
| `-server.zip` | 94 | ไม่ได้ |
| `-alpha.zip` (CurseForge) | 72 | ไม่ได้ |
| `-curseforge-local.zip` | 76 | **ห้ามเด็ดขาด** |

ADR 0005 สร้าง friend pack ขึ้นมาเพื่อให้แจก pack ได้โดยไม่ต้องแจก jar ของใคร
แต่มันไม่ได้บอกว่าอีก **สี่ไฟล์** ต้องทำยังไง และการกระทำที่นึกออกทันที — เอาไปใส่โฟลเดอร์เดียวกัน —
ทำให้สิ่งที่ ADR 0005 ทำไว้เป็นโมฆะ

### server pack ไม่ต้องมีตัวแทน

`-server.zip` ฝัง jar 94 ตัว จึงแจกไม่ได้เหมือนกัน **แต่มันไม่ต้องมีเวอร์ชันบางคู่กัน**:
friend pack พา manifest เต็มพร้อม `side` ของแต่ละมอดไปด้วยอยู่แล้ว และ `packwiz-installer`
รับ `-s server` ได้ ไฟล์เดียวใช้ได้ทั้งสองแบบ และ `README.txt` ข้างในควรบอกเรื่องนี้ —
ตอนนี้มันอธิบายแต่ทาง Prism ฝั่ง client

### จะเขียนอะไร

**`docs/friend-download-readme.md`** แล้วให้ build ของ friend pack copy ไปเป็น `build/README.md`
เพื่อให้มันวางอยู่ข้างไฟล์พร้อมอัปโหลด เขียน**ให้เพื่อนอ่าน** ไม่ใช่ให้ผู้พัฒนาอ่าน:

- โหลดไฟล์เดียว และทำไมมันแค่ 127 KB
- ขั้นตอนติดตั้งเรียงตามลำดับที่คนทำจริง
- มอดสี่ตัวที่ต้องโหลดเองพร้อมลิงก์
- วิธีเปิด server จากไฟล์เดียวกัน
- สิ่งที่ยังไม่ได้ตรวจสอบ พูดตรง ๆ ไม่ซุก

### เกณฑ์การปิดงาน

- [ ] มี `docs/friend-download-readme.md` เขียนสำหรับผู้เล่น
- [ ] `build-friend-pack.mjs` สร้างมันออกมาเป็น `build/README.md`
- [ ] `README.txt` ในตัว archive ครอบคลุมทาง server ด้วย
- [ ] มีหมายเหตุสั้น ๆ ใน `INSTALL.md` และ `docs/distribution-licenses.md` ว่า artifact ไหนอัปโหลดได้ ไหนไม่ได้
- [ ] `verify` เขียว

### นอกขอบเขต

**server pack แบบบาง** friend pack เป็นตัวนั้นอยู่แล้ว

**การโฮสต์อะไรก็ตาม** การอัปโหลดเป็นการกระทำของผู้พัฒนาบน Drive ของตัวเอง
