### PR TITLE
chore(release): bump the pack to 0.2.0-alpha so test builds are distinguishable (#101)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,23 @@ no entry, no tag, and is never handed to a friend as if it were a release.
 
 ## Unreleased
 
+> **The pack version is now `0.2.0-alpha`, and this is still not a release.**
+>
+> The number moved because it had stopped identifying a build. `build/README.md` tells every friend
+> to compare `pack-version.txt` and treat a mismatch as the problem — advice that is useless when
+> two materially different archives both say `0.1.0-alpha`. Since the last one was handed out the
+> pack gained In Control on clients (#88), Oculus (#91), spark (#94), four performance candidates
+> (#97), and went 114 → 120 mods. A bug report against "0.1.0-alpha" would name an ambiguous
+> artifact.
+>
+> `0.2.0-alpha` is the next rung on *Distribution Spec §8*'s own ladder
+> (`0.1.0-alpha → 0.2.0-alpha → 0.5.0-beta → 0.9.0-rc1 → 1.0.0`), and six new mods plus a
+> gameplay-affecting fix is a MINOR step rather than a PATCH.
+>
+> **No tag, no GitHub Release, no release entry** — the rule below still holds, and §16 has never
+> run. The one release this repository has is `militarybackpack-refmap-shim-v1.0.1`, which is a
+> 1 KB shim jar on its own version line and **not** the pack (#101).
+
 ### Added
 
 - **114 mods**, pinned to exact versions with hashes. Create is `6.0.8` — forced by the addon

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,15 +1,31 @@
 <!-- lang:en -->
 # Installing Industrial Civilization Survival
 
-**What you get:** `Industrial Civilization Survival 0.1.0-alpha` — Minecraft **1.20.1**,
-Forge **47.4.23**, **93 mods**.
+> ## ⚠ This is the **internal** install guide
+>
+> **If you are giving the pack to someone, they need
+> [`docs/friend-download-readme.md`](docs/friend-download-readme.md) instead** — shipped beside the
+> friend archive as `build/README.md`. It is written for them, in Thai, and it points at the one
+> artifact that may leave this machine.
+>
+> **The self-contained `-instance.zip` described below must not be handed to anyone.** It bundles
+> every third-party jar, and at least two authors permit modpack inclusion only if their jar is not
+> rehosted — **ADR 0005** demoted it to an internal test artifact for exactly that reason, and
+> `docs/distribution-licenses.md` carries the per-mod table. Nothing here overrides that.
 
-Two files are built. **Use the first one.**
+**What you get:** `Industrial Civilization Survival 0.2.0-alpha` — Minecraft **1.20.1**,
+Forge **47.4.23**, **120 mods**.
 
-| File | What it is |
-|---|---|
-| `…-0.1.0-alpha-instance.zip` (388 MB) | **Self-contained.** Every mod is inside it. Import and play — nothing is downloaded, nothing is fetched by hand |
-| `…-0.1.0-alpha.zip` (130 MB) | CurseForge format. The launcher resolves most mods itself; four must be downloaded manually |
+Five artifacts are built; `build/SHA256SUMS.txt` lists the four that are checksummed and their exact
+sizes. Sizes are deliberately not repeated here — they went stale twice.
+
+| File | What it is | May leave this machine |
+|---|---|---|
+| `…-0.2.0-alpha-friend.zip` | manifest plus our own layer, **zero third-party jars** | **yes** — this is the one |
+| `…-0.2.0-alpha-instance.zip` | **Self-contained.** Every mod is inside it. Import and play — nothing is downloaded | no |
+| `…-0.2.0-alpha.zip` | CurseForge format. The launcher resolves most mods itself; four must be downloaded manually | no |
+| `…-0.2.0-alpha-server.zip` | dedicated server | no |
+| `…-0.2.0-alpha-curseforge-local.zip` | CurseForge App import, bundles the 4 API-blocked mods | **never** |
 
 **The official Minecraft launcher cannot import a modpack.** You need Prism or the CurseForge App.
 This is not a limitation of this pack; the official launcher has no modpack support at all.
@@ -19,7 +35,7 @@ This is not a limitation of this pack; the official launcher has no modpack supp
 ## Before you start
 
 - **Java 17.** Forge 47.x for 1.20.1 requires it. Both launchers below can install it for you.
-- **8 GB of RAM allocated to the game**, 6 GB minimum. 93 mods with Create contraptions,
+- **8 GB of RAM allocated to the game**, 6 GB minimum. 120 mods with Create contraptions,
   MineColonies pathfinding and Born in Chaos is not a light pack.
 - **~2 GB of disk** for the instance.
 
@@ -31,7 +47,7 @@ This is not a limitation of this pack; the official launcher has no modpack supp
 ## Option A — Prism Launcher, self-contained *(recommended — one step)*
 
 1. **Add Instance** → **Import from zip**
-2. Select **`Industrial-Civilization-Survival-0.1.0-alpha-instance.zip`**
+2. Select **`Industrial-Civilization-Survival-0.2.0-alpha-instance.zip`**
 3. **Launch.**
 
 That is the whole procedure. Memory is preset to 4–8 GB and Forge 47.4.23 is pinned in the file.
@@ -51,7 +67,7 @@ To give the pack to someone, send the friend pack.
 
 
 1. **Minecraft** → **Create Custom Profile** → **Import**
-2. Select `Industrial-Civilization-Survival-0.1.0-alpha.zip` *(the 130 MB one)*
+2. Select `Industrial-Civilization-Survival-0.2.0-alpha.zip`
 3. Wait for it to download the mods, then **Play**.
 
 Use this if you want the CurseForge App to manage the instance. It resolves the four
@@ -92,7 +108,7 @@ options or keybinds. The same four mods above still need manual download.
 
 ## First launch
 
-Expect **3–6 minutes** on first launch. Forge is loading 93 mods, and Create, MineColonies and
+Expect **3–6 minutes** on first launch. Forge is loading 120 mods, and Create, MineColonies and
 KubeJS all build registries and recipes on startup.
 
 **If it crashes**, the useful file is `logs/latest.log` in the instance folder — the last few
@@ -102,7 +118,7 @@ hundred lines name the mod. `crash-reports/` has the same information formatted 
 
 ## What is in the pack, and what is not
 
-This is `0.1.0-alpha`.
+This is `0.2.0-alpha`.
 
 - ✅ **107 mods** at exact, verified versions; Create pinned to `6.0.8`. **`MODLIST.md`, at the top
   of this download, lists every one of them with a link to where it came from.**
@@ -130,15 +146,28 @@ may and may not redistribute, and `CHANGELOG.md` for what changed.
 <!-- lang:th -->
 # วิธีติดตั้ง Industrial Civilization Survival
 
-**สิ่งที่คุณได้:** `Industrial Civilization Survival 0.1.0-alpha` — Minecraft **1.20.1**,
-Forge **47.4.23**, **93 mods**
+**สิ่งที่คุณได้:** `Industrial Civilization Survival 0.2.0-alpha` — Minecraft **1.20.1**,
+Forge **47.4.23**, **120 mods**
 
-มีไฟล์ที่ build ออกมาสองตัว **ใช้ตัวแรก**
+> ## ⚠ นี่คือคู่มือติดตั้งสำหรับ**ภายใน**
+>
+> **ถ้าจะส่ง pack ให้คนอื่น เขาต้องใช้**
+> [`docs/friend-download-readme.md`](docs/friend-download-readme.md) แทน — ไฟล์นั้นถูกส่งไป
+> คู่กับ friend archive ในชื่อ `build/README.md` มันเขียนสำหรับเขา
+> และชี้ไปที่ artifact ตัวเดียวที่ออกจากเครื่องนี้ได้
+>
+> **`-instance.zip` ที่อธิบายข้างล่างห้ามส่งให้ใคร** มันบรรจุ jar ของคนอื่น
+> ไว้ทั้งหมด และมีผู้เขียนอย่างน้อยสองคนที่อนุญาตให้ใส่ modpack ได้
+> เฉพาะถ้าไม่เอา jar ของเขาไปแจกซ้ำ — **ADR 0005** ลดสถานะมันเป็น artifact
+> สำหรับทดสอบภายในด้วยเหตุผลนั้น และ `docs/distribution-licenses.md` มีตารางรายมอด
+
+artifact ที่ build ออกมามีห้าตัว `build/SHA256SUMS.txt` ระบุสี่ตัวที่มี checksum พร้อมขนาดจริง
+ขนาดไม่ถูกเขียนซ้ำที่นี่โดยตั้งใจ เพราะมันค้างเก่ามาแล้วสองครั้ง
 
 | ไฟล์ | คืออะไร |
 |---|---|
-| `…-0.1.0-alpha-instance.zip` (388 MB) | **มีทุกอย่างในตัว** mod ทุกตัวอยู่ข้างใน import แล้วเล่นได้เลย — ไม่โหลดอะไร ไม่ต้องไปหยิบอะไรเอง |
-| `…-0.1.0-alpha.zip` (130 MB) | รูปแบบ CurseForge launcher ไป resolve mod ส่วนใหญ่เอง แต่มีสี่ตัวที่ต้องโหลดด้วยมือ |
+| `…-0.2.0-alpha-instance.zip` | **มีทุกอย่างในตัว** mod ทุกตัวอยู่ข้างใน import แล้วเล่นได้เลย — **ห้ามแจกไฟล์นี้ ดู ADR 0005** |
+| `…-0.2.0-alpha.zip` | รูปแบบ CurseForge launcher ไป resolve mod ส่วนใหญ่เอง แต่มีสี่ตัวที่ต้องโหลดด้วยมือ |
 
 **Launcher ทางการของ Minecraft import modpack ไม่ได้** ต้องใช้ Prism หรือ CurseForge App
 นี่ไม่ใช่ข้อจำกัดของ pack นี้ แต่ launcher ทางการไม่มีฟีเจอร์ modpack เลย
@@ -157,7 +186,7 @@ Forge **47.4.23**, **93 mods**
 ## ทางเลือก A — Prism Launcher แบบมีทุกอย่างในตัว *(แนะนำ — ขั้นตอนเดียว)*
 
 1. **Add Instance** → **Import from zip**
-2. เลือก **`Industrial-Civilization-Survival-0.1.0-alpha-instance.zip`**
+2. เลือก **`Industrial-Civilization-Survival-0.2.0-alpha-instance.zip`**
 3. **Launch**
 
 จบแค่นั้น แรมถูกตั้งไว้ให้แล้ว 4–8 GB และ Forge 47.4.23 ถูก pin อยู่ในไฟล์
@@ -169,7 +198,7 @@ Forge **47.4.23**, **93 mods**
 ## ทางเลือก B — CurseForge App
 
 1. **Minecraft** → **Create Custom Profile** → **Import**
-2. เลือก `Industrial-Civilization-Survival-0.1.0-alpha.zip` *(ตัว 130 MB)*
+2. เลือก `Industrial-Civilization-Survival-0.2.0-alpha.zip`
 3. รอโหลด mod เสร็จ แล้วกด **Play**
 
 ใช้ทางนี้ถ้าอยากให้ CurseForge App เป็นคนจัดการ instance มันจัดการ mod สี่ตัวที่ถูกจำกัดด้วย API
@@ -220,7 +249,7 @@ java -jar packwiz-installer-bootstrap.jar http://localhost:8080/pack.toml
 
 ## ใน pack มีอะไร และยังไม่มีอะไร
 
-นี่คือ `0.1.0-alpha`
+นี่คือ `0.2.0-alpha`
 
 - ✅ **107 mod** ที่เวอร์ชันเป๊ะและตรวจสอบแล้ว Create pin ที่ `6.0.8`
   **`MODLIST.md` ที่อยู่บนสุดของไฟล์ที่โหลดมา ลงชื่อทุกตัวพร้อมลิงก์ไปยังที่มาของมัน**

--- a/docs/MODLIST.md
+++ b/docs/MODLIST.md
@@ -6,7 +6,7 @@
 
 # What is in this pack · ในแพ็กนี้มีอะไรบ้าง
 
-**Industrial Civilization Survival 0.1.0-alpha** — **120 mods** on Minecraft `1.20.1`,
+**Industrial Civilization Survival 0.2.0-alpha** — **120 mods** on Minecraft `1.20.1`,
 Forge `47.4.23`.
 
 Every mod here is somebody else's work. This file exists so you can see whose, and go and find

--- a/docs/friend-download-readme.md
+++ b/docs/friend-download-readme.md
@@ -2,7 +2,7 @@
 
 Minecraft **1.20.1** · Forge **47.4.23** · มอด **120** ตัว
 
-โหลดไฟล์เดียวพอ: **`Industrial-Civilization-Survival-0.1.0-alpha-friend.zip`** (127 KB)
+โหลดไฟล์เดียวพอ: **`Industrial-Civilization-Survival-0.2.0-alpha-friend.zip`** (132 KB)
 
 ---
 

--- a/pack.toml
+++ b/pack.toml
@@ -1,6 +1,6 @@
 name = "Industrial Civilization Survival"
 author = "xenodeve"
-version = "0.1.0-alpha"
+version = "0.2.0-alpha"
 pack-format = "packwiz:1.1.0"
 
 [index]


### PR DESCRIPTION
Closes #101.

## Verified by reading the archives

| Check | Result |
|---|---|
| `pack-version.txt` in friend / instance / server | all `version=0.2.0-alpha` |
| CurseForge `manifest.json` version | `0.2.0-alpha` |
| `sha256sum -c SHA256SUMS.txt` | 4/4 **OK** |
| `0.1.0` files left in `build/` | **none** |
| `verify` | green at 120 mods |

## A hazard found while editing INSTALL.md, fixed here

It read as the general distribution guide — *"Two files are built. **Use the first one.**"* — and
the first one was the self-contained `-instance.zip`, which **ADR 0005 demoted to an internal test
artifact because it rehosts every third-party jar**. Anyone following it would have handed out the
one artifact `docs/distribution-licenses.md` says must not leave this machine.

INSTALL.md now opens, in both languages, by naming itself the **internal** guide and pointing at
`docs/friend-download-readme.md`, with a five-row table stating for each artifact whether it may
leave the machine.

Also corrected there: **93 mods** (actual 120), *"Two files are built"* (actual five), and the
388 MB / 130 MB sizes. **Sizes are now deliberately not repeated** — they went stale twice, and
`SHA256SUMS.txt` already carries the real ones.

*(The commit message lists `index.toml` among the changed files; only `pack.toml` moved — the
metafile hashes were untouched, so the index needed no rewrite.)*

---

## Summary

Move the pack version `0.1.0-alpha` → **`0.2.0-alpha`** so the build now going to friends is
distinguishable from the one they already have.

**No tag, no GitHub Release, no CHANGELOG release entry.** Those are blocked by this repo's own
rules and stay blocked.

## Correcting the premise: `v1.0.1` was not the pack

There is exactly one release in this repository:

```
Tactical Backpacks refMap shim v1.0.1
tag: militarybackpack-refmap-shim-v1.0.1     Pre-release     2026-08-27
asset: militarybackpack-refmap-shim-1.0.1-pre-release-hotfix.jar   1067 bytes
```

That is the **1 KB shim jar** built by `scripts/build/build-militarybackpack-refmap-shim.py` — a
single JSON mapping in a wrapper. The tag was deliberately scoped rather than left as bare `v1.0.1`
so it could not be read as the pack's version.

**The pack has never been released and has never had a `1.0.0`.** `pack.toml` reads
`0.1.0-alpha`, and `CHANGELOG.md` still has an open `## Unreleased` section.

So `1.0.2` would take a number from the shim's line, and claim a maturity the pack does not have.

## `0.2.0-alpha` is the next rung on the spec's own ladder

*Distribution Spec §8* lists it literally:

```text
0.1.0-alpha
0.2.0-alpha      <- here
0.5.0-beta
0.9.0-rc1
1.0.0
```

and defines the step: `0.3.0` means a feature/progression update, `0.3.1` a compatibility/bugfix.
Six new mods and a gameplay-affecting fix is a MINOR step, not a PATCH.

## Why bump at all, when nothing is being released

Because a version number is a **build identifier** before it is a release name, and right now it
fails at that job.

`build/README.md` tells every friend:

> **ทุกคนต้องใช้เวอร์ชันเดียวกัน** เทียบไฟล์ `pack-version.txt` ได้ ถ้าเลขไม่ตรงกันคือปัญหาอยู่ตรงนั้น

That instruction is useless if two materially different builds both say `0.1.0-alpha`. And they are
materially different — since the last build handed out, the pack gained:

| Change | Why it matters to a tester |
|---|---|
| In Control reaches clients (#88) | the spawn director that was silently absent; early game should be measurably lighter |
| Oculus (#91) | shaders became possible |
| spark (#94) | profiler |
| BadOptimizations, AllTheLeaks, Dynamic FPS, Legendary Block Entities (#97) | four untested performance mods |
| 114 → 120 mods | |

A friend reporting a bug against "0.1.0-alpha" would be reporting against an ambiguous artifact.

## What stays blocked, and is not touched here

**No git tag and no GitHub Release.** `CHANGELOG.md` states its own rule:

> *The first release entry below this one will be `v0.1.0-alpha`, and it cannot be cut until the
> twelve-test release gate in Distribution Spec §16 passes — which needs a client.*

§16 has never run. This issue does not cut a release entry, does not tag, and does not publish.

**Nothing is published anywhere.** The redistribution question (#53) is answered for the friend
path by ADR 0005 and open for public release. Unchanged.

So the state after this issue is: **a versioned test build, not a release.** `## Unreleased` stays
open and gains a note saying why the number moved.

## Change inventory

| Path | What changes | How it is verified |
|---|---|---|
| `pack.toml` | `version = "0.2.0-alpha"` | `verify` pack-metadata check |
| `index.toml` | index hash follows | `packwiz refresh` |
| `CHANGELOG.md` | a note under `## Unreleased` explaining the bump; **no release entry** | read |
| `docs/friend-download-readme.md` | the filename it names, and its stale size | read |
| `INSTALL.md` | version references and stale artifact sizes, both language mirrors | read |
| `docs/MODLIST.md` | regenerated, carries the version string | `generate-modlist.mjs` |
| All five artifacts + `SHA256SUMS.txt` | rebuilt so filenames and stamps agree | `sha256sum -c`; read `pack-version.txt` out of the archive |

`DONE.md`, the Distribution Spec and `docs/agents/workflow.md` are **not** changed: their
`0.1.0-alpha` strings are either history or format examples, not the current version.

## Acceptance criteria

- [ ] `pack.toml` reads `0.2.0-alpha`
- [ ] `node scripts/validate/verify.mjs` green
- [ ] Every artifact filename carries `0.2.0-alpha`, and `pack-version.txt` inside each says the same — checked by reading the archives
- [ ] `SHA256SUMS.txt` regenerated and `sha256sum -c` passes
- [ ] `CHANGELOG.md` has **no** new release entry, and `## Unreleased` explains the bump
- [ ] **No git tag and no GitHub Release created**
- [ ] `build/README.md` names the new filename

## Out of scope

**Cutting `v0.1.0-alpha` or any release.** Blocked on the §16 gate, which needs a client.

**Publishing anywhere.** Blocked on #53.

---

## สรุปภาษาไทย

### สรุป

เปลี่ยนเวอร์ชันแพ็คจาก `0.1.0-alpha` เป็น **`0.2.0-alpha`** เพื่อให้ build ที่กำลังจะส่งให้เพื่อน
แยกออกจากตัวที่เพื่อนมีอยู่แล้วได้

**ไม่มี tag ไม่มี GitHub Release ไม่มี entry release ใน CHANGELOG** สามอย่างนั้นถูกกฎของ repo
เองบล็อกไว้ และยังบล็อกต่อ

### แก้ความเข้าใจก่อน: `v1.0.1` ไม่ใช่ของแพ็ค

ใน repository นี้มี release อยู่อันเดียว:

```
Tactical Backpacks refMap shim v1.0.1
tag: militarybackpack-refmap-shim-v1.0.1     Pre-release     2026-08-27
asset: militarybackpack-refmap-shim-1.0.1-pre-release-hotfix.jar   1067 bytes
```

นั่นคือ **jar ขนาด 1 KB** ที่ `scripts/build/build-militarybackpack-refmap-shim.py` สร้าง —
มี JSON mapping อันเดียวในกล่อง tag ถูกตั้งชื่อให้แคบโดยตั้งใจ แทนที่จะเป็น `v1.0.1` เปล่า ๆ
เพื่อไม่ให้ถูกอ่านว่าเป็นเวอร์ชันของแพ็ค

**แพ็คยังไม่เคยถูก release และไม่เคยมี `1.0.0`** `pack.toml` เขียนว่า `0.1.0-alpha`
และ `CHANGELOG.md` ยังมีหัวข้อ `## Unreleased` เปิดค้างอยู่

`1.0.2` จึงเป็นการหยิบเลขจากสายของ shim มาใช้ และอ้างความสุกงอมที่แพ็คยังไม่มี

### `0.2.0-alpha` คือขั้นถัดไปบนบันไดของ spec เอง

*Distribution Spec §8* เขียนไว้ตรง ๆ:

```text
0.1.0-alpha
0.2.0-alpha      <- ตรงนี้
0.5.0-beta
0.9.0-rc1
1.0.0
```

และนิยามขั้นไว้ว่า `0.3.0` คือ feature/progression update ส่วน `0.3.1` คือ compatibility/bugfix
มอดใหม่หกตัวกับการแก้ที่กระทบ gameplay เป็นขั้น MINOR ไม่ใช่ PATCH

### ทำไมต้องขยับเลข ทั้งที่ยังไม่ได้ release อะไร

เพราะเลขเวอร์ชันเป็น**ตัวระบุ build** ก่อนจะเป็นชื่อ release และตอนนี้มันทำหน้าที่นั้นไม่ได้

`build/README.md` บอกเพื่อนทุกคนไว้ว่า:

> **ทุกคนต้องใช้เวอร์ชันเดียวกัน** เทียบไฟล์ `pack-version.txt` ได้ ถ้าเลขไม่ตรงกันคือปัญหาอยู่ตรงนั้น

คำสั่งนั้นไร้ประโยชน์ทันทีถ้า build สองตัวที่ต่างกันจริงเขียนว่า `0.1.0-alpha` เหมือนกัน
และมันต่างกันจริง ตั้งแต่ build ที่แจกไปครั้งก่อน แพ็คได้เพิ่ม:

| การเปลี่ยนแปลง | ทำไมมันสำคัญกับคนทดสอบ |
|---|---|
| In Control ไปถึง client (#88) | spawn director ที่เคยหายไปเงียบ ๆ ช่วงต้นเกมควรเบาลงอย่างวัดได้ |
| Oculus (#91) | ใส่ shader ได้แล้ว |
| spark (#94) | profiler |
| BadOptimizations, AllTheLeaks, Dynamic FPS, Legendary Block Entities (#97) | มอด performance สี่ตัวที่ยังไม่ได้ทดสอบ |
| 114 → 120 มอด | |

เพื่อนที่รายงานบั๊กโดยอ้างว่า "0.1.0-alpha" จะเป็นการรายงานต่อ artifact ที่กำกวม

### สิ่งที่ยังถูกบล็อก และไม่ถูกแตะในงานนี้

**ไม่มี git tag และไม่มี GitHub Release** `CHANGELOG.md` เขียนกฎของตัวเองไว้ว่า:

> *entry release อันแรกที่อยู่ใต้บรรทัดนี้จะเป็น `v0.1.0-alpha` และตัดไม่ได้จนกว่า release gate
> สิบสองข้อใน Distribution Spec §16 จะผ่าน ซึ่งต้องใช้ client*

§16 ยังไม่เคยรัน issue นี้จึงไม่ตัด entry release ไม่ tag และไม่เผยแพร่

**ไม่มีการเผยแพร่ที่ไหนทั้งสิ้น** คำถามเรื่องการแจกจ่ายซ้ำ (#53) ตอบแล้วสำหรับเส้นทางเพื่อน
โดย ADR 0005 และยังเปิดอยู่สำหรับการปล่อยสู่สาธารณะ ไม่เปลี่ยน

สถานะหลังงานนี้จึงเป็น: **build ทดสอบที่มีเลขเวอร์ชัน ไม่ใช่ release** `## Unreleased`
ยังเปิดอยู่และได้หมายเหตุอธิบายว่าทำไมเลขถึงขยับ

### รายการจุดที่เปลี่ยน

| Path | เปลี่ยนอะไร | ตรวจยังไง |
|---|---|---|
| `pack.toml` | `version = "0.2.0-alpha"` | pack-metadata check ของ `verify` |
| `index.toml` | hash ตามไป | `packwiz refresh` |
| `CHANGELOG.md` | หมายเหตุใต้ `## Unreleased` อธิบายการขยับ; **ไม่มี entry release** | อ่าน |
| `docs/friend-download-readme.md` | ชื่อไฟล์ที่มันระบุ และขนาดที่ค้างเก่า | อ่าน |
| `INSTALL.md` | การอ้างเวอร์ชันและขนาด artifact ที่ค้างเก่า ทั้งสองภาษา | อ่าน |
| `docs/MODLIST.md` | generate ใหม่ มันมีสตริงเวอร์ชันอยู่ | `generate-modlist.mjs` |
| artifact ทั้งห้า + `SHA256SUMS.txt` | build ใหม่ให้ชื่อไฟล์และ stamp ตรงกัน | `sha256sum -c`; อ่าน `pack-version.txt` ออกมาจากไฟล์ zip |

`DONE.md`, Distribution Spec และ `docs/agents/workflow.md` **ไม่ถูกแก้**: สตริง `0.1.0-alpha`
ในนั้นเป็นประวัติหรือเป็นตัวอย่างรูปแบบ ไม่ใช่เวอร์ชันปัจจุบัน

### เกณฑ์การปิดงาน

- [ ] `pack.toml` อ่านได้ว่า `0.2.0-alpha`
- [ ] `node scripts/validate/verify.mjs` เขียว
- [ ] ชื่อไฟล์ artifact ทุกตัวมี `0.2.0-alpha` และ `pack-version.txt` ข้างในเขียนเหมือนกัน — ตรวจด้วยการอ่านไฟล์ zip
- [ ] `SHA256SUMS.txt` generate ใหม่และ `sha256sum -c` ผ่าน
- [ ] `CHANGELOG.md` **ไม่มี** entry release ใหม่ และ `## Unreleased` อธิบายการขยับ
- [ ] **ไม่สร้าง git tag และไม่สร้าง GitHub Release**
- [ ] `build/README.md` ระบุชื่อไฟล์ใหม่

### นอกขอบเขต

**การตัด `v0.1.0-alpha` หรือ release ใด ๆ** ถูกบล็อกที่ §16 gate ซึ่งต้องใช้ client

**การเผยแพร่ที่ใดก็ตาม** ถูกบล็อกที่ #53
