### PR TITLE
chore(release): pre-release v0.2.0-alpha — the friend pack only (#103)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,61 @@ no entry, no tag, and is never handed to a friend as if it were a release.
 
 ---
 
+## v0.2.0-alpha — pre-release, 2026-08-28
+
+**This is a pre-release for testing, not a release.** The twelve-test gate in *Distribution Spec
+§16* has never run, because it needs a client somebody has actually played on. Treat everything
+below as untested in game.
+
+**One artifact is published: `Industrial-Civilization-Survival-0.2.0-alpha-friend.zip`** — 132 KB,
+a manifest plus our own configs, scripts and quests, with **zero third-party jars**. It installs a
+client, and the same file installs a server with `-s server`.
+
+**The other four artifacts are not published and will not be.** `-instance.zip`, `-server.zip`,
+`-alpha.zip` and `-curseforge-local.zip` each bundle 83–120 jars, and two authors permit modpack
+inclusion only if their jar is not rehosted. `docs/distribution-licenses.md` has the per-artifact
+table; **ADR 0005** is why the friend pack exists at all.
+
+### Fixed
+
+- **Monsters no longer swarm the first days.** The spawn director — the thing that holds elite
+  monsters back until day 20, mid-tier until day 6, and trolls until day 25 — was never installed
+  on anyone's game. It was marked server-only, and singleplayer runs its own server inside the
+  client, so it was missing from the two ways people actually play. Early game should be markedly
+  lighter. Reported from a real playtest.
+- **The game starts.** Sophisticated Tactical Backpacks asks for a file under one name and ships it
+  under another, which killed the client during model loading, every time. A 1 KB shim supplies it
+  under the expected name.
+
+### Added
+
+- **Shaders are possible, and still optional.** Oculus is included — it is Iris, built for Forge.
+  Nothing changes until you pick a shaderpack; none ships. **Do not install OptiFine**: it collides
+  with the renderer this pack uses, and the README says so where a player will see it.
+- **A profiler.** spark ships with the pack, because a profiler you have to install after the
+  problem starts is a profiler you do not have.
+- **Four performance mods, none of them measured yet.** BadOptimizations, AllTheLeaks, Dynamic FPS
+  and Legendary Block Entities. They are installed, not accepted — nobody has a frame-time number
+  for this pack, so nothing here claims they help.
+
+### Changed
+
+- **114 → 120 mods.**
+- **The version number identifies a build again.** Two different archives were both called
+  `0.1.0-alpha`, which made the "compare `pack-version.txt`" instruction in the README useless.
+
+### Known, and unfixed
+
+- **Nobody has played this.** A client reaches the main menu; nothing past that is tested. Damage
+  numbers, difficulty and spawn rates are all design targets.
+- **Do not keep a world you care about.** Worldgen is Biomes O' Plenty, chosen on quality and never
+  tested across seeds. If it has to change, existing worlds go with it.
+- Improved Mobs cannot read Brimm Armors' defence values, so no Brimm armour will ever be worn by a
+  mob.
+- Three of the four performance mods are client-only and have never been run at all.
+
+---
+
 ## Unreleased
 
 > **The pack version is now `0.2.0-alpha`, and this is still not a release.**

--- a/docs/agents/blocked-work.md
+++ b/docs/agents/blocked-work.md
@@ -78,10 +78,22 @@ than anything else in this repo.**
 
 ---
 
-## Blocked by: a licensing question nobody has answered
+## Was blocked by a licensing question — **answered by ADR 0005** (#53 closed)
 
-**Do not ship, publish, or hand this pack to anyone until this is resolved.** `INSTALL.md` and
-`CHANGELOG.md` both say so.
+> **Update, #103.** This section used to open *"Do not ship, publish, or hand this pack to anyone
+> until this is resolved."* **That is no longer the state.** #53 is closed and ADR 0005 is the
+> answer: the pack stopped bundling jars, and `-friend.zip` — a manifest plus our own layer, **zero
+> third-party jars** — may be shared. It is published as a pre-release and it installs both a client
+> and a server.
+>
+> **What is still forbidden, and always will be under this delivery model:** publishing any artifact
+> that bundles jars — `-instance.zip`, `-server.zip`, `-alpha.zip`, and above all
+> `-curseforge-local.zip`, which carries the four mods whose authors switched third-party
+> downloading off. `docs/distribution-licenses.md` holds the per-artifact table and it is the
+> authority.
+>
+> The analysis below is kept because it is *why* the answer is what it is — not because the ban is
+> still blanket.
 
 ### The shape of the problem — it is not the licence list
 
@@ -270,10 +282,20 @@ artifact สามตัว build ซ้ำได้และ checksum สะอ
 
 ---
 
-## ติดเพราะ: คำถามเรื่องสัญญาอนุญาตที่ยังไม่มีใครตอบ
+## เคยติดเพราะคำถามเรื่องสัญญาอนุญาต — **ADR 0005 ตอบแล้ว** (#53 ปิด)
 
-**อย่าส่ง อย่าเผยแพร่ อย่ายื่น pack นี้ให้ใครจนกว่าเรื่องนี้จะจบ** `INSTALL.md` กับ `CHANGELOG.md`
-เขียนไว้ทั้งคู่
+> **อัปเดต, #103** หัวข้อนี้เคยเปิดด้วยประโยคว่า *"อย่าส่ง อย่าเผยแพร่ อย่ายื่น pack นี้ให้ใคร"*
+> **นั่นไม่ใช่สถานะปัจจุบันแล้ว** #53 ปิดไปแล้ว และ ADR 0005 คือคำตอบ:
+> pack เลิกบรรจุ jar แล้ว และ `-friend.zip` — manifest บวกชั้นงานของเราเอง
+> **ไม่มี jar ของคนอื่นเลย** — แจกได้ มันถูกเผยแพร่เป็น pre-release และติดตั้งได้ทั้ง client และ server
+>
+> **สิ่งที่ยังห้ามอยู่ และจะห้ามตลอดไปภายใต้รูปแบบการส่งมอบนี้:** การเผยแพร่ artifact ใด
+> ก็ตามที่บรรจุ jar — `-instance.zip`, `-server.zip`, `-alpha.zip` และเหนือสิ่งอื่นใด
+> `-curseforge-local.zip` ซึ่งพกมอดสี่ตัวที่ผู้เขียนปิดการโหลดโดยบุคคลที่สามไว้
+> `docs/distribution-licenses.md` มีตารางราย artifact และมันคือผู้มีอำนาจ
+>
+> การวิเคราะห์ข้างล่างเก็บไว้เพราะมันคือ *เหตุผล* ที่คำตอบเป็นแบบนี้ ไม่ใช่เพราะคำสั่งห้าม
+> ยังเป็นการห้ามทั้งหมด
 
 ### รูปร่างของปัญหา — มันไม่ใช่รายการสัญญาอนุญาต
 


### PR DESCRIPTION
Closes #103.

## Summary

Publish `v0.2.0-alpha` as a **GitHub pre-release carrying `-friend.zip` only**, and record why the
other four artifacts cannot go with it.

## Answering the request directly: one of five, not five

The request was to release every artifact. The repo's own licence audit — all 120 mods read —
already decided this, and the table is in `docs/distribution-licenses.md`:

| Artifact | Third-party jars inside | May be shared |
|---|---:|---|
| `-friend.zip` | **0** | **yes** — and it serves client *and* server via `-s server` |
| `-instance.zip` | 120 | no |
| `-server.zip` | 96 | no |
| `-alpha.zip` (CurseForge format) | ~83 | no |
| `-curseforge-local.zip` | ~83 incl. the 4 API-blocked mods | **never** |

That file states the rule in one line:

> **Only `-friend.zip` may be uploaded anywhere.** … it is easy to undo by accident — putting all
> five artifacts in one shared folder republishes 113 jars.

**This is not a licence-list problem, it is a delivery-model problem.** Two authors are quoted
verbatim in the audit:

> *Serene Seasons* — "You may include this mod in a Modrinth-hosted modpack **as long as you do not
> rehost the mod**…"

> *Entity Culling* — "Feel free to use this mod in your … modpacks… **Do not redistribute the JAR
> files anywhere else!**"

Both permit the modpack. Both forbid rehosting the jar. Four of our five artifacts rehost jars;
`-friend.zip` does not — it ships a manifest and our own layer, and `packwiz-installer` fetches each
mod from its author at install time. That is exactly the shape those conditions allow, and it is why
**ADR 0005** exists.

`-curseforge-local.zip` is the worst case and is marked `never`: it deliberately bundles the four
mods whose authors switched third-party downloading **off**, two of them All Rights Reserved with an
explicit opt-out. It exists for one machine.

**The good news is that the one publishable artifact is not a reduced offering.** `-friend.zip`
installs a client, and the same file installs a server with `-s server`. Nothing is lost by
publishing only it.

## Why a pre-release and not a release

`CHANGELOG.md`'s own rule: the first **release** entry cannot be cut until the twelve-test gate in
*Distribution Spec §16* passes, and §16 needs a client nobody has played on. `CLAUDE.md` adds that a
version without a changelog entry is not a release.

A **pre-release** resolves both honestly: it is labelled as a test build, it gets a changelog entry
that says §16 has not run, and it gives friends a stable URL instead of a file passed around chat
with no version anchor. The shim used the same mechanism.

## A stale instruction this corrects

`docs/agents/blocked-work.md:83` still reads:

> **Do not ship, publish, or hand this pack to anyone until this is resolved.**

**#53 is closed** — ADR 0005 resolved it for the friend path. Left as-is, that line stops the next
agent from doing something now permitted, and it contradicts `docs/distribution-licenses.md` in the
same repository. It gets scoped to what is actually still blocked: public release of any
jar-bundling artifact.

## Change inventory

| Path | What changes | How it is verified |
|---|---|---|
| `CHANGELOG.md` | a `v0.2.0-alpha` **pre-release** entry stating §16 has not run | read |
| `docs/agents/blocked-work.md` | the blanket publish ban scoped to jar-bundling artifacts, both mirrors | read |
| `docs/OPEN-WORK-LEDGER.md` | the release row reflects that a pre-release exists | read |
| git tag `v0.2.0-alpha` | created, pointing at the merge commit | `git tag -l` |
| GitHub pre-release | `-friend.zip`, `README.md`, `SHA256SUMS.txt` — **and nothing else** | read the asset list back |

## Acceptance criteria

- [ ] `CHANGELOG.md` has a `v0.2.0-alpha` entry marked pre-release, stating §16 has not run
- [ ] `blocked-work.md` no longer forbids what ADR 0005 permits, and still forbids what it does not
- [ ] Tag `v0.2.0-alpha` exists
- [ ] The pre-release carries **exactly three assets** — the friend zip, the README, the checksums
- [ ] **No jar-bundling artifact is attached** — verified by reading the release asset list, not by intending it
- [ ] `prerelease: true`
- [ ] `node scripts/validate/verify.mjs` green

## Out of scope

**Publishing `-instance.zip`, `-server.zip`, `-alpha.zip` or `-curseforge-local.zip`** anywhere, in
any form, including a Google Drive folder shared alongside the release.

**Cutting a full release.** Blocked on §16, which needs a played client.

**CurseForge or Modrinth publication.** A different platform with its own rules; *Distribution Spec*
§33–34, and not attempted here.

---

## สรุปภาษาไทย

### สรุป

ปล่อย `v0.2.0-alpha` เป็น **GitHub pre-release ที่มีแค่ `-friend.zip`** และบันทึกว่าทำไมอีกสี่ตัว
ไปด้วยไม่ได้

### ตอบคำถามตรง ๆ: หนึ่งในห้า ไม่ใช่ห้า

คำขอคือปล่อย artifact ทุกตัว การตรวจสัญญาอนุญาตของ repo เอง — อ่านครบทั้ง 120 มอด —
ตัดสินเรื่องนี้ไว้แล้ว และตารางอยู่ใน `docs/distribution-licenses.md`:

| Artifact | jar ของคนอื่นข้างใน | แจกได้ไหม |
|---|---:|---|
| `-friend.zip` | **0** | **ได้** — และใช้ได้ทั้ง client *และ* server ผ่าน `-s server` |
| `-instance.zip` | 120 | ไม่ได้ |
| `-server.zip` | 96 | ไม่ได้ |
| `-alpha.zip` (รูปแบบ CurseForge) | ~83 | ไม่ได้ |
| `-curseforge-local.zip` | ~83 รวมมอด 4 ตัวที่ถูกปิด API | **ห้ามเด็ดขาด** |

ไฟล์นั้นเขียนกฎไว้บรรทัดเดียว:

> **มีแค่ `-friend.zip` เท่านั้นที่อัปโหลดที่ไหนก็ได้** … มันพลาดได้ง่ายมาก —
> การเอา artifact ทั้งห้าไปไว้ในโฟลเดอร์แชร์เดียวกันคือการเผยแพร่ jar ซ้ำ 113 ตัว

**นี่ไม่ใช่ปัญหาที่รายชื่อสัญญาอนุญาต แต่เป็นปัญหาที่รูปแบบการส่งมอบ** ผู้เขียนสองคนถูกอ้างคำพูดไว้ตรง ๆ
ในการตรวจ:

> *Serene Seasons* — "คุณใส่มอดนี้ใน modpack ที่ Modrinth โฮสต์ได้ **ตราบใดที่คุณไม่เอามอดไปโฮสต์ซ้ำ**…"

> *Entity Culling* — "ใส่มอดนี้ใน modpack ของคุณได้เลย… **อย่าเอาไฟล์ JAR ไปแจกที่อื่น!**"

ทั้งคู่อนุญาต modpack ทั้งคู่ห้ามโฮสต์ jar ซ้ำ artifact สี่ในห้าตัวของเราโฮสต์ jar ซ้ำ
ส่วน `-friend.zip` ไม่ทำ — มันส่งแค่ manifest กับชั้นงานของเราเอง แล้ว `packwiz-installer`
ไปดึงมอดแต่ละตัวจากผู้เขียนตอนติดตั้ง นั่นคือรูปแบบที่เงื่อนไขพวกนั้นอนุญาตพอดี และเป็นเหตุผลที่
**ADR 0005** มีอยู่

`-curseforge-local.zip` เป็นกรณีแย่ที่สุดและถูกทำเครื่องหมายว่า `ห้ามเด็ดขาด`:
มันจงใจบรรจุมอดสี่ตัวที่ผู้เขียนปิดการโหลดโดยบุคคลที่สามไว้ สองในนั้นเป็น All Rights Reserved
พร้อมการปฏิเสธชัดเจน มันมีไว้สำหรับเครื่องเดียว

**ข่าวดีคือ artifact ตัวเดียวที่ปล่อยได้ไม่ใช่ของที่ลดทอน** `-friend.zip` ติดตั้ง client ได้
และไฟล์เดียวกันติดตั้ง server ได้ด้วย `-s server` การปล่อยแค่ตัวนี้จึงไม่ได้เสียอะไรไป

### ทำไมเป็น pre-release ไม่ใช่ release

กฎของ `CHANGELOG.md` เอง: entry **release** อันแรกตัดไม่ได้จนกว่า gate สิบสองข้อใน
*Distribution Spec §16* จะผ่าน และ §16 ต้องใช้ client ที่ยังไม่มีใครเล่น ส่วน `CLAUDE.md`
เสริมว่าเวอร์ชันที่ไม่มี entry ใน changelog ไม่ใช่ release

**pre-release** แก้ทั้งสองข้ออย่างซื่อตรง: มันถูกติดป้ายว่าเป็น build ทดสอบ
มี entry ใน changelog ที่บอกว่า §16 ยังไม่รัน และให้เพื่อน ๆ มี URL ที่คงที่แทนที่จะส่งไฟล์กันในแชท
โดยไม่มีจุดยึดเรื่องเวอร์ชัน ตัว shim ก็ใช้กลไกเดียวกัน

### คำสั่งที่ค้างเก่าซึ่งงานนี้แก้

`docs/agents/blocked-work.md:83` ยังเขียนว่า:

> **อย่าส่ง อย่าเผยแพร่ อย่ายื่น pack นี้ให้ใครจนกว่าเรื่องนี้จะจบ**

**#53 ปิดไปแล้ว** — ADR 0005 แก้มันสำหรับเส้นทางเพื่อน ถ้าปล่อยไว้ บรรทัดนั้นจะห้าม agent
คนถัดไปทำสิ่งที่ตอนนี้อนุญาตแล้ว และมันขัดกับ `docs/distribution-licenses.md` ใน repo เดียวกัน
มันจะถูกจำกัดขอบเขตให้เหลือเฉพาะสิ่งที่ยังถูกบล็อกจริง: การปล่อย artifact ที่บรรจุ jar สู่สาธารณะ

### รายการจุดที่เปลี่ยน

| Path | เปลี่ยนอะไร | ตรวจยังไง |
|---|---|---|
| `CHANGELOG.md` | entry **pre-release** ของ `v0.2.0-alpha` ที่ระบุว่า §16 ยังไม่รัน | อ่าน |
| `docs/agents/blocked-work.md` | จำกัดขอบเขตคำสั่งห้ามเผยแพร่ให้เหลือเฉพาะ artifact ที่บรรจุ jar ทั้งสองภาษา | อ่าน |
| `docs/OPEN-WORK-LEDGER.md` | แถว release สะท้อนว่ามี pre-release แล้ว | อ่าน |
| git tag `v0.2.0-alpha` | สร้าง ชี้ไปที่ merge commit | `git tag -l` |
| GitHub pre-release | `-friend.zip`, `README.md`, `SHA256SUMS.txt` — **และไม่มีอย่างอื่น** | อ่านรายการ asset กลับมา |

### เกณฑ์การปิดงาน

- [ ] `CHANGELOG.md` มี entry `v0.2.0-alpha` ทำเครื่องหมายว่า pre-release และระบุว่า §16 ยังไม่รัน
- [ ] `blocked-work.md` ไม่ห้ามสิ่งที่ ADR 0005 อนุญาตแล้ว และยังห้ามสิ่งที่มันไม่ได้อนุญาต
- [ ] มี tag `v0.2.0-alpha`
- [ ] pre-release มี asset **สามไฟล์พอดี** — friend zip, README, checksums
- [ ] **ไม่มี artifact ที่บรรจุ jar แนบไปด้วย** — ตรวจด้วยการอ่านรายการ asset ไม่ใช่ด้วยความตั้งใจ
- [ ] `prerelease: true`
- [ ] `node scripts/validate/verify.mjs` เขียว

### นอกขอบเขต

**การเผยแพร่ `-instance.zip`, `-server.zip`, `-alpha.zip` หรือ `-curseforge-local.zip`**
ที่ใดก็ตาม ในรูปแบบใดก็ตาม รวมถึงโฟลเดอร์ Google Drive ที่แชร์ควบคู่ไปกับ release

**การตัด release เต็ม** ถูกบล็อกที่ §16 ซึ่งต้องมี client ที่เล่นแล้ว

**การเผยแพร่บน CurseForge หรือ Modrinth** เป็นแพลตฟอร์มคนละตัวที่มีกฎของตัวเอง
*Distribution Spec* §33–34 และไม่ได้ทำในงานนี้
