### PR TITLE
feat(perf): add Noisium and ship v0.2.2-alpha (#131)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,28 @@ no entry, no tag, and is never handed to a friend as if it were a release.
 
 ---
 
+## v0.2.2-alpha — pre-release, 2026-08-28
+
+**Still a pre-release and still untested in game.** Nothing in v0.2.1 or v0.2.2 has been launched.
+
+### Added
+
+- **Noisium** — speeds up the world-generation maths itself. It pairs with C2ME rather than
+  overlapping it: C2ME spreads chunk work across CPU cores, Noisium makes the work inside each of
+  those threads cheaper. Its upstream repository was archived in 2025, so this is a final build for
+  1.20.1 rather than a mod still being developed — which is fine for a pack pinned to 1.20.1.
+
+### Known issues
+
+- **C2ME's own page says it is not fully tested with Radium**, and v0.2.1 shipped both. If a world
+  generates wrongly, corrupts, freezes or lights strangely, remove **C2ME** first and **Radium**
+  second. Tracked as `C11` / #131.
+- **Do not hold a gun with shaders on for long** — a vertex buffer grows until the client runs out
+  of memory, about a minute in testing. `C9` / #117.
+- Frame generation is not available in the optional Super Resolution add-on (#119).
+
+---
+
 ## v0.2.1-alpha — pre-release, 2026-08-28
 
 **Still a pre-release, and still untested in game.** The twelve-test gate in *Distribution Spec §16*

--- a/docs/MODLIST.md
+++ b/docs/MODLIST.md
@@ -1,12 +1,12 @@
-<!-- roster-digest: 06a7973a9720658dc83ae1af834b0b15a5af774d7886930e83f71c5529b01114 -->
-<!-- mod-count: 126 -->
+<!-- roster-digest: 9211eeeb8e6fa99d824ef5835b4cfb96ede032f637e1ac4922ed770c48801b46 -->
+<!-- mod-count: 127 -->
 <!-- GENERATED FILE — do not edit by hand.
      Run: node scripts/build/generate-modlist.mjs
      `verify` refuses a roster that disagrees with mods/. -->
 
 # What is in this pack · ในแพ็กนี้มีอะไรบ้าง
 
-**Industrial Civilization Survival 0.2.0-alpha** — **126 mods** on Minecraft `1.20.1`,
+**Industrial Civilization Survival 0.2.2-alpha** — **127 mods** on Minecraft `1.20.1`,
 Forge `47.4.23`.
 
 Every mod here is somebody else's work. This file exists so you can see whose, and go and find
@@ -14,17 +14,17 @@ the original.
 
 **Where you will find this file.** It ships at the top of the client instance zip and at the top of
 the server zip. The CurseForge-format zip instead carries packwiz's own `modlist.html`, which lists
-125 names — the client-side set — with no versions, sides or links. This
+126 names — the client-side set — with no versions, sides or links. This
 file is the complete one.
 
 **ไฟล์นี้อยู่ตรงไหน** มันอยู่บนสุดของ zip ตัว client instance และบนสุดของ zip ตัว server
-ส่วน zip รูปแบบ CurseForge จะมี `modlist.html` ของ packwiz เองแทน ซึ่งลงชื่อไว้ 125 ชื่อ —
+ส่วน zip รูปแบบ CurseForge จะมี `modlist.html` ของ packwiz เองแทน ซึ่งลงชื่อไว้ 126 ชื่อ —
 ชุดฝั่ง client — โดยไม่มีเวอร์ชัน ไม่มี side ไม่มีลิงก์ ไฟล์นี้คือตัวที่ครบ
 
 ## Reading the table
 
 **The File column is the exact jar filename**, not a tidied-up version number. That is deliberate:
-126 mods use 126 filename conventions, and parsing a version out of them would mean
+127 mods use 127 filename conventions, and parsing a version out of them would mean
 guessing. The
 filename is what is actually on your disk, so it is also what you can match against your `mods/`
 folder when something goes wrong.
@@ -35,20 +35,20 @@ mod's name — twice now, a guessed slug in this repo has pointed at the wrong p
 at a modpack rather than the mod.
 
 **Client / Server** tells you where a mod runs. If you are hosting a server, you need the
-97 in *Both* and the 1 in *Server only*; the 28 client-only
+98 in *Both* and the 1 in *Server only*; the 28 client-only
 mods are not installed on a server and are not missing when they are absent.
 
 ## อ่านตารางยังไง
 
-**คอลัมน์ File คือชื่อไฟล์ jar จริง ๆ** ไม่ใช่เลขเวอร์ชันที่จัดให้สวย ตั้งใจให้เป็นแบบนั้น เพราะมอด 126 ตัว
-ใช้รูปแบบการตั้งชื่อไฟล์ 126 แบบ การพยายามแกะเวอร์ชันออกมาคือการเดา ชื่อไฟล์คือสิ่งที่อยู่บนเครื่องคุณจริง ๆ
+**คอลัมน์ File คือชื่อไฟล์ jar จริง ๆ** ไม่ใช่เลขเวอร์ชันที่จัดให้สวย ตั้งใจให้เป็นแบบนั้น เพราะมอด 127 ตัว
+ใช้รูปแบบการตั้งชื่อไฟล์ 127 แบบ การพยายามแกะเวอร์ชันออกมาคือการเดา ชื่อไฟล์คือสิ่งที่อยู่บนเครื่องคุณจริง ๆ
 ดังนั้นมันจึงเป็นสิ่งที่คุณเอาไปเทียบกับโฟลเดอร์ `mods/` ได้ตอนมีอะไรผิดพลาด
 
 **ลิงก์ต้นทาง resolve มา ไม่ได้เดา** packwiz บันทึก project *id* ไว้ ไม่เคยบันทึก slug
 สคริปต์นี้จึงตาม id ไปจนถึงหน้าที่มันไปจบแล้วลิงก์หน้านั้น มันไม่ประกอบ URL ขึ้นจากชื่อมอดเด็ดขาด —
 สอง​ครั้งแล้วที่ slug ที่เดาใน repo นี้ชี้ไปผิดโปรเจกต์ ครั้งหนึ่งชี้ไปที่ modpack แทนที่จะเป็นตัวมอด
 
-**Client / Server** บอกว่ามอดตัวนั้นทำงานฝั่งไหน ถ้าคุณจะเปิด server คุณต้องใช้ 97 ตัวใน *Both*
+**Client / Server** บอกว่ามอดตัวนั้นทำงานฝั่งไหน ถ้าคุณจะเปิด server คุณต้องใช้ 98 ตัวใน *Both*
 กับ 1 ตัวใน *Server only* ส่วนมอดฝั่ง client 28 ตัวจะไม่ถูกติดตั้งบน server
 และการที่มันไม่อยู่ตรงนั้นไม่ใช่ของหาย
 
@@ -57,7 +57,7 @@ mods are not installed on a server and are not missing when they are absent.
 
 ---
 
-## Both — client and server · ทั้งสองฝั่ง (97)
+## Both — client and server · ทั้งสองฝั่ง (98)
 
 | Mod · มอด | File · ไฟล์ | Source · ต้นทาง |
 |---|---|---|
@@ -129,6 +129,7 @@ mods are not installed on a server and are not missing when they are absent.
 | MrCrayfish's Furniture Mod: Refurbished | `refurbished_furniture-forge-1.20.1-1.0.20.jar` | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/refurbished-furniture) |
 | Multi-Piston | `multipiston-1.20-0.0.47-snapshot.jar` | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/multi-piston) |
 | Naturalist | `naturalist-5.0pre4+forge-1.20.1.jar` | [Modrinth](https://modrinth.com/mod/naturalist) |
+| Noisium | `noisium-forge-2.3.0+mc1.20-1.20.1.jar` | [Modrinth](https://modrinth.com/mod/noisium) |
 | Placebo | `Placebo-1.20.1-8.6.3.jar` | [Modrinth](https://modrinth.com/mod/placebo) |
 | Player Microchip (Tracker) | `player_tracking_chip-1.0.2-forge-1.20.1.jar` | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/player-microchip) |
 | playerAnimator | `player-animation-lib-forge-1.0.2-rc1+1.20.jar` | [Modrinth](https://modrinth.com/mod/playeranimator) |

--- a/docs/distribution-licenses.md
+++ b/docs/distribution-licenses.md
@@ -147,7 +147,7 @@ to rely on something other than a written grant.
 modpacks on a bullet reading `- Large Modpacks`. In context that sits under a **Performance**
 heading and describes what the mod is suitable for, not what you may do with it. It is silent.
 
-## Permissively licensed — 71 mods
+## Permissively licensed — 72 mods
 
 Redistribution is granted by the licence text itself. GPL/LGPL/MPL additionally require that the
 licence and source remain available; shipping the jars unmodified with `docs/MODLIST.md` linking
@@ -200,6 +200,7 @@ been modified.
 | ModernFix | [Modrinth](https://modrinth.com/mod/modernfix) | GNU Lesser General Public License v3.0 only | Modrinth API |
 | Mouse Tweaks | [Modrinth](https://modrinth.com/mod/mouse-tweaks) | BSD 3 Clause "New" or "Revised" License | Modrinth API |
 | Multi-Piston | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/multi-piston) | GNU General Public License version 3 (GPLv3) | project page |
+| Noisium | [Modrinth](https://modrinth.com/mod/noisium) | GNU Lesser General Public License v3.0 | jar `META-INF/mods.toml` |
 | Particle Core | [Modrinth](https://modrinth.com/mod/particle-core) | MIT License | jar `META-INF/mods.toml` |
 | Placebo | [Modrinth](https://modrinth.com/mod/placebo) | MIT License | Modrinth API |
 | playerAnimator | [Modrinth](https://modrinth.com/mod/playeranimator) | MIT License | Modrinth API |
@@ -507,6 +508,7 @@ player-microchip      1488872   IN MANIFEST
 | ModernFix | [Modrinth](https://modrinth.com/mod/modernfix) | GNU Lesser General Public License v3.0 only | Modrinth API |
 | Mouse Tweaks | [Modrinth](https://modrinth.com/mod/mouse-tweaks) | BSD 3 Clause "New" or "Revised" License | Modrinth API |
 | Multi-Piston | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/multi-piston) | GNU General Public License version 3 (GPLv3) | project page |
+| Noisium | [Modrinth](https://modrinth.com/mod/noisium) | GNU Lesser General Public License v3.0 | jar `META-INF/mods.toml` |
 | Particle Core | [Modrinth](https://modrinth.com/mod/particle-core) | MIT License | jar `META-INF/mods.toml` |
 | Placebo | [Modrinth](https://modrinth.com/mod/placebo) | MIT License | Modrinth API |
 | playerAnimator | [Modrinth](https://modrinth.com/mod/playeranimator) | MIT License | Modrinth API |

--- a/docs/performance-conflicts.md
+++ b/docs/performance-conflicts.md
@@ -394,10 +394,50 @@ until the GPU binding is fixed.
 
 ---
 
+## C11 — C2ME says it is not fully tested with Radium, and we shipped them together
+
+**Status: LIVE in v0.2.1-alpha. Stated by the mod's own author, not inferred. Issue #131.**
+
+C2ME for Forge's Modrinth page says, of its own mod:
+
+> *"And it's not fully tested with **Radium** (**Canary** is not recommended) and **Starlight**."*
+
+**Both halves of that pairing are in the pack as of v0.2.1-alpha**, added in the same change (#129),
+and **neither has been launched.** This is not a reason to pull either one — "not fully tested" is a
+caveat, not a defect — but it is the first thing to reach for if worlds, chunks or lighting behave
+strangely, and it should have been read before shipping rather than after.
+
+**What it changes about the order of suspicion.** If a world corrupts, generates wrongly, deadlocks
+or lights incorrectly: remove **C2ME** first, then **Radium**. Both are `side = "both"`, so both are
+in singleplayer too.
+
+**Two rules that follow, and they are hard.**
+
+- **Canary must never be installed.** C2ME says *not recommended*; Radium's own Modrinth entry
+  declares Canary **incompatible**; and Canary and Radium are both Lithium ports doing the same job.
+- **Starlight stays out for now** — same sentence names it, and adding a light-engine rewrite
+  alongside two untested-together chunk mods would make any resulting bug unattributable.
+  Recorded below as HOLD, not rejected.
+
+**Not known.** Whether the pairing is actually fine. Nobody has launched it.
+
+---
+
 ## DISCOVERED candidates — recorded, not installed
 
-`PERF-LIFECYCLE` state **DISCOVERED**. None has been run by anyone here. Metadata verified from the
-Modrinth API at the time of writing (#127) rather than recalled.
+**Six of these were INSTALLED in v0.2.1-alpha (#129) and are no longer candidates** — Colorwheel,
+CreateBetterFps, Particle Core, Radium Re-Reforged, Thulium and C2ME-Forge. Noisium was added in
+v0.2.2-alpha (#131). What remains below is what is still **not** in the pack.
+
+| Mod | State | Why |
+|---|---|---|
+| **Starlight (Forge)** `1.1.2+1.20` | **HOLD** | a light-engine rewrite, built 2023-07-08, and `C11` records C2ME naming it as untested alongside itself. Revisit only if profiling shows lighting is a hotspot — the goal is the CPU-bound frame time, not collecting performance mods |
+| **Memory Leak Fix** `v1.1.5` | **REJECTED** | AllTheLeaks `1.1.1` already occupies this role and is newer. Two mods patching the same vanilla methods is the shape that produced `C8`/#107 |
+| **Exordium** | **IMPOSSIBLE** | **no Forge 1.20.1 build exists.** The project page lists forge and 1.20.1 because that metadata is a union across all versions; checked per file, its nearest Forge builds are for 1.21.8 and 1.21.10 |
+| **Canary** | **FORBIDDEN** | see `C11`. Radium is already installed and the two are the same Lithium port |
+| **Rubidium** | **FORBIDDEN** | Embeddium is its maintained fork and already `provides` the `rubidium` id |
+
+The original DISCOVERED metadata, verified from the Modrinth API at the time of writing (#127):
 
 | Mod | Forge 1.20.1 | Published | Licence | Downloads | Declared relationships |
 |---|---|---|---|---|---|

--- a/index.toml
+++ b/index.toml
@@ -659,6 +659,11 @@ hash = "2674d6bbb1172447732119051e0621f0c8619bf63f4dfaa1ff81afd98f019a5e"
 metafile = true
 
 [[files]]
+file = "mods/noisium.pw.toml"
+hash = "16b69e87f9a9a3622970f7fd902a9ef4204106bd30b0623046be9da72e809b64"
+metafile = true
+
+[[files]]
 file = "mods/not-enough-animations.pw.toml"
 hash = "1c3d52224f1f174fbcf2c308a70e3c34a736694b626992891404db32cbd69c7e"
 metafile = true

--- a/mods/noisium.pw.toml
+++ b/mods/noisium.pw.toml
@@ -1,0 +1,20 @@
+name = "Noisium"
+filename = "noisium-forge-2.3.0+mc1.20-1.20.1.jar"
+# BOTH, and packwiz got this wrong. It derived "server" from Modrinth's project
+# metadata, which marks Noisium client:unsupported because worldgen is server
+# work. THAT IS THE #88 BUG EXACTLY: side = "server" removes a mod from every
+# CLIENT artifact, and singleplayer runs an integrated server -- so the mod
+# would be missing from the only place most of this group actually plays.
+# In Control cost us that once; a worldgen optimiser would cost it again, and
+# more quietly, because nothing crashes when worldgen is merely slower.
+side = "both"
+
+[download]
+url = "https://cdn.modrinth.com/data/KuNKN7d2/versions/gbYUKrDP/noisium-forge-2.3.0%2Bmc1.20-1.20.1.jar"
+hash-format = "sha512"
+hash = "5bc43bc1b748edcd63d074a8bb14d393d986c51e1933e1f38cd7a2dd2fd70dba5a46a6415f46d4a52c68e7e1e9ce101e54376ad04273df958608e2fdb43db502"
+
+[update]
+[update.modrinth]
+mod-id = "KuNKN7d2"
+version = "gbYUKrDP"

--- a/pack.toml
+++ b/pack.toml
@@ -1,12 +1,12 @@
 name = "Industrial Civilization Survival"
 author = "xenodeve"
-version = "0.2.1-alpha"
+version = "0.2.2-alpha"
 pack-format = "packwiz:1.1.0"
 
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "42935f8c08d89c4602c22ca919ed2db7ab3ba4f1021ab73dc58cce9d0181315a"
+hash = "b94ff2060134651f662562625f08bdcff84d3f84a4ca5f6bc5d92c87f4e549d6"
 
 [versions]
 forge = "47.4.23"


### PR DESCRIPTION
## Decision

From the *Forge Performance* Modrinth collection: **add Noisium `2.3.0` only.** Starlight is on
**HOLD**, Memory Leak Fix is **REJECTED**, and two entries in that collection are now **forbidden**
outright. Ships as **v0.2.2-alpha**. Roster 126 → 127.

## Noisium, and why it is not a duplicate of C2ME

They optimise different halves of the same job, and the upstream README says so: **C2ME spreads
chunk work across CPU cores; Noisium makes the work inside each of those threads cheaper.**

```
Chunky      pregeneration
C2ME        concurrent chunk generation · I/O · scheduling
Noisium     the worldgen computation inside each generation thread
```

`2.3.0+mc1.20-1.20.1`, 218,152 bytes, LGPL-3.0, sha512 `5bc43bc1b748edcd…` — downloaded and checked
against Modrinth's published hash. Six Forge 1.20.1 builds exist; this is the newest. No runtime
dependency beyond Minecraft.

**Its upstream is archived, and that is stated rather than discovered later.**
`github.com/Steveplays28/noisium` returns `archived: true`, last pushed 2025-07-29, 148 stars. This
is a final build for 1.20.1, not a mod still under development. For a pack pinned to 1.20.1 that is
a fact to record, not a reason to reject.

## `side` was wrong, and it was wrong in exactly the #88 direction

packwiz wrote **`side = "server"`**, derived from Modrinth's project metadata, which marks Noisium
client-unsupported because worldgen is server work.

**`side = "server"` removes a mod from every CLIENT artifact — and singleplayer runs an integrated
server.** That is #88 precisely: In Control was marked server-only and vanished from the only place
this group actually plays. A worldgen optimiser would have gone the same way, and more quietly,
because nothing crashes when worldgen is merely slower.

Corrected to **`both`**, with the reason written into the metafile. Verified by reading the
archives: Noisium is present in the instance zip, the server zip **and** the friend pack.

## `C11` — the finding that matters more than the addition

**C2ME's own Modrinth page says, of itself:**

> *"And it's not fully tested with **Radium** (**Canary** is not recommended) and **Starlight**."*

**Both halves of that pairing shipped in v0.2.1-alpha (#129), in the same change, and neither has
been launched.** That is not a defect — "not fully tested" is a caveat — but it should have been
read before shipping, and it changes the order of suspicion: if a world generates wrongly,
corrupts, deadlocks or lights incorrectly, remove **C2ME** first and **Radium** second. Both are
`side = "both"`, so both are in singleplayer too.

Two hard rules follow, and they are now recorded where the next agent will hit them:

- **Canary must never be installed.** C2ME calls it *not recommended*; Radium's own Modrinth entry
  declares it **incompatible**; and Canary and Radium are the same Lithium port doing the same job.
- **Rubidium must never be installed.** Embeddium is its maintained fork and already `provides` the
  `rubidium` id — verified in the Embeddium jar.

## The rest of the collection, checked per file rather than per project

| Mod | Verdict | Evidence |
|---|---|---|
| **Starlight (Forge)** `1.1.2+1.20` | **HOLD** | a light-engine rewrite, built **2023-07-08**, and named in the same C2ME sentence as untested. Adding it alongside two chunk mods that have never been launched together would make any resulting bug unattributable |
| **Memory Leak Fix** `v1.1.5` | **REJECTED** | AllTheLeaks `1.1.1` already fills this role and is newer (2026 vs 2024). Two mods patching the same vanilla methods is the shape that produced `C8`/#107 |
| **Exordium** | **IMPOSSIBLE** | **zero** Forge 1.20.1 builds. Its project page lists forge and 1.20.1 because that metadata is a **union across all versions**; read per file, its nearest Forge builds target 1.21.8 and 1.21.10 |
| ImmediatelyFast · Dynamic FPS · Entity Culling · BadOptimizations · ModernFix · FerriteCore | already in | — |

**The per-file check is the point.** A project's `loaders` and `game_versions` are the union of
everything it ever shipped, so "supports Forge 1.20.1" on a project page can be true while no such
file exists.

## Acceptance criteria

- [ ] `mods/noisium.pw.toml` pinned, `side = "both"`, reason written in the file
- [ ] `verify` green at **127 mods**
- [ ] Licence row in both copies of `docs/distribution-licenses.md`
- [ ] `C11` recorded; the DISCOVERED table updated to say which six shipped and what is forbidden
- [ ] `pack.toml` at `0.2.2-alpha`, CHANGELOG entry present
- [ ] Artifacts rebuilt, checksums regenerated, **Noisium confirmed present on both sides by reading the archives**
- [ ] **Nothing launched. Nothing measured.**

## Out of scope

Starlight. The GPU binding, distances and heap — still deferred, still open. `C9` and `C10`'s open
question, unchanged.

---

## สรุปภาษาไทย

### การตัดสินใจ

จาก collection *Forge Performance* บน Modrinth: **เอา Noisium `2.3.0` ตัวเดียว** Starlight เป็น
**HOLD** Memory Leak Fix **ไม่เอา** และมีสองตัวใน collection นั้นที่ตอนนี้ **ห้ามลงเด็ดขาด**
ออกเป็น **v0.2.2-alpha** roster 126 → 127

### Noisium และทำไมมันไม่ซ้ำกับ C2ME

สองตัวนี้ optimize คนละครึ่งของงานเดียวกัน และ README ของต้นทางเขียนไว้เอง: **C2ME กระจายงาน chunk
ไปหลายคอร์ ส่วน Noisium ทำให้งานที่อยู่ในแต่ละ thread นั้นถูกลง**

```
Chunky      pregeneration
C2ME        สร้าง chunk พร้อมกันหลายคอร์ · I/O · การจัดคิว
Noisium     การคำนวณ worldgen ภายในแต่ละ thread
```

`2.3.0+mc1.20-1.20.1` 218,152 ไบต์ LGPL-3.0 sha512 `5bc43bc1b748edcd…` — โหลดมาแล้วเทียบกับ hash
ที่ Modrinth ประกาศ มี build ของ Forge 1.20.1 อยู่หกไฟล์ ตัวนี้ใหม่สุด ไม่มี dependency
นอกจาก Minecraft

**repo ต้นทางถูก archive แล้ว และบอกไว้ตรงนี้ ไม่ปล่อยให้ไปเจอทีหลัง**
`github.com/Steveplays28/noisium` ตอบว่า `archived: true` push ล่าสุด 2025-07-29 มี 148 ดาว
นี่คือ build สุดท้ายสำหรับ 1.20.1 ไม่ใช่มอดที่ยังพัฒนาอยู่ สำหรับแพ็คที่ล็อกอยู่ที่ 1.20.1
อันนี้เป็นข้อเท็จจริงที่ต้องจด ไม่ใช่เหตุผลที่จะปฏิเสธ

### `side` ผิด และผิดไปในทิศทางของ #88 พอดี

packwiz เขียนมาว่า **`side = "server"`** ซึ่งมันดึงจาก metadata ของ Modrinth ที่ระบุว่า Noisium
ไม่รองรับฝั่ง client เพราะ worldgen เป็นงานฝั่ง server

**`side = "server"` จะเอามอดออกจาก artifact ฝั่ง client ทุกตัว และ singleplayer รัน integrated
server** นั่นคือ #88 เป๊ะ ๆ: In Control เคยถูกตั้งเป็น server-only แล้วหายไปจากที่เดียวที่กลุ่มนี้
เล่นจริง มอด optimize worldgen ก็จะไปทางเดียวกัน และเงียบกว่าด้วย เพราะไม่มีอะไร crash
เวลาที่ worldgen แค่ช้าลง

แก้เป็น **`both`** พร้อมเขียนเหตุผลไว้ในไฟล์ metafile ตรวจด้วยการอ่าน zip แล้ว: Noisium อยู่ใน
instance zip, server zip **และ** friend pack

### `C11` — สิ่งที่สำคัญกว่าตัวที่เพิ่งเพิ่ม

**หน้า Modrinth ของ C2ME เขียนถึงตัวมันเองว่า:**

> *"And it's not fully tested with **Radium** (**Canary** is not recommended) and **Starlight**."*

**ทั้งคู่ในประโยคนั้นถูกส่งไปพร้อมกันใน v0.2.1-alpha (#129) ในการเปลี่ยนแปลงเดียวกัน
และยังไม่มีตัวไหนถูกเปิดเลย** นี่ไม่ใช่ข้อบกพร่อง คำว่า "ยังไม่ได้ทดสอบเต็มที่" เป็นคำเตือน
แต่มันควรถูกอ่านก่อนส่ง ไม่ใช่หลังส่ง และมันเปลี่ยนลำดับการตั้งข้อสงสัย: ถ้าโลกสร้างผิด เสียหาย
ค้าง หรือแสงเพี้ยน ให้ถอด **C2ME** ก่อน แล้วค่อย **Radium** ทั้งคู่เป็น `side = "both"`
เพราะงั้นมันอยู่ใน singleplayer ด้วย

กฎสองข้อที่ตามมา และบันทึกไว้ในที่ที่ agent คนถัดไปจะเจอแล้ว:

- **ห้ามลง Canary เด็ดขาด** C2ME บอกว่า *ไม่แนะนำ* ส่วน Radium เองก็ประกาศบน Modrinth ว่า
  **เข้ากันไม่ได้** และ Canary กับ Radium คือ Lithium port ตัวเดียวกันที่ทำงานเดียวกัน
- **ห้ามลง Rubidium เด็ดขาด** Embeddium คือ fork ที่ดูแลต่อของมัน และประกาศ `provides` เป็น
  `rubidium` อยู่แล้ว — ตรวจจาก jar ของ Embeddium

### ที่เหลือใน collection ตรวจรายไฟล์ ไม่ใช่ราย project

| มอด | ผล | หลักฐาน |
|---|---|---|
| **Starlight (Forge)** `1.1.2+1.20` | **HOLD** | เขียน light engine ใหม่ build เมื่อ **2023-07-08** และถูกเอ่ยชื่อในประโยคเดียวกันของ C2ME ว่ายังไม่ได้ทดสอบ การใส่มันคู่กับมอด chunk สองตัวที่ไม่เคยถูกเปิดพร้อมกันเลย จะทำให้บั๊กที่ตามมาหาเจ้าของไม่ได้ |
| **Memory Leak Fix** `v1.1.5` | **ไม่เอา** | AllTheLeaks `1.1.1` ทำหน้าที่นี้อยู่แล้วและใหม่กว่า (2026 vs 2024) สองมอด patch เมธอดเดียวกันคือรูปแบบที่ทำให้เกิด `C8`/#107 |
| **Exordium** | **เป็นไปไม่ได้** | มี build ของ Forge 1.20.1 **ศูนย์ไฟล์** หน้า project ขึ้นว่ารองรับ forge และ 1.20.1 เพราะ metadata นั้นคือ **การรวมทุกเวอร์ชันที่เคยปล่อย** พออ่านรายไฟล์ build ฝั่ง Forge ที่ใกล้ที่สุดคือ 1.21.8 กับ 1.21.10 |
| ImmediatelyFast · Dynamic FPS · Entity Culling · BadOptimizations · ModernFix · FerriteCore | มีอยู่แล้ว | — |

**การตรวจรายไฟล์คือประเด็น** ค่า `loaders` และ `game_versions` ระดับ project คือการรวมทุกอย่าง
ที่มันเคยปล่อย เพราะงั้นคำว่า "รองรับ Forge 1.20.1" บนหน้า project เป็นจริงได้ทั้งที่ไม่มีไฟล์นั้นอยู่เลย

### เกณฑ์การปิดงาน

- [ ] `mods/noisium.pw.toml` pin ไว้ `side = "both"` และเขียนเหตุผลไว้ในไฟล์
- [ ] `verify` เขียวที่ **127 มอด**
- [ ] มีแถวสัญญาอนุญาตใน `docs/distribution-licenses.md` ทั้งสองชุด
- [ ] บันทึก `C11` และอัปเดตตาราง DISCOVERED ว่าหกตัวไหนเข้าไปแล้วและอะไรห้ามลง
- [ ] `pack.toml` เป็น `0.2.2-alpha` และมี entry ใน CHANGELOG
- [ ] build artifact ใหม่ สร้าง checksum ใหม่ และ **ยืนยันว่า Noisium อยู่ทั้งสองฝั่งด้วยการอ่าน zip**
- [ ] **ยังไม่ได้เปิดเกม ยังไม่มีอะไรถูกวัด**

### นอกขอบเขต

Starlight ส่วน GPU binding ระยะ และ heap — ยังเลื่อนอยู่และยังค้าง ส่วน `C9` กับคำถามค้างของ `C10`
ไม่เปลี่ยน
