### PR TITLE
feat(perf): install all six candidates and ship v0.2.1-alpha (#129)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,43 @@ no entry, no tag, and is never handed to a friend as if it were a release.
 
 ---
 
+## v0.2.1-alpha — pre-release, 2026-08-28
+
+**Still a pre-release, and still untested in game.** The twelve-test gate in *Distribution Spec §16*
+has not run. Six mods were added and **none of them has been launched once.**
+
+### Added
+
+- **Colorwheel** — lets Create's Flywheel renderer work while a shader pack is on. Until now it did
+  not: the game reported `Flywheel Backend: flywheel:off`, so every Create machine was drawn the
+  slow way. This is the one most likely to change how a machine-heavy base feels.
+- **CreateBetterFps** — further Create rendering work that Colorwheel does not cover.
+- **Particle Core** — culls and cheapens particles. This pack throws a lot of them: rain, gunfire,
+  explosions, Create.
+- **Radium Re-Reforged** — broad game-logic optimiser (the Lithium family): mob AI, collisions,
+  block ticking.
+- **Thulium** — client-side work on allocations, the sound engine and the event bus. This pack has
+  a heavy sound and event stack.
+- **C2ME for Forge** — parallel chunk generation, loading and I/O. **The riskiest of the six**: it
+  is an alpha build of a mod that rewrites how chunks are made and saved. If worlds start behaving
+  strangely, remove this one first.
+
+### Changed
+
+- **Shader keybinds no longer fight the gun.** Reloading with `R` used to recompile the whole
+  shader pack, which is why it stuttered every magazine. Oculus now uses `F8` (reload), `F10`
+  (toggle) and `F12` (shader pack selection). Shipped in a four-line `options.txt`; nothing else
+  about your settings is touched.
+
+### Known issues
+
+- **Do not hold a gun with shaders on for long.** A vertex buffer grows until the client runs out of
+  memory — about a minute in testing. Turn shaders off if it happens. Tracked as `C9` / #117.
+- Frame generation is **not** available in the optional Super Resolution add-on and its menu will
+  not appear; the backend for it lives in a mod that cannot be installed yet (#119).
+
+---
+
 ## v0.2.0-alpha — pre-release, 2026-08-28
 
 **This is a pre-release for testing, not a release.** The twelve-test gate in *Distribution Spec

--- a/docs/MODLIST.md
+++ b/docs/MODLIST.md
@@ -1,12 +1,12 @@
-<!-- roster-digest: 847e4a5c1407256231461151e39ea8cd01e9e8896a3dfeff9762924ccf0a8a51 -->
-<!-- mod-count: 120 -->
+<!-- roster-digest: 06a7973a9720658dc83ae1af834b0b15a5af774d7886930e83f71c5529b01114 -->
+<!-- mod-count: 126 -->
 <!-- GENERATED FILE — do not edit by hand.
      Run: node scripts/build/generate-modlist.mjs
      `verify` refuses a roster that disagrees with mods/. -->
 
 # What is in this pack · ในแพ็กนี้มีอะไรบ้าง
 
-**Industrial Civilization Survival 0.2.0-alpha** — **120 mods** on Minecraft `1.20.1`,
+**Industrial Civilization Survival 0.2.0-alpha** — **126 mods** on Minecraft `1.20.1`,
 Forge `47.4.23`.
 
 Every mod here is somebody else's work. This file exists so you can see whose, and go and find
@@ -14,17 +14,17 @@ the original.
 
 **Where you will find this file.** It ships at the top of the client instance zip and at the top of
 the server zip. The CurseForge-format zip instead carries packwiz's own `modlist.html`, which lists
-119 names — the client-side set — with no versions, sides or links. This
+125 names — the client-side set — with no versions, sides or links. This
 file is the complete one.
 
 **ไฟล์นี้อยู่ตรงไหน** มันอยู่บนสุดของ zip ตัว client instance และบนสุดของ zip ตัว server
-ส่วน zip รูปแบบ CurseForge จะมี `modlist.html` ของ packwiz เองแทน ซึ่งลงชื่อไว้ 119 ชื่อ —
+ส่วน zip รูปแบบ CurseForge จะมี `modlist.html` ของ packwiz เองแทน ซึ่งลงชื่อไว้ 125 ชื่อ —
 ชุดฝั่ง client — โดยไม่มีเวอร์ชัน ไม่มี side ไม่มีลิงก์ ไฟล์นี้คือตัวที่ครบ
 
 ## Reading the table
 
 **The File column is the exact jar filename**, not a tidied-up version number. That is deliberate:
-120 mods use 120 filename conventions, and parsing a version out of them would mean
+126 mods use 126 filename conventions, and parsing a version out of them would mean
 guessing. The
 filename is what is actually on your disk, so it is also what you can match against your `mods/`
 folder when something goes wrong.
@@ -35,21 +35,21 @@ mod's name — twice now, a guessed slug in this repo has pointed at the wrong p
 at a modpack rather than the mod.
 
 **Client / Server** tells you where a mod runs. If you are hosting a server, you need the
-95 in *Both* and the 1 in *Server only*; the 24 client-only
+97 in *Both* and the 1 in *Server only*; the 28 client-only
 mods are not installed on a server and are not missing when they are absent.
 
 ## อ่านตารางยังไง
 
-**คอลัมน์ File คือชื่อไฟล์ jar จริง ๆ** ไม่ใช่เลขเวอร์ชันที่จัดให้สวย ตั้งใจให้เป็นแบบนั้น เพราะมอด 120 ตัว
-ใช้รูปแบบการตั้งชื่อไฟล์ 120 แบบ การพยายามแกะเวอร์ชันออกมาคือการเดา ชื่อไฟล์คือสิ่งที่อยู่บนเครื่องคุณจริง ๆ
+**คอลัมน์ File คือชื่อไฟล์ jar จริง ๆ** ไม่ใช่เลขเวอร์ชันที่จัดให้สวย ตั้งใจให้เป็นแบบนั้น เพราะมอด 126 ตัว
+ใช้รูปแบบการตั้งชื่อไฟล์ 126 แบบ การพยายามแกะเวอร์ชันออกมาคือการเดา ชื่อไฟล์คือสิ่งที่อยู่บนเครื่องคุณจริง ๆ
 ดังนั้นมันจึงเป็นสิ่งที่คุณเอาไปเทียบกับโฟลเดอร์ `mods/` ได้ตอนมีอะไรผิดพลาด
 
 **ลิงก์ต้นทาง resolve มา ไม่ได้เดา** packwiz บันทึก project *id* ไว้ ไม่เคยบันทึก slug
 สคริปต์นี้จึงตาม id ไปจนถึงหน้าที่มันไปจบแล้วลิงก์หน้านั้น มันไม่ประกอบ URL ขึ้นจากชื่อมอดเด็ดขาด —
 สอง​ครั้งแล้วที่ slug ที่เดาใน repo นี้ชี้ไปผิดโปรเจกต์ ครั้งหนึ่งชี้ไปที่ modpack แทนที่จะเป็นตัวมอด
 
-**Client / Server** บอกว่ามอดตัวนั้นทำงานฝั่งไหน ถ้าคุณจะเปิด server คุณต้องใช้ 95 ตัวใน *Both*
-กับ 1 ตัวใน *Server only* ส่วนมอดฝั่ง client 24 ตัวจะไม่ถูกติดตั้งบน server
+**Client / Server** บอกว่ามอดตัวนั้นทำงานฝั่งไหน ถ้าคุณจะเปิด server คุณต้องใช้ 97 ตัวใน *Both*
+กับ 1 ตัวใน *Server only* ส่วนมอดฝั่ง client 28 ตัวจะไม่ถูกติดตั้งบน server
 และการที่มันไม่อยู่ตรงนั้นไม่ใช่ของหาย
 
 > **หมายเหตุ** ตารางด้านล่างมีชุดเดียว ไม่ได้ทำสองภาษา เพราะเนื้อในเป็นชื่อมอด ชื่อไฟล์ และ URL ซึ่งเป็น
@@ -57,7 +57,7 @@ mods are not installed on a server and are not missing when they are absent.
 
 ---
 
-## Both — client and server · ทั้งสองฝั่ง (95)
+## Both — client and server · ทั้งสองฝั่ง (97)
 
 | Mod · มอด | File · ไฟล์ | Source · ต้นทาง |
 |---|---|---|
@@ -78,6 +78,7 @@ mods are not installed on a server and are not missing when they are absent.
 | Cloth Config API | `cloth-config-11.1.136-forge.jar` | [Modrinth](https://modrinth.com/mod/cloth-config) |
 | ClothingCraft | `clothingcraft-1.0.0.jar` | [Modrinth](https://modrinth.com/mod/clothingcraft) |
 | Clumps | `Clumps-forge-1.20.1-12.0.0.4.jar` | [Modrinth](https://modrinth.com/mod/clumps) |
+| Concurent Chunk Management Engine - Forge | `c2meforge-0.2.0-forge.4-all.jar` | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/concurent-chunk-management-engine-forge) |
 | Corpse | `corpse-forge-1.20.1-1.0.23.jar` | [Modrinth](https://modrinth.com/mod/corpse) |
 | Countered's Terrain Slabs | `terrain_slabs-forge-4.0.2-beta.jar` | [Modrinth](https://modrinth.com/mod/countereds-terrain-slabs) |
 | Crafting Tweaks | `craftingtweaks-forge-1.20.1-18.2.9.jar` | [Modrinth](https://modrinth.com/mod/crafting-tweaks) |
@@ -134,6 +135,7 @@ mods are not installed on a server and are not missing when they are absent.
 | PlayerRevive | `PlayerRevive_FORGE_v2.0.31_mc1.20.1.jar` | [Modrinth](https://modrinth.com/mod/playerrevive) |
 | Polymorph | `polymorph-forge-0.49.10+1.20.1.jar` | [Modrinth](https://modrinth.com/mod/polymorph) |
 | Puzzles Lib | `PuzzlesLib-v8.1.33-1.20.1-Forge.jar` | [Modrinth](https://modrinth.com/mod/puzzles-lib) |
+| Radium Re-Reforged | `radium-mc1.20.1-0.14.1+git.54e0012.jar` | [CurseForge](https://www.curseforge.com/projects/1649038) |
 | Rhino | `rhino-forge-2001.2.3-build.10.jar` | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/rhino) |
 | Ritchie's Projectile Library | `ritchiesprojectilelib-2.1.1+mc.1.20.1-forge.jar` | [Modrinth](https://modrinth.com/mod/rpl) |
 | Security Craft | `[1.20.1] SecurityCraft v1.10.2.1.jar` | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/security-craft) |
@@ -157,7 +159,7 @@ mods are not installed on a server and are not missing when they are absent.
 | Visual Workbench | `VisualWorkbench-v8.0.1-1.20.1-Forge.jar` | [Modrinth](https://modrinth.com/mod/visual-workbench) |
 | YetAnotherConfigLib (YACL) | `yet_another_config_lib_v3-3.6.6+1.20.1-forge.jar` | [Modrinth](https://modrinth.com/mod/yacl) |
 
-## Client only · เฉพาะฝั่ง client (24)
+## Client only · เฉพาะฝั่ง client (28)
 
 Not installed on a server. `docs/side-classification.md` records the evidence for each call.
 
@@ -172,6 +174,8 @@ Not installed on a server. `docs/side-classification.md` records the evidence fo
 | Better Animations Collection | `BetterAnimationsCollection-v8.0.1-1.20.1-Forge.jar` | [Modrinth](https://modrinth.com/mod/better-animations-collection) |
 | Better Biome Blend | `betterbiomeblend-forge-1.20.1-1.4.0.jar` | [Modrinth](https://modrinth.com/mod/better-biome-blend) |
 | Client Dynamic Light | `clientdynamiclight-1.20.1-3.2.1.jar` | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/client-dynamic-light) |
+| Colorwheel | `colorwheel-forge-1.2.9+mc1.20.1.jar` | [Modrinth](https://modrinth.com/mod/colorwheel) |
+| CreateBetterFps | `createbetterfps-1.20.1-1.1.2.jar` | [Modrinth](https://modrinth.com/mod/createbetterfps) |
 | Dynamic FPS | `dynamic-fps-3.11.4+minecraft-1.20.0-forge.jar` | [Modrinth](https://modrinth.com/mod/dynamic-fps) |
 | Embeddium | `embeddium-0.3.31+mc1.20.1.jar` | [Modrinth](https://modrinth.com/mod/embeddium) |
 | Entity Culling | `entityculling-forge-1.10.5-mc1.20.1.jar` | [Modrinth](https://modrinth.com/mod/entityculling) |
@@ -183,12 +187,14 @@ Not installed on a server. `docs/side-classification.md` records the evidence fo
 | Mouse Tweaks | `MouseTweaks-forge-mc1.20.1-2.25.1.jar` | [Modrinth](https://modrinth.com/mod/mouse-tweaks) |
 | Not Enough Animations | `notenoughanimations-forge-1.12.4-mc1.20.1.jar` | [Modrinth](https://modrinth.com/mod/not-enough-animations) |
 | Oculus | `oculus-mc1.20.1-1.8.0.jar` | [Modrinth](https://modrinth.com/mod/oculus) |
+| Particle Core | `particle_core-0.3.3+1.20.1+forge.jar` | [Modrinth](https://modrinth.com/mod/particle-core) |
 | Particle Rain | `particlerain-4.0.0-beta.11+1.20.1-forge.jar` | [Modrinth](https://modrinth.com/mod/particle-rain) |
 | Polytone | `polytone-1.20-3.5.26.jar` | [Modrinth](https://modrinth.com/mod/polytone) |
 | SmoothPlayerAnimations | `SmoothPlayerAnimations_Forge_1.20.1_1.0.3.jar` | [Modrinth](https://modrinth.com/mod/smoothplayeranimations) |
 | Soft Imprints | `softimprints-forge-1.20.1-2.8.0.jar` | [Modrinth](https://modrinth.com/mod/snow-imprints) |
 | Sound Physics Remastered | `sound-physics-remastered-forge-1.20.1-1.5.1.jar` | [Modrinth](https://modrinth.com/mod/sound-physics-remastered) |
 | Subtle Effects | `SubtleEffects-forge-1.20.1-1.14.3.jar` | [Modrinth](https://modrinth.com/mod/subtle-effects) |
+| Thulium | `thulium-1.0.5.jar` | [CurseForge](https://www.curseforge.com/projects/1462886) |
 
 ## Server only · เฉพาะฝั่ง server (1)
 

--- a/docs/distribution-licenses.md
+++ b/docs/distribution-licenses.md
@@ -147,7 +147,7 @@ to rely on something other than a written grant.
 modpacks on a bullet reading `- Large Modpacks`. In context that sits under a **Performance**
 heading and describes what the mod is suitable for, not what you may do with it. It is silent.
 
-## Permissively licensed — 65 mods
+## Permissively licensed — 71 mods
 
 Redistribution is granted by the licence text itself. GPL/LGPL/MPL additionally require that the
 licence and source remain available; shipping the jars unmodified with `docs/MODLIST.md` linking
@@ -170,9 +170,12 @@ been modified.
 | Cloth Config API | [Modrinth](https://modrinth.com/mod/cloth-config) | GNU Lesser General Public License v3.0 only | Modrinth API |
 | ClothingCraft | [Modrinth](https://modrinth.com/mod/clothingcraft) | MIT License | Modrinth API |
 | Clumps | [Modrinth](https://modrinth.com/mod/clumps) | MIT License | Modrinth API |
+| Colorwheel | [Modrinth](https://modrinth.com/mod/colorwheel) | MIT License | jar `META-INF/mods.toml` |
+| Concurent Chunk Management Engine - Forge | [CurseForge](https://www.curseforge.com/projects/1610389) | MIT License | jar `META-INF/mods.toml` |
 | Create Crafts & Additions | [Modrinth](https://modrinth.com/mod/createaddition) | MIT License | Modrinth API |
 | Create: Diesel Generators | [Modrinth](https://modrinth.com/mod/create-diesel-generators) | MIT License | Modrinth API |
 | Create: Steam 'n' Rails | [Modrinth](https://modrinth.com/mod/create-steam-n-rails) | GNU Lesser General Public License v3.0 only | Modrinth API |
+| CreateBetterFps | [Modrinth](https://modrinth.com/mod/createbetterfps) | MIT License | jar `META-INF/mods.toml` |
 | CreativeCore | [Modrinth](https://modrinth.com/mod/creativecore) | GNU Lesser General Public License v3.0 only | Modrinth API |
 | Curios API | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/curios) | GNU Lesser General Public License version 3 (LGPLv3) | project page |
 | Domum Ornamentum | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/domum-ornamentum) | GNU General Public License version 3 (GPLv3) | project page |
@@ -197,11 +200,13 @@ been modified.
 | ModernFix | [Modrinth](https://modrinth.com/mod/modernfix) | GNU Lesser General Public License v3.0 only | Modrinth API |
 | Mouse Tweaks | [Modrinth](https://modrinth.com/mod/mouse-tweaks) | BSD 3 Clause "New" or "Revised" License | Modrinth API |
 | Multi-Piston | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/multi-piston) | GNU General Public License version 3 (GPLv3) | project page |
+| Particle Core | [Modrinth](https://modrinth.com/mod/particle-core) | MIT License | jar `META-INF/mods.toml` |
 | Placebo | [Modrinth](https://modrinth.com/mod/placebo) | MIT License | Modrinth API |
 | playerAnimator | [Modrinth](https://modrinth.com/mod/playeranimator) | MIT License | Modrinth API |
 | PlayerRevive | [Modrinth](https://modrinth.com/mod/playerrevive) | GNU Lesser General Public License v2.1 only | Modrinth API |
 | Polymorph | [Modrinth](https://modrinth.com/mod/polymorph) | GNU Lesser General Public License v3.0 or later | Modrinth API |
 | Puzzles Lib | [Modrinth](https://modrinth.com/mod/puzzles-lib) | Mozilla Public License 2.0 | Modrinth API |
+| Radium Re-Reforged | [CurseForge](https://www.curseforge.com/projects/1649038) | GNU Lesser General Public License v3.0 only | jar `META-INF/mods.toml` |
 | Rhino | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/rhino) | Mozilla Public License 2.0 | project page |
 | Ritchie's Projectile Library | [Modrinth](https://modrinth.com/mod/rpl) | MIT License | Modrinth API |
 | Security Craft | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/security-craft) | MIT License | project page |
@@ -212,6 +217,7 @@ been modified.
 | Structurize | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/structurize) | GNU General Public License version 3 (GPLv3) | project page |
 | TaCZ x Guns Lights Addon [NEW] - Update 2.5.0 | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/tacz-x-gunslightsaddon-addon) | Academic Free License v3.0 | project page |
 | The Hordes | [Modrinth](https://modrinth.com/mod/the-hordes) | GNU Lesser General Public License v2.1 only | Modrinth API |
+| Thulium | [CurseForge](https://www.curseforge.com/projects/1462886) | MIT License | jar `META-INF/mods.toml` |
 | Uranus | [Modrinth](https://modrinth.com/mod/uranus) | GNU Lesser General Public License v3.0 or later | Modrinth API |
 | Visual Workbench | [Modrinth](https://modrinth.com/mod/visual-workbench) | Mozilla Public License 2.0 | Modrinth API |
 | YetAnotherConfigLib (YACL) | [Modrinth](https://modrinth.com/mod/yacl) | GNU Lesser General Public License v3.0 or later | Modrinth API |
@@ -471,9 +477,12 @@ player-microchip      1488872   IN MANIFEST
 | Cloth Config API | [Modrinth](https://modrinth.com/mod/cloth-config) | GNU Lesser General Public License v3.0 only | Modrinth API |
 | ClothingCraft | [Modrinth](https://modrinth.com/mod/clothingcraft) | MIT License | Modrinth API |
 | Clumps | [Modrinth](https://modrinth.com/mod/clumps) | MIT License | Modrinth API |
+| Colorwheel | [Modrinth](https://modrinth.com/mod/colorwheel) | MIT License | jar `META-INF/mods.toml` |
+| Concurent Chunk Management Engine - Forge | [CurseForge](https://www.curseforge.com/projects/1610389) | MIT License | jar `META-INF/mods.toml` |
 | Create Crafts & Additions | [Modrinth](https://modrinth.com/mod/createaddition) | MIT License | Modrinth API |
 | Create: Diesel Generators | [Modrinth](https://modrinth.com/mod/create-diesel-generators) | MIT License | Modrinth API |
 | Create: Steam 'n' Rails | [Modrinth](https://modrinth.com/mod/create-steam-n-rails) | GNU Lesser General Public License v3.0 only | Modrinth API |
+| CreateBetterFps | [Modrinth](https://modrinth.com/mod/createbetterfps) | MIT License | jar `META-INF/mods.toml` |
 | CreativeCore | [Modrinth](https://modrinth.com/mod/creativecore) | GNU Lesser General Public License v3.0 only | Modrinth API |
 | Curios API | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/curios) | GNU Lesser General Public License version 3 (LGPLv3) | project page |
 | Domum Ornamentum | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/domum-ornamentum) | GNU General Public License version 3 (GPLv3) | project page |
@@ -498,11 +507,13 @@ player-microchip      1488872   IN MANIFEST
 | ModernFix | [Modrinth](https://modrinth.com/mod/modernfix) | GNU Lesser General Public License v3.0 only | Modrinth API |
 | Mouse Tweaks | [Modrinth](https://modrinth.com/mod/mouse-tweaks) | BSD 3 Clause "New" or "Revised" License | Modrinth API |
 | Multi-Piston | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/multi-piston) | GNU General Public License version 3 (GPLv3) | project page |
+| Particle Core | [Modrinth](https://modrinth.com/mod/particle-core) | MIT License | jar `META-INF/mods.toml` |
 | Placebo | [Modrinth](https://modrinth.com/mod/placebo) | MIT License | Modrinth API |
 | playerAnimator | [Modrinth](https://modrinth.com/mod/playeranimator) | MIT License | Modrinth API |
 | PlayerRevive | [Modrinth](https://modrinth.com/mod/playerrevive) | GNU Lesser General Public License v2.1 only | Modrinth API |
 | Polymorph | [Modrinth](https://modrinth.com/mod/polymorph) | GNU Lesser General Public License v3.0 or later | Modrinth API |
 | Puzzles Lib | [Modrinth](https://modrinth.com/mod/puzzles-lib) | Mozilla Public License 2.0 | Modrinth API |
+| Radium Re-Reforged | [CurseForge](https://www.curseforge.com/projects/1649038) | GNU Lesser General Public License v3.0 only | jar `META-INF/mods.toml` |
 | Rhino | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/rhino) | Mozilla Public License 2.0 | project page |
 | Ritchie's Projectile Library | [Modrinth](https://modrinth.com/mod/rpl) | MIT License | Modrinth API |
 | Security Craft | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/security-craft) | MIT License | project page |
@@ -513,6 +524,7 @@ player-microchip      1488872   IN MANIFEST
 | Structurize | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/structurize) | GNU General Public License version 3 (GPLv3) | project page |
 | TaCZ x Guns Lights Addon [NEW] - Update 2.5.0 | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/tacz-x-gunslightsaddon-addon) | Academic Free License v3.0 | project page |
 | The Hordes | [Modrinth](https://modrinth.com/mod/the-hordes) | GNU Lesser General Public License v2.1 only | Modrinth API |
+| Thulium | [CurseForge](https://www.curseforge.com/projects/1462886) | MIT License | jar `META-INF/mods.toml` |
 | Uranus | [Modrinth](https://modrinth.com/mod/uranus) | GNU Lesser General Public License v3.0 or later | Modrinth API |
 | Visual Workbench | [Modrinth](https://modrinth.com/mod/visual-workbench) | Mozilla Public License 2.0 | Modrinth API |
 | YetAnotherConfigLib (YACL) | [Modrinth](https://modrinth.com/mod/yacl) | GNU Lesser General Public License v3.0 or later | Modrinth API |

--- a/docs/side-classification.md
+++ b/docs/side-classification.md
@@ -61,6 +61,23 @@ about the mod, a statement by its author that the loader acts on.
 | Client Dynamic Light | `client-dynamic-light` | `clientSideOnly = true` |
 | Entity Culling | `entityculling` | `clientSideOnly = true` |
 | Not Enough Animations | `not-enough-animations` | `clientSideOnly = true` |
+| Thulium | `thulium` | `clientSideOnly = true` |
+
+### Client because the server has no renderer — #129
+
+Three of the #129 performance batch declare no `clientSideOnly`, so the reason has to be written
+rather than read off. Each is checkable without redoing the reasoning:
+
+| Mod | Slug | The checkable fact |
+|---|---|---|
+| Colorwheel | `colorwheel` | its own description is *"Allows you to use Iris Shaders with Flywheel"*, and its `mods.toml` makes **`oculus` mandatory** — Oculus is already `client` in this roster, so a server loading Colorwheel could not satisfy it |
+| CreateBetterFps | `createbetterfps` | its `mods.toml` declares **every** one of its own dependencies — `create`, `oculus`, `embeddium` — as `side = "CLIENT"`, and two of them are mandatory |
+| Particle Core | `particle-core` | its `mods.toml` declares **every** dependency as `side = "CLIENT"`, including the mandatory `kotlinforforge` and `fzzy_config` |
+
+**Radium Re-Reforged and C2ME-Forge are `both`, deliberately.** Both change game logic the
+integrated server runs, and #88 is the standing reminder that singleplayer *is* a server: a
+gameplay mod marked one-sided disappears from the side it was not marked for. Neither declares
+`clientSideOnly`, and neither is a renderer.
 
 **`client-dynamic-light` was marked `both` and was wrong.** Forge would have skipped it on a server
 anyway, so nothing was broken — but packwiz was downloading it into every server install, and the
@@ -340,6 +357,23 @@ gate ตรวจไม่ได้ว่าเหตุผล*ดี*หรื�
 | Client Dynamic Light | `client-dynamic-light` | `clientSideOnly = true` |
 | Entity Culling | `entityculling` | `clientSideOnly = true` |
 | Not Enough Animations | `not-enough-animations` | `clientSideOnly = true` |
+| Thulium | `thulium` | `clientSideOnly = true` |
+
+### Client because the server has no renderer — #129
+
+Three of the #129 performance batch declare no `clientSideOnly`, so the reason has to be written
+rather than read off. Each is checkable without redoing the reasoning:
+
+| Mod | Slug | The checkable fact |
+|---|---|---|
+| Colorwheel | `colorwheel` | its own description is *"Allows you to use Iris Shaders with Flywheel"*, and its `mods.toml` makes **`oculus` mandatory** — Oculus is already `client` in this roster, so a server loading Colorwheel could not satisfy it |
+| CreateBetterFps | `createbetterfps` | its `mods.toml` declares **every** one of its own dependencies — `create`, `oculus`, `embeddium` — as `side = "CLIENT"`, and two of them are mandatory |
+| Particle Core | `particle-core` | its `mods.toml` declares **every** dependency as `side = "CLIENT"`, including the mandatory `kotlinforforge` and `fzzy_config` |
+
+**Radium Re-Reforged and C2ME-Forge are `both`, deliberately.** Both change game logic the
+integrated server runs, and #88 is the standing reminder that singleplayer *is* a server: a
+gameplay mod marked one-sided disappears from the side it was not marked for. Neither declares
+`clientSideOnly`, and neither is a renderer.
 
 **`client-dynamic-light` เคยถูกทำเครื่องหมายเป็น `both` และมันผิด** Forge จะข้ามมันบน server
 อยู่แล้ว จึงไม่มีอะไรพัง — แต่ packwiz ดาวน์โหลดมันเข้าไปในทุก server install และ compatibility

--- a/index.toml
+++ b/index.toml
@@ -345,6 +345,16 @@ hash = "903352ffbd84d4b95fed905893f4715d9c3f88ec9fff6fb06f6e359e0b839dc3"
 metafile = true
 
 [[files]]
+file = "mods/colorwheel.pw.toml"
+hash = "55f8316d2d00790e3e9bd1285a328706ef35e8fd2070e0248496bf9720f3f328"
+metafile = true
+
+[[files]]
+file = "mods/concurent-chunk-management-engine-forge.pw.toml"
+hash = "21c48ec56eb3018a3a4baeb85ba2b16926afae557f6b80dc937c0ce01ea1ad34"
+metafile = true
+
+[[files]]
 file = "mods/corpse.pw.toml"
 hash = "2fba2317a375669ccb1376525d4d4e0d1903cc5dc44fc70dce1d0e3dbb6aacb1"
 metafile = true
@@ -382,6 +392,11 @@ metafile = true
 [[files]]
 file = "mods/createaddition.pw.toml"
 hash = "e6d1f36e9e0193fe410d136e0cda8a7f6dbbc809c0644f06a601bddf5b38a395"
+metafile = true
+
+[[files]]
+file = "mods/createbetterfps.pw.toml"
+hash = "f54ff443e8b460c15c32ec45b84d49a62a33a4f652f2eaa613d3bc9c2a67f469"
 metafile = true
 
 [[files]]
@@ -654,6 +669,11 @@ hash = "f83b253ca6a8e6f2f847952704da0e1fb00e65cbb10b7c9cb15d1a1780618da0"
 metafile = true
 
 [[files]]
+file = "mods/particle-core.pw.toml"
+hash = "cc71ab4296fffdfca0a373adba4c7721ccad228f305fda8566507063de65e40e"
+metafile = true
+
+[[files]]
 file = "mods/particle-rain.pw.toml"
 hash = "0345711933e73891f8e1a7cff32ed0f9cef39ddee0b10e267736743f02fa4a00"
 metafile = true
@@ -691,6 +711,11 @@ metafile = true
 [[files]]
 file = "mods/puzzles-lib.pw.toml"
 hash = "4dd7038889da90e145f9d074bec64a61aaae12dc57c875aa7ad99b8b2e07979b"
+metafile = true
+
+[[files]]
+file = "mods/radium-re-reforged.pw.toml"
+hash = "b2dc6daa1c257d6adc9b42ffd07e9a3cdffe2fd6b9ea2b169023c38387073287"
 metafile = true
 
 [[files]]
@@ -821,6 +846,11 @@ metafile = true
 [[files]]
 file = "mods/the-hordes.pw.toml"
 hash = "ef4dabd18fc684f656126d1e77895e50f0789993a055a5a08e810225512dd0ba"
+metafile = true
+
+[[files]]
+file = "mods/thulium.pw.toml"
+hash = "ca5aeddfbce3bf46a9bab9ffa7b9c75fe4e6c2ab7c2e9498527d043ac687437b"
 metafile = true
 
 [[files]]

--- a/mods/colorwheel.pw.toml
+++ b/mods/colorwheel.pw.toml
@@ -1,0 +1,13 @@
+name = "Colorwheel"
+filename = "colorwheel-forge-1.2.9+mc1.20.1.jar"
+side = "client"
+
+[download]
+url = "https://cdn.modrinth.com/data/BzHgFoGz/versions/eveWpY7P/colorwheel-forge-1.2.9%2Bmc1.20.1.jar"
+hash-format = "sha512"
+hash = "53a7b955b747817855b3f8b26a5487fa60449610087ad98cf741013f1d5850a3d57ad75a0a2bbc25198dca9e61d6b6510d020cfe2605e79dc4c08d858cc6e9d4"
+
+[update]
+[update.modrinth]
+mod-id = "BzHgFoGz"
+version = "eveWpY7P"

--- a/mods/concurent-chunk-management-engine-forge.pw.toml
+++ b/mods/concurent-chunk-management-engine-forge.pw.toml
@@ -1,0 +1,13 @@
+name = "Concurent Chunk Management Engine - Forge"
+filename = "c2meforge-0.2.0-forge.4-all.jar"
+side = "both"
+
+[download]
+hash-format = "sha1"
+hash = "4aacc52528c4548de216814e34d95d9683c86888"
+mode = "metadata:curseforge"
+
+[update]
+[update.curseforge]
+file-id = 8689384
+project-id = 1610389

--- a/mods/createbetterfps.pw.toml
+++ b/mods/createbetterfps.pw.toml
@@ -1,0 +1,13 @@
+name = "CreateBetterFps"
+filename = "createbetterfps-1.20.1-1.1.2.jar"
+side = "client"
+
+[download]
+url = "https://cdn.modrinth.com/data/lMYIHZNH/versions/75GMC9GD/createbetterfps-1.20.1-1.1.2.jar"
+hash-format = "sha512"
+hash = "44ce50b3180f76e383c3d7f2ef96dfe62168b2e9a95b78c65e1d835f477ca7cd307ac2a05486ddf728739061d089ae158bf794826cbae7d20253b701f1c17020"
+
+[update]
+[update.modrinth]
+mod-id = "lMYIHZNH"
+version = "75GMC9GD"

--- a/mods/particle-core.pw.toml
+++ b/mods/particle-core.pw.toml
@@ -1,0 +1,13 @@
+name = "Particle Core"
+filename = "particle_core-0.3.3+1.20.1+forge.jar"
+side = "client"
+
+[download]
+url = "https://cdn.modrinth.com/data/RSeLon5O/versions/cFafZfyr/particle_core-0.3.3%2B1.20.1%2Bforge.jar"
+hash-format = "sha512"
+hash = "46694c2525b1e14b20ec6043ce9f7e7b92b9fe3a7d55c995951ec54d7acecf1c1a8a674d829efb42e6d1d9c7b0a29fd0edc834a876fb5a85ad90f35b932748ff"
+
+[update]
+[update.modrinth]
+mod-id = "RSeLon5O"
+version = "cFafZfyr"

--- a/mods/radium-re-reforged.pw.toml
+++ b/mods/radium-re-reforged.pw.toml
@@ -1,0 +1,13 @@
+name = "Radium Re-Reforged"
+filename = "radium-mc1.20.1-0.14.1+git.54e0012.jar"
+side = "both"
+
+[download]
+hash-format = "sha1"
+hash = "b418b5fa7140342c068e3e015755d7c84056e36a"
+mode = "metadata:curseforge"
+
+[update]
+[update.curseforge]
+file-id = 8637449
+project-id = 1649038

--- a/mods/thulium.pw.toml
+++ b/mods/thulium.pw.toml
@@ -1,0 +1,18 @@
+name = "Thulium"
+filename = "thulium-1.0.5.jar"
+# CLIENT. Its own META-INF/mods.toml declares clientSideOnly=true -- read from
+# the jar, not inferred from the name. packwiz defaults a CurseForge add to
+# "both"; left alone this would put a client-only jar in the server pack.
+# The opposite mistake is the one that cost us #88, so the classification is
+# recorded here with its evidence either way.
+side = "client"
+
+[download]
+hash-format = "sha1"
+hash = "f5153f1fa4fc2f5167a7b82e19a1f96ddc2738b2"
+mode = "metadata:curseforge"
+
+[update]
+[update.curseforge]
+file-id = 8406011
+project-id = 1462886

--- a/pack.toml
+++ b/pack.toml
@@ -1,12 +1,12 @@
 name = "Industrial Civilization Survival"
 author = "xenodeve"
-version = "0.2.0-alpha"
+version = "0.2.1-alpha"
 pack-format = "packwiz:1.1.0"
 
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "d304d8cb8485addaa86ea0d4311ec4fed3936f67aa6be79040aa5571c2aded6b"
+hash = "42935f8c08d89c4602c22ca919ed2db7ab3ba4f1021ab73dc58cce9d0181315a"
 
 [versions]
 forge = "47.4.23"


### PR DESCRIPTION
## Decision

The developer lifts **`PERF-FREEZE`** and instructs that **all six** candidates from #127 go in —
no staged phases — and that the pack ships as **v0.2.1**.

**Said plainly because the freeze was the developer's own instruction** (*"ให้ freeze performance
mod additions ตรงนี้เลย"*). It is being lifted by the person who set it, for a named set. The
environment work (GPU binding, distances, heap) is deferred by the same instruction and stays open
in the ledger.

Roster **120 → 126**.

## Verified before installing, not after

Every jar downloaded and hashed against what the host publishes; every `META-INF/mods.toml` read.

| Mod | Version | Bytes | Licence | Side | Hash checked against |
|---|---|---|---|---|---|
| Colorwheel | `1.2.9+mc1.20.1` | 1,028,327 | MIT | `client` | Modrinth sha512 |
| CreateBetterFps | `1.1.2` | 25,214 | MIT | `client` | Modrinth sha512 |
| Particle Core | `0.3.3+1.20.1+forge` | 773,448 | MIT | `client` | Modrinth sha512 |
| Radium Re-Reforged | `0.14.1+git.54e0012` | 735,401 | LGPL-3.0-only | `both` | CurseForge sha1 |
| Thulium | `1.0.5` | 23,691 | MIT | `client` | CurseForge sha1 |
| C2ME for Forge | `0.2.0-forge.4` | 1,176,948 | MIT | `both` | CurseForge sha1 |

**Every mandatory dependency was already in the roster.** Colorwheel needs `oculus [1.7.0,)` (have
1.8.0); CreateBetterFps needs `oculus [1.8.0,)` and `embeddium [0.3.31-beta.53,)`; Particle Core
needs `kotlinforforge [4.11.0,4.99.0]` (have 4.12.0) and `fzzy_config [0.7.5,)` (have 0.7.6).
Nothing extra had to be added — 120 → 126, not 120 → 130.

**Sides, with the reason written down** (`docs/side-classification.md`). Thulium declares
`clientSideOnly = true`; packwiz had defaulted it to `both`, which would have shipped a client-only
jar into the server pack. Colorwheel, CreateBetterFps and Particle Core declare no such flag, so
each carries a checkable fact instead — Colorwheel makes `oculus` **mandatory** and Oculus is
already `client` here; the other two declare **every** dependency as `side = "CLIENT"`. Radium and
C2ME are **`both`**, deliberately: they change logic the integrated server runs, and #88 is the
standing reminder that singleplayer *is* a server.

**Read back from the artifacts, not from the build log.** The four client mods are present in the
instance zip and **absent from the server zip**; Radium and C2ME are in both.

## The #107 trap, checked properly this time

**Radium declares `provides = ["lithium"]`.** That is the exact shape that killed the client in
#107: a mod declaring `provides` activates compatibility code in mods that never name it, and a
`mods.toml` grep cannot see it.

**My first scan said "nothing references lithium" and my first scan was broken.** Its control case —
ImmediatelyFast 1.5.5, which this session already proved references `net.coderbot.iris` — returned
zero. Two bugs: `unzip -p jar '*.class'` does not match nested entries, and `Class.forName()` stores
a **dotted** name in the constant pool while I searched the slashed form. A detector that cannot
find a known positive is not evidence of absence.

The fixed scanner (validated against that control, and recursing into JarJar'd jars) found **five**
real references:

| Mod | What it actually does with `lithium` |
|---|---|
| **FerriteCore** | probes for the class `me.jellysquid.mods.lithium.common.LithiumMod` and **disables its own `lithiumCompat` mixins** when present. **Radium contains that exact class** (711 lithium entries) — checked. So FerriteCore will stand down some of its work. Graceful, by design, and now measured rather than assumed |
| **ModernFix** | `lithium` appears in `ModernFixEarlyConfig` — its mixin auto-disable list |
| **C2ME** | ships a `LithiumFamily` class to detect and stand down against lithium-family mods |
| **Cupboard** | one config option is documented *"incompatible with lithium and its forks"* — its **default is `false`** and this pack ships **no cupboard config**, so the default applies |
| Dynamic FPS | false positive: `lithium-ion` battery strings in a bundled library |

**No `Class.forName` + swallow + `System.exit` shape anywhere** — that was #107's mechanism. What
this batch triggers is graceful degradation, not a crash path.

## Risk, stated rather than buried

**C2ME is the riskiest thing in this change.** It is an **alpha** build of a mod that rewrites chunk
generation, loading and I/O, going into a pack with Biomes O' Plenty, Regions Unexplored,
TerraBlender and Ice and Fire. The analysis that proposed it called it *exploration only* and said
it was not the answer to the reported symptom. It is in because the instruction was all six. **If
worlds start behaving strangely, remove this one first** — that sentence is in the changelog too.

**Nothing was tested one at a time.** The proposing analysis recommended against it in its own
words, and #98 is the same lesson from this repo. If FPS improves, which of the six did it will not
be known; if something breaks, which one broke it will not be known. With no baseline and
`C-UPFG-07` unresolved there is nothing measurable to lose *today* — it is lost later, when someone
asks whether Thulium earned its place.

## Acceptance criteria

- [ ] Six metafiles pinned, correct sides, reasons written
- [ ] `verify` green at **126 mods**
- [ ] Licence rows in both copies of `docs/distribution-licenses.md`
- [ ] `MODLIST.md` regenerated and agreeing with `mods/`
- [ ] `pack.toml` at `0.2.1-alpha`, CHANGELOG entry present
- [ ] All artifacts rebuilt, checksums regenerated, side split verified by reading the archives
- [ ] **Nothing launched, nothing measured, and the report says so**

## Out of scope

The GPU binding, `simulationDistance`/`renderDistance`, heap — deferred by instruction, still open.
`C9` and `C10`'s open question, unchanged.

---

## สรุปภาษาไทย

### การตัดสินใจ

ผู้พัฒนายกเลิก **`PERF-FREEZE`** และสั่งให้เอา candidate จาก #127 เข้า **ครบทั้งหกตัว** ไม่แบ่งเฟส
และให้ออกแพ็คเป็น **v0.2.1**

**เขียนตรง ๆ เพราะ freeze เป็นคำสั่งของผู้พัฒนาเอง** (*"ให้ freeze performance mod additions ตรงนี้เลย"*)
คนที่ยกเลิกคือคนที่ตั้งมันขึ้นมา สำหรับชุดที่ระบุชื่อไว้ ส่วนงานฝั่ง environment (GPU binding, ระยะ, heap)
เลื่อนตามคำสั่งเดียวกันและยังค้างอยู่ใน ledger

roster **120 → 126**

### ตรวจก่อนลง ไม่ใช่ลงแล้วค่อยตรวจ

โหลด jar ทุกตัวมาเทียบ hash กับที่ต้นทางประกาศ และอ่าน `META-INF/mods.toml` ทุกไฟล์

| มอด | เวอร์ชัน | ไบต์ | สัญญาอนุญาต | Side | เทียบ hash กับ |
|---|---|---|---|---|---|
| Colorwheel | `1.2.9+mc1.20.1` | 1,028,327 | MIT | `client` | sha512 ของ Modrinth |
| CreateBetterFps | `1.1.2` | 25,214 | MIT | `client` | sha512 ของ Modrinth |
| Particle Core | `0.3.3+1.20.1+forge` | 773,448 | MIT | `client` | sha512 ของ Modrinth |
| Radium Re-Reforged | `0.14.1+git.54e0012` | 735,401 | LGPL-3.0-only | `both` | sha1 ของ CurseForge |
| Thulium | `1.0.5` | 23,691 | MIT | `client` | sha1 ของ CurseForge |
| C2ME for Forge | `0.2.0-forge.4` | 1,176,948 | MIT | `both` | sha1 ของ CurseForge |

**dependency บังคับทุกตัวมีอยู่ใน roster แล้ว** Colorwheel ต้องมี `oculus [1.7.0,)` (เรามี 1.8.0),
CreateBetterFps ต้องมี `oculus [1.8.0,)` กับ `embeddium [0.3.31-beta.53,)`, Particle Core ต้องมี
`kotlinforforge [4.11.0,4.99.0]` (เรามี 4.12.0) กับ `fzzy_config [0.7.5,)` (เรามี 0.7.6)
ไม่ต้องเพิ่มอะไรมาเสริมเลย 120 → 126 ไม่ใช่ 120 → 130

**side พร้อมเหตุผลที่เขียนไว้** (`docs/side-classification.md`) Thulium ประกาศ `clientSideOnly = true`
แต่ packwiz ตั้งให้เป็น `both` ซึ่งจะทำให้ jar ฝั่ง client หลุดเข้าไปใน server pack
ส่วน Colorwheel, CreateBetterFps และ Particle Core ไม่ได้ประกาศ flag นั้น แต่ละตัวจึงมีข้อเท็จจริง
ที่ตรวจได้แทน — Colorwheel บังคับ `oculus` ซึ่งเป็น `client` อยู่แล้วในแพ็คนี้ ส่วนอีกสองตัว
ประกาศ dependency **ทุกตัว** เป็น `side = "CLIENT"` ส่วน Radium กับ C2ME เป็น **`both`** โดยตั้งใจ
เพราะทั้งคู่แก้ logic ที่ integrated server รัน และ #88 คือเครื่องเตือนว่า singleplayer **คือ** server

**อ่านกลับมาจาก artifact ไม่ใช่จาก log ของ build** มอดฝั่ง client สี่ตัวอยู่ใน instance zip
และ **ไม่อยู่ใน server zip** ส่วน Radium กับ C2ME อยู่ทั้งสองที่

### กับดักแบบ #107 รอบนี้ตรวจให้ถูกวิธี

**Radium ประกาศ `provides = ["lithium"]`** นั่นคือรูปแบบเดียวกับที่ทำให้ client ตายใน #107:
มอดที่ประกาศ `provides` จะไปปลุกโค้ด compatibility ในมอดที่ไม่เคยเอ่ยชื่อมันเลย และการ grep `mods.toml`
มองไม่เห็น

**สแกนรอบแรกของผมบอกว่า "ไม่มีอะไรอ้างถึง lithium" และสแกนรอบแรกของผมพัง** control case คือ
ImmediatelyFast 1.5.5 ซึ่ง session นี้พิสูจน์ไปแล้วว่าอ้างถึง `net.coderbot.iris` กลับได้ศูนย์
มีบั๊กสองจุด: `unzip -p jar '*.class'` ไม่ match entry ที่ซ้อนอยู่ และ `Class.forName()`
เก็บชื่อแบบ **มีจุด** ใน constant pool ขณะที่ผมค้นแบบมี slash **detector ที่หา positive ที่รู้ว่ามีไม่เจอ
ไม่ใช่หลักฐานว่าไม่มี**

สแกนที่แก้แล้ว (ผ่าน control และไล่เข้า jar ที่ซ้อนอยู่) เจอของจริง **ห้าจุด**:

| มอด | มันทำอะไรกับ `lithium` จริง ๆ |
|---|---|
| **FerriteCore** | ตรวจหาคลาส `me.jellysquid.mods.lithium.common.LithiumMod` แล้ว **ปิด mixin ส่วน `lithiumCompat` ของตัวเอง** ถ้าเจอ **และ Radium มีคลาสนั้นอยู่จริง** (711 entry ที่เกี่ยวกับ lithium) — ตรวจแล้ว แปลว่า FerriteCore จะถอยงานบางส่วน เป็นการถอยอย่างนุ่มนวลตามที่ออกแบบไว้ และตอนนี้วัดได้แล้ว ไม่ใช่การเดา |
| **ModernFix** | `lithium` อยู่ใน `ModernFixEarlyConfig` ซึ่งเป็นลิสต์ปิด mixin อัตโนมัติ |
| **C2ME** | มีคลาส `LithiumFamily` ไว้ตรวจจับและถอยให้มอดตระกูล lithium |
| **Cupboard** | มี config ตัวหนึ่งเขียนกำกับว่า *"incompatible with lithium and its forks"* ค่า **default เป็น `false`** และแพ็คนี้ **ไม่ได้ส่ง config ของ cupboard ไปเลย** ค่า default จึงมีผล |
| Dynamic FPS | false positive: เป็นสตริง `lithium-ion` ของไลบรารีแบตเตอรี่ที่แถมมา |

**ไม่มีรูปแบบ `Class.forName` + กลืน exception + `System.exit` ที่ไหนเลย** ซึ่งคือกลไกของ #107
สิ่งที่ชุดนี้ไปกระตุ้นคือการถอยอย่างนุ่มนวล ไม่ใช่เส้นทางที่ทำให้ crash

### ความเสี่ยง พูดออกมา ไม่กลบ

**C2ME คือสิ่งที่เสี่ยงที่สุดในการเปลี่ยนแปลงครั้งนี้** มันเป็น build ระดับ **alpha** ของมอดที่เขียนใหม่
เรื่องการสร้าง โหลด และเขียนอ่าน chunk แล้วเอาไปใส่ในแพ็คที่มี Biomes O' Plenty, Regions Unexplored,
TerraBlender และ Ice and Fire บทวิเคราะห์ที่เสนอมันเองเรียกมันว่า *exploration only* และบอกว่า
มันไม่ใช่คำตอบของอาการที่รายงานมา มันเข้ามาเพราะคำสั่งคือเอาทั้งหกตัว **ถ้าโลกเริ่มมีอาการแปลก ๆ
ให้ถอดตัวนี้ออกก่อน** ประโยคนี้อยู่ใน changelog ด้วย

**ไม่มีการทดสอบทีละตัวเลย** บทวิเคราะห์ที่เสนอเองก็แนะนำไม่ให้ทำแบบนี้ และ #98 คือบทเรียนเดียวกัน
ของ repo นี้ ถ้า FPS ดีขึ้นจะไม่รู้ว่าตัวไหนทำ ถ้าพังก็จะไม่รู้ว่าตัวไหนพัง ในเมื่อยังไม่มี baseline
และ `C-UPFG-07` ยังไม่ถูกแก้ **วันนี้** จึงยังไม่เสียอะไรที่วัดได้ ที่จะเสียคือตอนหลัง
ตอนที่มีคนถามว่า Thulium คุ้มที่จะอยู่ในแพ็คไหม

### เกณฑ์การปิดงาน

- [ ] metafile หกไฟล์ pin ไว้ side ถูก มีเหตุผลเขียนกำกับ
- [ ] `verify` เขียวที่ **126 มอด**
- [ ] มีแถวสัญญาอนุญาตใน `docs/distribution-licenses.md` ทั้งสองชุด
- [ ] สร้าง `MODLIST.md` ใหม่และตรงกับ `mods/`
- [ ] `pack.toml` เป็น `0.2.1-alpha` และมี entry ใน CHANGELOG
- [ ] build artifact ใหม่ทุกตัว สร้าง checksum ใหม่ และตรวจการแยก side ด้วยการอ่าน zip
- [ ] **ยังไม่ได้เปิดเกม ยังไม่มีอะไรถูกวัด และรายงานต้องเขียนแบบนั้น**

### นอกขอบเขต

GPU binding, `simulationDistance`/`renderDistance`, heap — เลื่อนตามคำสั่ง ยังค้างอยู่
ส่วน `C9` และคำถามค้างของ `C10` ไม่เปลี่ยน
