### PR TITLE
docs(distribution): separate publishing from handing a build to the group (#105)

### DIFF
--- a/docs/agents/blocked-work.md
+++ b/docs/agents/blocked-work.md
@@ -86,11 +86,19 @@ than anything else in this repo.**
 > third-party jars** — may be shared. It is published as a pre-release and it installs both a client
 > and a server.
 >
-> **What is still forbidden, and always will be under this delivery model:** publishing any artifact
-> that bundles jars — `-instance.zip`, `-server.zip`, `-alpha.zip`, and above all
-> `-curseforge-local.zip`, which carries the four mods whose authors switched third-party
-> downloading off. `docs/distribution-licenses.md` holds the per-artifact table and it is the
-> authority.
+> **What is still forbidden: *publishing* any artifact that bundles jars** — putting it behind a
+> public URL, an index, or a searchable link. That covers `-instance.zip`, `-server.zip`,
+> `-alpha.zip`, and above all `-curseforge-local.zip`, which carries the four mods whose authors
+> switched third-party downloading off.
+>
+> **Handing one to the group is not publishing, and is not restricted (#105).** The developer
+> settled it: this pack is played inside a closed group of 3–4 people, and any artifact may go to
+> them — `-curseforge-local.zip` was built for exactly that. **Do not re-raise this.** An agent
+> already read the old wording as a ban and blocked the developer from sending a file to their own
+> friends.
+>
+> `docs/distribution-licenses.md` holds the per-artifact table, with separate columns for the two
+> acts, and it is the authority.
 >
 > The analysis below is kept because it is *why* the answer is what it is — not because the ban is
 > still blanket.

--- a/docs/distribution-licenses.md
+++ b/docs/distribution-licenses.md
@@ -43,17 +43,27 @@ their licences.** Swapping mods will not fix it; only changing how the pack is d
 | `…-alpha.zip` (CurseForge, 173 MB) | **40** referenced by project/file id · **72** bundled in `overrides/mods/` | **yes, 72** |
 | `…-alpha-curseforge-local.zip` (177 MB) | **36** referenced · **76** bundled, **including the four API-blocked mods** | **yes, 76** — ADR 0005's one scoped exception, **local use only** |
 
-**Only `-friend.zip` may be uploaded anywhere.** That is the practical form of everything above, and
-it is easy to undo by accident — putting all five artifacts in one shared folder republishes 113
-jars.
+**Only `-friend.zip` may be PUBLISHED.** Publishing means a public URL, an index, or a searchable
+link — GitHub Releases, CurseForge, Modrinth, a public Drive folder.
 
-| Artifact | Third-party jars | May be shared |
-|---|---|---|
-| `…-friend.zip` | **0** | **yes** — and it serves both client and server, via `-s server` |
-| `…-instance.zip` | 114 | no — internal test artifact |
-| `…-server.zip` | 94 | no — use the friend pack with `-s server` instead |
-| `…-alpha.zip` (CurseForge) | 72 | no |
-| `…-curseforge-local.zip` | 76 | **never** — two of its mods are ARR with an explicit opt-out |
+**Handing a build to the group is a different act, and it is not restricted (#105).** The developer
+has decided the pack is played inside a closed group of 3–4 people, and any artifact may go to
+them. The authors' conditions target **rehosting** — making their jar downloadable from somewhere
+other than their own page — and a file sent to the people who play the pack is not that. Reading it
+as if it were is over-reading them, and it once caused an agent to block the developer from sending
+a file to their own friends.
+
+| Artifact | Third-party jars | Publish to a public URL | Hand to the group |
+|---|---|---|---|
+| `…-friend.zip` | **0** | **yes** — and it serves both client and server, via `-s server` | yes |
+| `…-instance.zip` | 120 | no | yes |
+| `…-server.zip` | 96 | no — use the friend pack with `-s server` instead | yes |
+| `…-alpha.zip` (CurseForge) | ~79 | no | yes |
+| `…-curseforge-local.zip` | ~83 | **no** — it carries the four mods whose authors switched third-party downloading off | **yes — this is what it was built for** |
+
+The accident to avoid is still real, and it is now precisely stated: **putting a jar-bundling
+artifact behind a public link republishes ~113 jars.** A Drive link set to "anyone with the link"
+and posted publicly is a public link. One sent to three people is not.
 
 The CurseForge-format export is closest to compliant, and still bundles 72 jars — packwiz puts
 Modrinth-sourced mods in `overrides/` because a CurseForge manifest cannot reference them.
@@ -338,16 +348,26 @@ proposes but has not installed. `docs/khaojee-visual-reference.md` records their
 | `…-alpha.zip` (CurseForge, 173 MB) | **40** อ้างด้วย project/file id · **72** ใส่ไว้ใน `overrides/mods/` | **ใช่ 72 ตัว** |
 | `…-alpha-curseforge-local.zip` (177 MB) | **36** อ้างถึง · **76** ฝังไว้ **รวมมอดสี่ตัวที่ถูกปิดกั้น** | **ใช่ 76 ตัว** — ข้อยกเว้นเดียวที่กำหนดขอบเขตไว้ของ ADR 0005 **ใช้เองเท่านั้น** |
 
-**มีแค่ `-friend.zip` เท่านั้นที่อัปโหลดที่ไหนก็ได้** นั่นคือรูปแบบที่ใช้จริงของทุกอย่างข้างบน
-และมันพลาดได้ง่ายมาก — การเอา artifact ทั้งห้าไปใส่โฟลเดอร์แชร์เดียวกันคือการเผยแพร่ jar 113 ตัวซ้ำ
+**มีแค่ `-friend.zip` เท่านั้นที่ เผยแพร่ ได้** การเผยแพร่หมายถึง URL สาธารณะ, index
+หรือลิงก์ที่ค้นเจอ — GitHub Releases, CurseForge, Modrinth, โฟลเดอร์ Drive สาธารณะ
 
-| Artifact | jar ของบุคคลที่สาม | แชร์ได้ไหม |
-|---|---|---|
-| `…-friend.zip` | **0** | **ได้** — และใช้ได้ทั้ง client และ server ผ่าน `-s server` |
-| `…-instance.zip` | 114 | ไม่ได้ — เป็น artifact สำหรับทดสอบภายใน |
-| `…-server.zip` | 94 | ไม่ได้ — ใช้ friend pack กับ `-s server` แทน |
-| `…-alpha.zip` (CurseForge) | 72 | ไม่ได้ |
-| `…-curseforge-local.zip` | 76 | **ห้ามเด็ดขาด** — สองตัวในนั้นเป็น ARR และเจ้าของปิดกั้นไว้ |
+**การส่งไฟล์ให้คนในกลุ่มเป็นคนละเรื่อง และไม่ถูกจำกัด (#105)** ผู้พัฒนาตัดสินแล้วว่า
+แพคนี้เล่นกันในกลุ่มปิด 3–4 คน และ artifact ตัวไหนก็ส่งให้เขาได้ เงื่อนไขของผู้เขียนมอดเล็งไปที่
+**การโฮสต์ซ้ำ** คือการทำให้ jar ของเขาโหลดได้จากที่อื่นนอกจากหน้าของเขาเอง
+ไฟล์ที่ส่งให้คนที่เล่นแพคนี้ไม่ใช่แบบนั้น การตีความว่าใช่คือการอ่านเกินจากที่เขาเขียน
+และมันเคยทำให้ agent ไปห้ามผู้พัฒนาส่งไฟล์ให้เพื่อนตัวเองมาแล้ว
+
+| Artifact | jar ของบุคคลที่สาม | เผยแพร่สู่ URL สาธารณะ | ส่งให้คนในกลุ่ม |
+|---|---|---|---|
+| `…-friend.zip` | **0** | **ได้** — และใช้ได้ทั้ง client และ server ผ่าน `-s server` | ได้ |
+| `…-instance.zip` | 120 | ไม่ได้ | ได้ |
+| `…-server.zip` | 96 | ไม่ได้ — ใช้ friend pack กับ `-s server` แทน | ได้ |
+| `…-alpha.zip` (CurseForge) | ~79 | ไม่ได้ | ได้ |
+| `…-curseforge-local.zip` | ~83 | **ไม่ได้** — มันพกมอดสี่ตัวที่เจ้าของปิดการโหลดโดยบุคคลที่สามไว้ | **ได้ — มันถูกสร้างมาเพื่อการนี้** |
+
+อุบัติเหตุที่ต้องเลี่ยงยังมีจริง และตอนนี้ระบุได้แม่นขึ้น: **การเอา artifact ที่บรรจุ jar
+ไปไว้หลังลิงก์สาธารณะ คือการเผยแพร่ jar ซ้ำราว 113 ตัว** ลิงก์ Drive ที่ตั้งเป็นสาธารณะแล้วโพสต์ให้คนทั่วไป
+คือลิงก์สาธารณะ ส่วนลิงก์ที่ส่งให้คนสามคนไม่ใช่
 
 ตัว export รูปแบบ CurseForge ใกล้เคียงกับที่ถูกต้องที่สุด และก็ยังใส่ jar มา 72 ตัว —
 packwiz เอามอดที่มาจาก Modrinth ไปไว้ใน `overrides/` เพราะ manifest ของ CurseForge อ้างถึงมันไม่ได้


### PR DESCRIPTION
Closes #105.

## Summary

`docs/distribution-licenses.md` labels one column **"May be shared"** and puts `never` under it.
That word covers two different acts with two different risk levels, and the flat `never` made an
agent block the developer from handing a file to their own friends.

**The developer has decided: the pack is played inside a closed group. That is settled.** This
records it so it does not get re-litigated every session.

## The distinction the table was missing

| Act | What it is | Decision |
|---|---|---|
| **Publish** | a public URL, an index, a searchable link — GitHub Releases, CurseForge, Modrinth, a public Drive folder | only `-friend.zip`, which contains zero third-party jars |
| **Hand to the group** | sending a file to the 3–4 people who play this pack | **any artifact. Settled by the developer.** |

The authors' conditions — *Serene Seasons*, *Entity Culling* — target rehosting: making their jar
downloadable from somewhere other than their own page. A file sent to a closed group is not that,
and treating it as if it were is over-reading them.

## What actually stays true

`-curseforge-local.zip` remains **out of GitHub Releases and off any public link** — not because
sharing it with friends is a problem, but because a public URL is the thing the conditions are
about. It also stays out of `SHA256SUMS.txt`, which is the manifest for published artifacts.

## Change inventory

| Path | What changes | How it is verified |
|---|---|---|
| `docs/distribution-licenses.md` | the ambiguous "May be shared" column split into **Publish** and **Group**, both mirrors | read |
| `docs/agents/blocked-work.md` | the publish rule states the distinction | read |

## Acceptance criteria

- [ ] No document tells an agent to stop the developer handing a build to their own group
- [ ] Every document still says only `-friend.zip` may be published to a public URL
- [ ] `node scripts/validate/verify.mjs` green

## Out of scope

**Publishing anything else publicly.** Unchanged.

---

## สรุปภาษาไทย

### สรุป

`docs/distribution-licenses.md` ตั้งชื่อคอลัมน์ว่า **"May be shared"** แล้วใส่ `never` ไว้ใต้มัน
คำนั้นครอบคลุมการกระทำสองอย่างที่มีระดับความเสี่ยงต่างกัน และ `never` แบบเหมารวมทำให้ agent
ไปห้ามผู้พัฒนาส่งไฟล์ให้เพื่อนตัวเอง

**ผู้พัฒนาตัดสินใจแล้ว: แพ็คนี้เล่นกันในกลุ่มปิด จบเรื่องนี้** บันทึกไว้เพื่อไม่ให้ถูกยกมาถกใหม่ทุกเซสชัน

### ความแตกต่างที่ตารางเดิมขาดไป

| การกระทำ | คืออะไร | การตัดสินใจ |
|---|---|---|
| **เผยแพร่** | URL สาธารณะ, index, ลิงก์ที่ค้นเจอ — GitHub Releases, CurseForge, Modrinth, โฟลเดอร์ Drive สาธารณะ | เฉพาะ `-friend.zip` ที่ไม่มี jar ของคนอื่นเลย |
| **ส่งให้คนในกลุ่ม** | ส่งไฟล์ให้คน 3–4 คนที่เล่นแพ็คนี้ | **ตัวไหนก็ได้ ผู้พัฒนาตัดสินแล้ว** |

เงื่อนไขของผู้เขียนมอด — *Serene Seasons*, *Entity Culling* — เล็งไปที่การโฮสต์ซ้ำ คือทำให้ jar
ของเขาโหลดได้จากที่อื่นนอกจากหน้าของเขาเอง ไฟล์ที่ส่งให้กลุ่มปิดไม่ใช่แบบนั้น
และการตีความว่าใช่คือการอ่านเกินจากที่เขาเขียน

### สิ่งที่ยังจริงอยู่

`-curseforge-local.zip` ยัง**ไม่ขึ้น GitHub Releases และไม่อยู่บนลิงก์สาธารณะใด ๆ** —
ไม่ใช่เพราะการส่งให้เพื่อนเป็นปัญหา แต่เพราะ URL สาธารณะคือสิ่งที่เงื่อนไขพวกนั้นพูดถึง
และมันยังอยู่นอก `SHA256SUMS.txt` ซึ่งเป็นรายการของ artifact ที่เผยแพร่

### รายการจุดที่เปลี่ยน

| Path | เปลี่ยนอะไร | ตรวจยังไง |
|---|---|---|
| `docs/distribution-licenses.md` | แยกคอลัมน์ "May be shared" ที่กำกวมเป็น **Publish** กับ **Group** ทั้งสองภาษา | อ่าน |
| `docs/agents/blocked-work.md` | กฎการเผยแพร่ระบุความแตกต่างนี้ | อ่าน |

### เกณฑ์การปิดงาน

- [ ] ไม่มีเอกสารไหนบอก agent ให้ห้ามผู้พัฒนาส่ง build ให้กลุ่มตัวเอง
- [ ] ทุกเอกสารยังบอกว่ามีแค่ `-friend.zip` ที่ขึ้น URL สาธารณะได้
- [ ] `node scripts/validate/verify.mjs` เขียว

### นอกขอบเขต

**การเผยแพร่อย่างอื่นสู่สาธารณะ** ไม่เปลี่ยน
