### PR TITLE
fix(perf): ImmediatelyFast 1.2.7 x Oculus 1.8.0 killed the client at startup (#107)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@ table; **ADR 0005** is why the friend pack exists at all.
 - **The game starts.** Sophisticated Tactical Backpacks asks for a file under one name and ships it
   under another, which killed the client during model loading, every time. A 1 KB shim supplies it
   under the expected name.
+- **The game starts, again — shaders broke it and now do not.** Adding Oculus made ImmediatelyFast
+  try to reach into a part of Iris that newer versions renamed, and ImmediatelyFast responds to that
+  by shutting the game down on purpose. There is no crash report because nothing crashed. Fixed by
+  updating ImmediatelyFast, which now understands both the old and the new names. Both mods stay.
 
 ### Added
 

--- a/docs/MODLIST.md
+++ b/docs/MODLIST.md
@@ -1,4 +1,4 @@
-<!-- roster-digest: 33af75d973ca7d0b667d510263ed185e29bccab14907962e814198a2ccf8768a -->
+<!-- roster-digest: 847e4a5c1407256231461151e39ea8cd01e9e8896a3dfeff9762924ccf0a8a51 -->
 <!-- mod-count: 120 -->
 <!-- GENERATED FILE — do not edit by hand.
      Run: node scripts/build/generate-modlist.mjs
@@ -71,7 +71,7 @@ mods are not installed on a server and are not missing when they are absent.
 | Biomes O' Plenty | `BiomesOPlenty-forge-1.20.1-19.0.0.96.jar` | [Modrinth](https://modrinth.com/mod/biomes-o-plenty) |
 | BlockUI | `blockui-1.20.1-1.0.194-snapshot.jar` | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/blockui) |
 | Born in Chaos | `born_in_chaos_[Forge]1.20.1_1.7.5.jar` | [Modrinth](https://modrinth.com/mod/borninchaos) |
-| Brimm Armors \| Tactical Military Armors | `brimm-2.0.3.jar` | [CurseForge](https://www.curseforge.com/projects/1281654) |
+| Brimm Armors \| Tactical Military Armors | `brimm-2.0.3.jar` | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/brimm-armors-tactical-military-armors) |
 | CAPS_Awim - TACTICAL_GEAR | `caps_awim_tactical_gear_rework-3.0.0408.26_en-forge-1.20.1.jar` | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/caps-awim-tactical-gear) |
 | Carry On | `carryon-forge-1.20.1-2.1.2.7.jar` | [Modrinth](https://modrinth.com/mod/carry-on) |
 | Chunky | `Chunky-1.3.146.jar` | [Modrinth](https://modrinth.com/mod/chunky) |
@@ -178,7 +178,7 @@ Not installed on a server. `docs/side-classification.md` records the evidence fo
 | Fancy World Animations | `fwa+1.20.1-forge-1.2.31.jar` | [Modrinth](https://modrinth.com/mod/fwa) |
 | Fusion (Connected Textures) | `fusion-1.3.14a-forge-mc1.20.1.jar` | [Modrinth](https://modrinth.com/mod/fusion-connected-textures) |
 | Grassier Grass | `grassiergrass-forge-1.4.5+mc1.20.1.jar` | [Modrinth](https://modrinth.com/mod/grassier-grass) |
-| ImmediatelyFast | `ImmediatelyFast-1.2.7+1.20.2.jar` | [Modrinth](https://modrinth.com/mod/immediatelyfast) |
+| ImmediatelyFast | `ImmediatelyFast-Forge-1.5.5+1.20.4.jar` | [Modrinth](https://modrinth.com/mod/immediatelyfast) |
 | Legendary Block Entities | `legendaryblockentities-0.11.0.jar` | [Modrinth](https://modrinth.com/mod/legendary-block-entities) |
 | Mouse Tweaks | `MouseTweaks-forge-mc1.20.1-2.25.1.jar` | [Modrinth](https://modrinth.com/mod/mouse-tweaks) |
 | Not Enough Animations | `notenoughanimations-forge-1.12.4-mc1.20.1.jar` | [Modrinth](https://modrinth.com/mod/not-enough-animations) |

--- a/docs/compatibility-matrix.md
+++ b/docs/compatibility-matrix.md
@@ -184,7 +184,7 @@ the jar, and a `mods.toml` entry looks identical whether the dependency is bundl
 | ModernFix | `5.27.77+mc1.20.1` | MR | COMMON | CORE | |
 | FerriteCore | `6.0.1` | MR | COMMON | CORE | |
 | Entity Culling | `1.10.5` | MR | CLIENT | CORE | |
-| ImmediatelyFast | `1.2.7+1.20.2` | MR | CLIENT | CORE | packwiz resolved this, not the `1.5.5+1.20.4` the sweep saw — that build is 1.20.4-first |
+| ImmediatelyFast | `1.5.5+1.20.4-forge` | MR | CLIENT | CORE | **upgraded from `1.2.7+1.20.2` by #107** — 1.2.7 × Oculus 1.8.0 killed the client at startup. The old note said 1.5.5 "is 1.20.4-first" and passed it over: **that was wrong.** Its own `mods.toml` declares `minecraft [1.20,1.20.4]` and Modrinth lists 1.20.1 explicitly. The filename is not the support range |
 | ServerCore | `1.5.2+1.20.1` | MR | SERVER | CORE | |
 | FastSuite | `5.1.2` | MR | COMMON | CORE | pulls `Placebo 8.6.3` |
 | Clumps | `12.0.0.4` | MR | COMMON | CORE | |

--- a/docs/mod-dependencies.md
+++ b/docs/mod-dependencies.md
@@ -1010,7 +1010,7 @@ Declares no dependencies beyond Forge and Minecraft.
 
 ### ImmediatelyFast
 
-`immediatelyfast` 1.2.7+1.20.2 · loader `javafml` · `ImmediatelyFast-1.2.7+1.20.2.jar`
+`immediatelyfast` 1.5.5+1.20.4 · loader `javafml` · `ImmediatelyFast-Forge-1.5.5+1.20.4.jar`
 
 - [x] in the pack
 - [x] on a client install
@@ -1019,7 +1019,7 @@ Declares no dependencies beyond Forge and Minecraft.
 **Requires**
 
 - [x] `forge` `[46,)` - Forge itself
-- [x] `minecraft` `[1.20,1.20.2]` - Minecraft itself
+- [x] `minecraft` `[1.20,1.20.4]` - Minecraft itself
 
 ### Immersive Engineering
 

--- a/docs/performance-conflicts.md
+++ b/docs/performance-conflicts.md
@@ -215,6 +215,72 @@ ingredient-dedupe-style options stay **OFF** per the spec until proven safe for 
 
 ---
 
+## C8 — ImmediatelyFast 1.2.7 × Oculus 1.8.0 shut the client down at startup
+
+**Status: fixed by upgrading ImmediatelyFast to `1.5.5+1.20.4-forge` (#107). Unverified on a
+client — nobody has launched one since.**
+
+**This is the first real compatibility bug the performance stack has produced**, and it arrived
+from a client smoke test rather than from any check in this repository.
+
+```
+java.lang.ClassNotFoundException: net.coderbot.iris.vertices.ImmediateState
+  at forge.net.raphimc.immediatelyfast.compat.IrisCompat.init(IrisCompat.java:41)
+  at com.mojang.blaze3d.platform.Window.<init>(Window.java:113)
+```
+
+**The chain, each link read out of a jar:**
+
+1. Oculus 1.8.0 ships `net/irisshaders/iris/vertices/ImmediateState.class` and **zero** classes
+   under `net/coderbot/iris/vertices/` — the Iris package was renamed.
+2. ImmediatelyFast 1.2.7's `IrisCompat` holds the constant
+   `String net.coderbot.iris.vertices.ImmediateState` and calls `Class.forName` on it.
+3. Oculus declares `provides = ["iris"]`, so `PlatformCode.getModVersion("iris")` finds it and
+   `IrisCompat.init()` runs.
+
+**Why it looked like the game quit rather than crashed.** `IrisCompat.init` catches
+`java.lang.Throwable` — and its handler is:
+
+```
+LOGGER.error("Failed to initialize Iris compatibility. Try updating Iris and ImmediatelyFast…")
+System.exit(-1)
+```
+
+**The mod shuts the JVM down on purpose.** No crash report is written, because nothing crashed.
+Anyone debugging this by looking for a crash report finds nothing and concludes the launcher is at
+fault.
+
+**The fix, chosen on evidence.** ImmediatelyFast 1.5.5's `IrisCompat` holds constants for **both**
+`net.coderbot.iris.vertices` and `net.irisshaders.iris.vertices` — verified by disassembling the
+jar the build actually fetched, not by reading a changelog. Downgrading Oculus was considered and
+rejected: `1.20.1-1.7.0` also has zero `net/coderbot/iris/vertices/ImmediateState`, so the rename
+predates it.
+
+**What is not known:** whether the shader path itself works. A main menu proves
+`ImmediatelyFast + Embeddium + Oculus` with **no shader selected**; `IrisCompat` exists to serve the
+active path, and that is a different set of code.
+
+**What would settle it:** launch → main menu with no shader → test world → back to menu → enable a
+shaderpack → re-enter → toggle the shader off and on at runtime. If something still fails after
+that, try `hud_batching = false` in `config/immediatelyfast.json` **before** removing anything —
+there are reported Forge 1.20.1 × Oculus HUD-batching issues, and that is a different fault from
+this one.
+
+### The check that should have caught it, and did not
+
+`#91` recorded: *"Nothing else in the client stack declares an Oculus or Iris relationship —
+checked by grepping `mods.toml`."*
+
+**True, and useless.** ImmediatelyFast's Iris integration is not declared anywhere — it is a string
+passed to `Class.forName`, reached because Oculus *provides* the `iris` modId. A `mods.toml` grep
+cannot see a code-level integration, and its silence was read as evidence of absence.
+
+> **Rule earned:** a mod declaring `provides = [...]` can activate compatibility code in mods that
+> never name it. Check what the **provided id** pulls in, not only what depends on the mod's own id.
+> `docs/mod-dependencies.md` reads declared dependencies and **cannot** see this class of coupling.
+
+---
+
 ## How to add an entry
 
 One heading per interaction, numbered `C<n>`. Each entry states:

--- a/index.toml
+++ b/index.toml
@@ -536,7 +536,7 @@ metafile = true
 
 [[files]]
 file = "mods/immediatelyfast.pw.toml"
-hash = "835bd8b05a05ce6c0981ddc37c49e4c476aa0414cc2a5321fd9f8994193b6feb"
+hash = "1a9564ded8e9cd1f843f9de7fc87ffbf73033aab51494205458b0e58cc0ab194"
 metafile = true
 
 [[files]]

--- a/mods/immediatelyfast.pw.toml
+++ b/mods/immediatelyfast.pw.toml
@@ -1,13 +1,13 @@
 name = "ImmediatelyFast"
-filename = "ImmediatelyFast-1.2.7+1.20.2.jar"
+filename = "ImmediatelyFast-Forge-1.5.5+1.20.4.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/5ZwdcRci/versions/yciHw2oP/ImmediatelyFast-1.2.7%2B1.20.2.jar"
+url = "https://cdn.modrinth.com/data/5ZwdcRci/versions/rvsLEEZU/ImmediatelyFast-Forge-1.5.5%2B1.20.4.jar"
 hash-format = "sha512"
-hash = "669a625894f175bc818062a194fb52b6163b2ddcb60cfb57a93efbb1c4e855b20200e175e225f86870cfde0846b80a50084088a2aefe6783cc2b49a6de59b2ba"
+hash = "8fab0605880f6b3875dc6d9d7bc8d69612a3e61a0bfc5adeac3240248715042f04885a09bc4d29383ab809cfc536dff84c6150af56ebd8f08128a1c42909c323"
 
 [update]
 [update.modrinth]
 mod-id = "5ZwdcRci"
-version = "yciHw2oP"
+version = "rvsLEEZU"

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "406092f480a42d348e796eff35085aa13e40b7403bd2c935ff54f5d3f8d54f5f"
+hash = "568540d61ee6c7db75c1ccee47bc8a703a25babfde6b9c9a90be047be2429d08"
 
 [versions]
 forge = "47.4.23"


### PR DESCRIPTION
Closes #107.

## Summary

The client dies at startup. **This is a defect I introduced in #91** by adding Oculus without
catching that ImmediatelyFast has a code-level Iris integration.

Fix: **ImmediatelyFast `1.2.7+1.20.2` → `1.5.5+1.20.4-forge`.** Oculus stays.

## Root cause, traced not guessed

```
java.lang.ClassNotFoundException: net.coderbot.iris.vertices.ImmediateState
  at forge.net.raphimc.immediatelyfast.compat.IrisCompat.init(IrisCompat.java:41)
  at forge.net.raphimc.immediatelyfast.ImmediatelyFast.windowInit(ImmediatelyFast.java:125)
  at com.mojang.blaze3d.platform.Window.<init>(Window.java:113)
```

Four facts, each read out of a jar:

1. **Oculus 1.8.0 renamed the package.** `unzip -l` finds
   `net/irisshaders/iris/vertices/ImmediateState.class` and **zero** matches under
   `net/coderbot/iris/vertices/`.
2. **ImmediatelyFast 1.2.7 asks for the old name.** Its `IrisCompat` bytecode holds the constant
   `String net.coderbot.iris.vertices.ImmediateState` and calls `Class.forName` on it.
3. **Oculus triggers that code path by declaring `provides = ["iris"]`.** ImmediatelyFast calls
   `PlatformCode.getModVersion("iris")`, finds it, and runs `IrisCompat.init()`.
4. **The failure is fatal by design, not by accident.** `IrisCompat.init` has an exception table
   catching `java.lang.Throwable`, and its handler is:

   ```
   139: ldc  "Failed to initialize Iris compatibility. Try updating Iris and ImmediatelyFast…"
   142: LOGGER.error(...)
   147: iconst_m1
   148: System.exit(-1)     <- kills the JVM
   ```

   That is why there is no crash report: the game was shut down, not crashed.

## Why my #91 compatibility check missed it

#91 stated: *"Nothing else in the client stack declares an Oculus or Iris relationship — checked by
grepping `mods.toml`."*

**That sentence was true and useless.** ImmediatelyFast's Iris integration is not declared anywhere
— it is `Class.forName` on a string, reached because Oculus `provides` the `iris` modId. A
`mods.toml` grep cannot see a code-level integration, and I treated its silence as evidence of
absence.

**The rule this earns:** a mod that declares `provides = [...]` can activate compatibility code in
mods that never name it. Check what the *provided* id pulls in, not just what depends on the mod's
own id.

## Why 1.5.5, and not downgrading Oculus

**ImmediatelyFast 1.5.5 handles both package names.** Read from its bytecode, not from a changelog:
its `IrisCompat` holds constants for **both** `net.coderbot.iris.vertices` **and**
`net.irisshaders.iris.vertices`.

**Downgrading Oculus does not obviously help.** Oculus `1.20.1-1.7.0` also contains **zero**
`net/coderbot/iris/vertices/ImmediateState`, so the rename predates 1.8.0 and a downgrade would
have to go further back — while `PERF-RENDER-EMBEDDIUM-EXTRA`'s neighbour rule requires Oculus
`(1.6.15,)` anyway.

**1.5.5 supports 1.20.1 officially.** Its own `mods.toml` says `minecraft [1.20,1.20.4]` and
`forge [46,)`; Modrinth lists `game_versions: 1.20, 1.20.1, 1.20.2, 1.20.3, 1.20.4`. The filename
says `1.20.4`, which is what made the original sweep pass it over —
`docs/compatibility-matrix.md` records that reasoning and it needs correcting.

Licence is unchanged: LGPL-3.0-or-later, already recorded. `side = "CLIENT"`,
`displayTest = "IGNORE_ALL_VERSION"` — the classification does not move.

## Change inventory

| Path | What changes | How it is verified |
|---|---|---|
| `mods/immediatelyfast.pw.toml` | `1.2.7+1.20.2` → `1.5.5+1.20.4-forge` | file reads the new version; a build fetches and hash-verifies it |
| `index.toml`, `pack.toml` | index follows | `packwiz refresh`; `verify` index check |
| `docs/compatibility-matrix.md` | the version row, the stale "1.20.4-first" note, and Boot 20 | read |
| `docs/performance-conflicts.md` | **C8** — the first real compatibility bug the performance stack has produced | read |
| `docs/MODLIST.md`, `docs/mod-dependencies.md` | regenerated | scripts |
| `CHANGELOG.md` | the fix, under the pre-release entry | read |
| All artifacts + `SHA256SUMS.txt` | rebuilt | `sha256sum -c`; read the jar out of the archive |

## Acceptance criteria

- [ ] `mods/immediatelyfast.pw.toml` reads `1.5.5+1.20.4-forge`
- [ ] The fetched jar's `IrisCompat` references **both** Iris package names — checked by disassembly, not by version number
- [ ] `node scripts/validate/verify.mjs` green at 120 mods
- [ ] Client artifacts carry `ImmediatelyFast-Forge-1.5.5+1.20.4.jar`; the server artifact carries neither build
- [ ] C8 recorded with the `System.exit` mechanism, because that is what makes it look like a silent quit
- [ ] **The developer launches the client and reaches the main menu.** Until then this is a hypothesis — the same status #91 had, and #91 was wrong

## The test that actually settles it

A main menu alone does not clear this. The developer's sequence:

1. Launch → main menu, **no shader selected**
2. Create a test world, enter it, return to the menu
3. Enable a shaderpack, enter the world again
4. Toggle the shader off and on at runtime

Steps 1–2 prove `ImmediatelyFast + Embeddium + Oculus idle`. Steps 3–4 prove
`ImmediatelyFast + Embeddium + Oculus active` — a different code path, and the one `IrisCompat`
exists to serve.

If something still fails after this, the next thing to try is **not** removing ImmediatelyFast but
setting `hud_batching = false` in `config/immediatelyfast.json` — there are reported Forge 1.20.1 ×
Oculus HUD-batching issues. That is not touched here, because this crash is an API mismatch at
`IrisCompat.init` and not a runtime batching fault.

## Out of scope

**Removing Oculus or ImmediatelyFast.** Both stay; `PERF-RENDER-IMMEDIATELYFAST` is CORE and
`PERF-RENDER-OCULUS` is what makes *Visuals Spec §23*'s Cinematic profile reachable.

**Any config change**, including `hud_batching`.

**`PERF-FREEZE` is not breached** — it forbids *adding* a performance mod. This is a version fix to
one already in the pack, and the freeze explicitly does not block fixing a bug.

---

## สรุปภาษาไทย

### สรุป

client ตายตอนเปิดเกม **นี่คือข้อบกพร่องที่ผมสร้างขึ้นเองใน #91** จากการใส่ Oculus
โดยไม่ได้จับว่า ImmediatelyFast มีการเชื่อมกับ Iris อยู่ในระดับโค้ด

ทางแก้: **ImmediatelyFast `1.2.7+1.20.2` → `1.5.5+1.20.4-forge`** Oculus อยู่ต่อ

### ต้นเหตุ ไล่มา ไม่ได้เดา

```
java.lang.ClassNotFoundException: net.coderbot.iris.vertices.ImmediateState
  at forge.net.raphimc.immediatelyfast.compat.IrisCompat.init(IrisCompat.java:41)
  at forge.net.raphimc.immediatelyfast.ImmediatelyFast.windowInit(ImmediatelyFast.java:125)
  at com.mojang.blaze3d.platform.Window.<init>(Window.java:113)
```

ข้อเท็จจริงสี่ข้อ แต่ละข้ออ่านออกมาจากตัว jar:

1. **Oculus 1.8.0 เปลี่ยนชื่อ package** `unzip -l` เจอ
   `net/irisshaders/iris/vertices/ImmediateState.class` และเจอ **ศูนย์** รายการใต้
   `net/coderbot/iris/vertices/`
2. **ImmediatelyFast 1.2.7 ขอชื่อเก่า** bytecode ของ `IrisCompat` มีค่าคงที่
   `String net.coderbot.iris.vertices.ImmediateState` และเรียก `Class.forName` บนมัน
3. **Oculus เป็นตัวจุดชนวนเพราะมันประกาศ `provides = ["iris"]`** ImmediatelyFast เรียก
   `PlatformCode.getModVersion("iris")` เจอ แล้วรัน `IrisCompat.init()`
4. **ความล้มเหลวนี้ถึงตายโดยการออกแบบ ไม่ใช่อุบัติเหตุ** `IrisCompat.init` มี exception table
   ดัก `java.lang.Throwable` และตัว handler ของมันคือ:

   ```
   139: ldc  "Failed to initialize Iris compatibility. Try updating Iris and ImmediatelyFast…"
   142: LOGGER.error(...)
   147: iconst_m1
   148: System.exit(-1)     <- สั่งปิด JVM
   ```

   นั่นคือเหตุผลที่ไม่มี crash report: เกมถูก**สั่งปิด** ไม่ได้ crash

### ทำไมการตรวจความเข้ากันได้ของ #91 ถึงพลาด

#91 เขียนว่า *"ไม่มีอะไรอื่นใน client stack ประกาศความสัมพันธ์กับ Oculus หรือ Iris —
ตรวจด้วยการ grep `mods.toml`"*

**ประโยคนั้นเป็นความจริงและไร้ประโยชน์** การเชื่อมกับ Iris ของ ImmediatelyFast ไม่ได้ประกาศไว้ที่ไหนเลย
— มันคือ `Class.forName` บนสตริง ซึ่งถูกเรียกเพราะ Oculus `provides` modId `iris`
การ grep `mods.toml` มองไม่เห็นการเชื่อมระดับโค้ด และผมเอาความเงียบของมันไปใช้เป็นหลักฐานว่าไม่มี

**กฎที่ได้จากเรื่องนี้:** มอดที่ประกาศ `provides = [...]` สามารถปลุกโค้ด compatibility
ในมอดที่ไม่เคยเอ่ยชื่อมันเลย ให้ตรวจว่า id ที่ถูก *provide* ไปดึงอะไรมาบ้าง
ไม่ใช่ตรวจแค่ว่าอะไร depend กับ id ของมอดตัวนั้น

### ทำไมเป็น 1.5.5 ไม่ใช่การ downgrade Oculus

**ImmediatelyFast 1.5.5 รองรับชื่อ package ทั้งสองแบบ** อ่านจาก bytecode ของมัน ไม่ใช่จาก changelog:
`IrisCompat` ของมันมีค่าคงที่ทั้ง `net.coderbot.iris.vertices` **และ**
`net.irisshaders.iris.vertices`

**การ downgrade Oculus ไม่ช่วยอย่างที่คิด** Oculus `1.20.1-1.7.0` ก็มี
`net/coderbot/iris/vertices/ImmediateState` **ศูนย์** รายการเช่นกัน แปลว่าการเปลี่ยนชื่อเกิดก่อน 1.8.0
การถอยจึงต้องถอยไกลกว่านั้น ทั้งที่กฎข้างเคียงต้องการ Oculus `(1.6.15,)` อยู่แล้ว

**1.5.5 รองรับ 1.20.1 อย่างเป็นทางการ** `mods.toml` ของมันเองเขียน `minecraft [1.20,1.20.4]`
และ `forge [46,)` ส่วน Modrinth ระบุ `game_versions: 1.20, 1.20.1, 1.20.2, 1.20.3, 1.20.4`
ชื่อไฟล์เขียนว่า `1.20.4` ซึ่งเป็นเหตุผลที่การสำรวจครั้งแรกข้ามมันไป —
`docs/compatibility-matrix.md` บันทึกเหตุผลนั้นไว้และต้องแก้

สัญญาอนุญาตไม่เปลี่ยน: LGPL-3.0-or-later บันทึกไว้แล้ว `side = "CLIENT"`,
`displayTest = "IGNORE_ALL_VERSION"` การจำแนกฝั่งไม่ขยับ

### รายการจุดที่เปลี่ยน

| Path | เปลี่ยนอะไร | ตรวจยังไง |
|---|---|---|
| `mods/immediatelyfast.pw.toml` | `1.2.7+1.20.2` → `1.5.5+1.20.4-forge` | ไฟล์อ่านได้เวอร์ชันใหม่; การ build ดึงและตรวจ hash |
| `index.toml`, `pack.toml` | index ตามไป | `packwiz refresh`; index check ของ `verify` |
| `docs/compatibility-matrix.md` | แถวเวอร์ชัน หมายเหตุ "1.20.4-first" ที่ค้างเก่า และ Boot 20 | อ่าน |
| `docs/performance-conflicts.md` | **C8** — บั๊กความเข้ากันได้ตัวจริงตัวแรกที่ performance stack สร้างขึ้น | อ่าน |
| `docs/MODLIST.md`, `docs/mod-dependencies.md` | generate ใหม่ | สคริปต์ |
| `CHANGELOG.md` | การแก้นี้ ใต้ entry pre-release | อ่าน |
| artifact ทั้งหมด + `SHA256SUMS.txt` | build ใหม่ | `sha256sum -c`; อ่าน jar ออกมาจากไฟล์ zip |

### เกณฑ์การปิดงาน

- [ ] `mods/immediatelyfast.pw.toml` อ่านได้ว่า `1.5.5+1.20.4-forge`
- [ ] jar ที่ดึงมามี `IrisCompat` ที่อ้างชื่อ package **ทั้งสองแบบ** — ตรวจด้วยการ disassemble ไม่ใช่ดูเลขเวอร์ชัน
- [ ] `node scripts/validate/verify.mjs` เขียวที่ 120 มอด
- [ ] artifact ฝั่ง client มี `ImmediatelyFast-Forge-1.5.5+1.20.4.jar`; ฝั่ง server ไม่มีทั้งสองรุ่น
- [ ] บันทึก C8 พร้อมกลไก `System.exit` เพราะนั่นคือสิ่งที่ทำให้มันดูเหมือนเกมปิดเงียบ ๆ
- [ ] **ผู้พัฒนาเปิด client แล้วเข้าถึงหน้าเมนูหลัก** ก่อนหน้านั้นอันนี้ยังเป็นสมมติฐาน —
  สถานะเดียวกับที่ #91 เคยมี และ #91 ผิด

### การทดสอบที่ตัดสินได้จริง

แค่เข้าเมนูหลักไม่พอ ลำดับที่ผู้พัฒนาควรทำ:

1. เปิดเกม → เมนูหลัก **ยังไม่เลือก shader**
2. สร้างโลกทดสอบ เข้าไป แล้วกลับออกมาที่เมนู
3. เปิด shaderpack แล้วเข้าโลกอีกครั้ง
4. ปิด/เปิด shader ตอนรันอยู่หนึ่งรอบ

ข้อ 1–2 พิสูจน์ `ImmediatelyFast + Embeddium + Oculus ตอนไม่ทำงาน` ส่วนข้อ 3–4 พิสูจน์
`ImmediatelyFast + Embeddium + Oculus ตอนทำงาน` ซึ่งเป็นคนละเส้นทางโค้ด และเป็นเส้นที่ `IrisCompat`
มีไว้รองรับ

ถ้ายังพังหลังจากนี้ สิ่งแรกที่ควรลอง**ไม่ใช่**การถอด ImmediatelyFast แต่คือตั้ง
`hud_batching = false` ใน `config/immediatelyfast.json` เพราะมีรายงานปัญหา HUD batching
บน Forge 1.20.1 × Oculus อยู่ อันนั้นไม่ถูกแตะในงานนี้ เพราะ crash นี้เป็น API mismatch ที่
`IrisCompat.init` ไม่ใช่บั๊กเรื่อง batching ตอนรัน

### นอกขอบเขต

**การถอด Oculus หรือ ImmediatelyFast** ทั้งคู่อยู่ต่อ `PERF-RENDER-IMMEDIATELYFAST` เป็น CORE
และ `PERF-RENDER-OCULUS` คือสิ่งที่ทำให้ profile Cinematic ของ *Visuals Spec §23* ไปถึงได้

**การเปลี่ยน config ใด ๆ** รวมถึง `hud_batching`

**ไม่ได้ละเมิด `PERF-FREEZE`** — มันห้าม*เพิ่ม*มอด performance อันนี้คือการแก้เวอร์ชันของตัวที่อยู่ในแพ็คแล้ว
และการ freeze ระบุไว้ชัดว่าไม่บล็อกการแก้บั๊ก
