### PR TITLE
perf: one command runs a whole benchmark session (#139)

### DIFF
--- a/scripts/analyze/session-report.mjs
+++ b/scripts/analyze/session-report.mjs
@@ -54,12 +54,16 @@ if (!logPath || !existsSync(logPath)) {
   say('fields not comparable. Everything below is a fragment.\n')
 } else {
   const log = readFileSync(logPath, 'utf8')
-  const find = re => (log.match(re) || [, ''])[1].trim()
+  // These logs are CRLF. .trim() alone leaves a carriage return inside a
+  // captured line, which breaks the markdown table cell it lands in -- the
+  // first report generated did exactly that. Collapse any break, then trim.
+  const clean = v => String(v || '').replace(/[\r\n]+/g, ' ').trim()
+  const find = re => clean((log.match(re) || [, ''])[1])
   const gpu = find(/OpenGL Renderer:\s*(.+)/)
   const shader = find(/Using shaderpack:\s*(.+)/)
   const mods = find(/Loading (\d+) mods/)
-  const fw = [...log.matchAll(/Flywheel [Bb]ackend[^\n]*/g)].map(m => m[0]).slice(-1)[0] || ''
-  const cw = [...log.matchAll(/\[Colorwheel\][^\n]*/g)].map(m => m[0]).slice(0, 1)[0] || ''
+  const fw = clean([...log.matchAll(/Flywheel [Bb]ackend[^\r\n]*/g)].map(m => m[0]).slice(-1)[0])
+  const cw = clean([...log.matchAll(/\[Colorwheel\][^\r\n]*/g)].map(m => m[0]).slice(0, 1)[0])
   const expect = one('expect-gpu')
 
   say(`| Field | Value |`)

--- a/scripts/benchmark/run-session.ps1
+++ b/scripts/benchmark/run-session.ps1
@@ -1,0 +1,235 @@
+# One keypress, one benchmark session.
+#
+#   pwsh scripts/benchmark/run-session.ps1 -Zone A -Variant baseline -Date 2026-08-29
+#
+# You stand at the benchmark spot in game. You run this. Three minutes later
+# there is a report.
+#
+# WHAT IT AUTOMATES, AND WHAT IT CANNOT
+#
+#   PresentMon        started and stopped by this script          fully automatic
+#   spark profiler    needs an in-game chat command               KEYSTROKES
+#   F3+L              needs a keypress                            KEYSTROKES
+#   the spark link    printed into latest.log by spark itself     read from the log
+#   collection        copy + analyse                              fully automatic
+#
+#   Minecraft has no external control surface for a singleplayer client, so the
+#   two in-game actions are sent as keystrokes to its window. That is the fragile
+#   part and it is called out rather than hidden: if the window loses focus, or
+#   you type during the run, the keystrokes land somewhere else and the run is
+#   void. The script checks afterwards whether spark actually produced a link,
+#   so a keystroke that missed is reported as a failure rather than as an empty
+#   result.
+#
+# -DryRun exercises everything except touching the game: path resolution,
+# preflight, the log read, collection and the report. Use it to check the wiring
+# before trusting a real run.
+#
+# It reads the instance. It never deletes, moves or edits anything in it.
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$Zone,
+    [Parameter(Mandatory = $true)][string]$Variant,
+    [Parameter(Mandatory = $true)][string]$Date,          # YYYY-MM-DD, not the clock: a run
+                                                          # stamped from the machine clock is a
+                                                          # run nobody can reproduce
+    [string]$InstanceDir = "$env:USERPROFILE\curseforge\minecraft\Instances\Industrial Civilization Survival",
+    [string]$PresentMon  = "",
+    [int]$Seconds        = 60,
+    [string]$ExpectGpu   = "RTX 4070 SUPER",
+    [switch]$SpikeProfile,                                # --only-ticks-over 100 instead
+    [switch]$DryRun
+)
+
+$ErrorActionPreference = 'Stop'
+$repo = (Resolve-Path "$PSScriptRoot\..\..").Path
+function Step($m) { Write-Host "  $m" }
+function Fail($m) { Write-Host "`nSTOP: $m" -ForegroundColor Red; exit 1 }
+
+Write-Host "`nBenchmark session - zone $Zone / $Variant / $Date"
+Write-Host ("=" * 58)
+
+# ---------------------------------------------------------------- preflight
+Write-Host "`nPreflight"
+
+if (-not (Test-Path $InstanceDir)) { Fail "instance not found: $InstanceDir" }
+$logPath = Join-Path $InstanceDir 'logs\latest.log'
+if (-not (Test-Path $logPath))     { Fail "no logs\latest.log under $InstanceDir - has the client ever run?" }
+Step "instance   $InstanceDir"
+
+# The commit must describe what runs. PERF-HARNESS-VARIANTS.
+Push-Location $repo
+$dirty  = (git status --porcelain) -join "`n"
+$commit = (git rev-parse HEAD).Trim()
+Pop-Location
+if ($dirty -and -not $DryRun) {
+    Write-Host $dirty
+    Fail "the working tree is dirty, so the commit would not describe the run. Commit first."
+}
+Step "commit     $($commit.Substring(0,12))"
+
+# The GPU that C-UPFG-07 was about. Read it, do not assume it.
+$gpuLine = Select-String -Path $logPath -Pattern 'OpenGL Renderer:' | Select-Object -First 1
+if ($gpuLine) {
+    $gpu = ($gpuLine.Line -split 'OpenGL Renderer:')[1].Trim()
+    Step "gpu        $gpu"
+    if ($ExpectGpu -and $gpu -notlike "*$ExpectGpu*") {
+        Fail "wrong GPU - expected '$ExpectGpu'. C-UPFG-07 was exactly this, and every number taken in that state is void."
+    }
+} else {
+    Step "gpu        (no OpenGL Renderer line yet - the client may not have finished starting)"
+}
+
+# PresentMon is optional, and what it costs to skip is stated rather than implied.
+if (-not $PresentMon) {
+    foreach ($c in @("$env:ProgramFiles\PresentMon\PresentMon.exe",
+                     "$repo\tools\PresentMon.exe",
+                     "$env:USERPROFILE\Downloads\PresentMon.exe")) {
+        if (Test-Path $c) { $PresentMon = $c; break }
+    }
+}
+if ($PresentMon -and (Test-Path $PresentMon)) {
+    Step "presentmon $PresentMon"
+} else {
+    $PresentMon = ""
+    Step "presentmon NOT FOUND - no frametimes, no GPU-busy, and therefore NO"
+    Step "           CPU-bound/GPU-bound verdict. Everything else still works."
+    Step "           https://github.com/GameTechDev/PresentMon/releases"
+}
+
+# ---------------------------------------------------------------- output dir
+$dest = Join-Path $repo "benchmarks\captures\$Date\$($commit.Substring(0,12))\zone-$($Zone.ToLower())\$Variant"
+New-Item -ItemType Directory -Force -Path $dest | Out-Null
+Step "output     $($dest.Replace($repo,'.'))"
+
+$logSizeBefore = (Get-Item $logPath).Length
+
+# ---------------------------------------------------------------- the window
+$mc = Get-Process -Name javaw, java -ErrorAction SilentlyContinue |
+      Where-Object { $_.MainWindowTitle } | Select-Object -First 1
+if (-not $DryRun) {
+    if (-not $mc) { Fail "no Minecraft window found. Start the game, stand at the spot, then run this." }
+    Step "window     $($mc.MainWindowTitle)"
+}
+
+if (-not $DryRun) {
+    Add-Type -AssemblyName System.Windows.Forms
+    Add-Type @"
+using System;
+using System.Runtime.InteropServices;
+public class Win {
+  [DllImport("user32.dll")] public static extern bool SetForegroundWindow(IntPtr h);
+  [DllImport("user32.dll")] public static extern void keybd_event(byte vk, byte scan, uint flags, UIntPtr extra);
+  public const int KEYUP = 0x0002;
+  public static void Chord(byte hold, byte tap) {
+    keybd_event(hold, 0, 0, UIntPtr.Zero);
+    System.Threading.Thread.Sleep(60);
+    keybd_event(tap, 0, 0, UIntPtr.Zero);
+    System.Threading.Thread.Sleep(60);
+    keybd_event(tap, 0, KEYUP, UIntPtr.Zero);
+    System.Threading.Thread.Sleep(30);
+    keybd_event(hold, 0, KEYUP, UIntPtr.Zero);
+  }
+}
+"@
+    Write-Host "`nFocusing the game in 5 seconds. DO NOT touch the keyboard or mouse until this finishes." -ForegroundColor Yellow
+    Start-Sleep -Seconds 5
+    [Win]::SetForegroundWindow($mc.MainWindowHandle) | Out-Null
+    Start-Sleep -Milliseconds 800
+}
+
+# ---------------------------------------------------------------- capture
+$csv = Join-Path $dest 'presentmon.csv'
+$pm = $null
+if ($PresentMon -and -not $DryRun) {
+    $pm = Start-Process -FilePath $PresentMon `
+        -ArgumentList @('-process_name', 'javaw.exe', '-output_file', "`"$csv`"", '-terminate_after_timed',
+                        '-timed', ($Seconds + 20), '-no_top', '-stop_existing_session') `
+        -PassThru -WindowStyle Hidden
+    Write-Host "`nPresentMon capturing"
+}
+
+$sparkCmd = if ($SpikeProfile) { "/spark profiler --thread * --only-ticks-over 100 --timeout $Seconds" }
+            else                { "/spark profiler --thread * --timeout $Seconds" }
+
+if ($DryRun) {
+    Write-Host "`n[dry run] would send: T, then '$sparkCmd', then Enter"
+    Write-Host "[dry run] would wait $($Seconds + 8)s, then hold F3 and tap L (a chord, not two keys), then wait 12s"
+} else {
+    Write-Host "spark: $sparkCmd"
+    [System.Windows.Forms.SendKeys]::SendWait('t')          # open chat
+    Start-Sleep -Milliseconds 600
+    # SendKeys treats + ^ % ~ ( ) { } [ ] as modifiers; the command has none of them,
+    # but * is fine and the braces are what would bite. Sent literally on purpose.
+    [System.Windows.Forms.SendKeys]::SendWait($sparkCmd)
+    Start-Sleep -Milliseconds 300
+    [System.Windows.Forms.SendKeys]::SendWait('{ENTER}')
+
+    Write-Host "profiling for $Seconds seconds - stand still and keep looking at the same thing"
+    Start-Sleep -Seconds ($Seconds + 8)
+
+    # F3+L is a CHORD: F3 must be HELD while L is pressed. SendKeys cannot hold a
+    # key down -- '{F3}L' presses and releases F3 and then presses L, which does
+    # nothing at all. keybd_event can, so the chord is driven directly.
+    Write-Host "F3+L (Minecraft's own profiler, 10s)"
+    [Win]::Chord(0x72, 0x4C)   # VK_F3, VK_L
+    Start-Sleep -Seconds 12
+}
+
+if ($pm) { $pm.WaitForExit(30000) | Out-Null; if (-not $pm.HasExited) { $pm.Kill() } }
+
+# ---------------------------------------------------------------- collect
+Write-Host "`nCollecting"
+Copy-Item $logPath (Join-Path $dest 'latest.log') -Force
+Step "latest.log"
+
+# spark prints its link into the log; no need to read chat
+$newText = ''
+$fs = [System.IO.File]::Open($logPath, 'Open', 'Read', 'ReadWrite')
+try {
+    $fs.Seek($logSizeBefore, 'Begin') | Out-Null
+    $sr = New-Object System.IO.StreamReader($fs)
+    $newText = $sr.ReadToEnd()
+} finally { $fs.Dispose() }
+
+$sparkUrl = [regex]::Match($newText, 'https?://spark\.lucko\.me/\S+').Value
+if ($sparkUrl) {
+    Step "spark      $sparkUrl"
+    Set-Content -Path (Join-Path $dest 'spark-url.txt') -Value $sparkUrl
+} elseif (-not $DryRun) {
+    Step "spark      NO LINK IN THE LOG"
+    Step "           The keystrokes did not reach the game, or the profile failed."
+    Step "           This is the fragile step; the run is not usable without it."
+}
+
+# the newest F3+L result
+$profDir = Join-Path $InstanceDir 'debug\profiling'
+if (Test-Path $profDir) {
+    $newest = Get-ChildItem $profDir -Recurse -Filter 'profiling-result.txt' -ErrorAction SilentlyContinue |
+              Sort-Object LastWriteTime -Descending | Select-Object -First 1
+    if ($newest) {
+        Copy-Item $newest.FullName (Join-Path $dest 'profiling-result.txt') -Force
+        Step "F3+L       $($newest.LastWriteTime.ToString('HH:mm:ss'))"
+    } else { Step "F3+L       no profiling-result.txt found" }
+} else { Step "F3+L       no debug\profiling directory - F3+L never ran here" }
+
+if (Test-Path $csv) { Step "presentmon $([math]::Round((Get-Item $csv).Length/1KB)) KB" }
+
+# ---------------------------------------------------------------- report
+Write-Host "`nReport"
+$reportArgs = @("$repo\scripts\analyze\session-report.mjs",
+          '--log', (Join-Path $dest 'latest.log'),
+          '--expect-gpu', $ExpectGpu,
+          '--out', (Join-Path $dest 'report.md'))
+if ($sparkUrl) { $reportArgs += @('--spark', ($sparkUrl -split '/')[-1]) }
+if (Test-Path (Join-Path $dest 'profiling-result.txt')) { $reportArgs += @('--profiler', (Join-Path $dest 'profiling-result.txt')) }
+if (Test-Path $csv) { $reportArgs += @('--capframex', $csv) }
+
+Push-Location $repo
+& node @args
+Pop-Location
+
+Write-Host "`n$($dest.Replace($repo,'.'))\report.md"
+Write-Host "`nNothing here is a per-mod frame cost. Correlation names suspects;"
+Write-Host "leave-one-out proves them (PERF-HARNESS-LEAVEONEOUT)."


### PR DESCRIPTION
## What it does

```
pwsh scripts/benchmark/run-session.ps1 -Zone A -Variant baseline -Date 2026-08-29
```

Stand at the benchmark spot in game, run this, and about three minutes later there is a report.
It starts PresentMon, drives the spark profiler and F3+L, collects every artifact into
`benchmarks/captures/<date>/<commit>/<zone>/<variant>/`, and runs `session-report.mjs` over the lot.

## What is automatic and what is not, stated rather than implied

| Step | How |
|---|---|
| PresentMon start / stop | ✅ CLI, fully automatic |
| `/spark profiler --thread * --timeout 60` | ⚠️ **keystrokes into the game window** |
| F3+L | ⚠️ **a key chord into the game window** |
| Getting the spark link back | ✅ **spark writes it into `latest.log`** — no copying from chat |
| Collect + analyse | ✅ |

**Minecraft has no external control surface for a singleplayer client**, so the two in-game actions
are keystrokes. That is the fragile part and it is named in the script's own header rather than
hidden: lose window focus, or type during the run, and the keystrokes land somewhere else.

**A missed keystroke is reported as a failure, not as an empty result.** After the run the script
looks for a spark URL in the bytes the log gained; if there is none it says so and says why.

## Two bugs found while building it, both by testing rather than by reading

**`{F3}L` would never have worked.** F3+L is a **chord** — F3 must be *held* while L is pressed —
and `SendKeys` cannot hold a key down. `'{F3}L'` presses and releases F3, then presses L, which does
nothing at all. Replaced with a `keybd_event` P/Invoke that drives a real chord. **This would have
failed silently every run**, producing a session with no engine-section data and no error.

**The first report rendered a broken markdown table.** These logs are CRLF and `.trim()` leaves a
carriage return in the middle of a captured line. Caught by looking at the output instead of at the
exit code.

## Preconditions it refuses to run without

- **A dirty working tree** — the commit would not describe what ran (`PERF-HARNESS-VARIANTS`)
- **The wrong GPU** — reads `OpenGL Renderer:` from the log and stops if it is not the expected card.
  `C-UPFG-07` was exactly this, for weeks
- **No Minecraft window** — says so instead of typing into whatever is focused

PresentMon missing is *not* fatal: the run proceeds and the script states the cost — no frametimes,
no GPU-busy, and therefore **no CPU-bound/GPU-bound verdict**, which is the one thing the whole
correlation exists to produce.

## Tested

`-DryRun` exercises path resolution, preflight, the GPU check, the log read, collection and the
report — everything except touching the game. It runs clean, correctly reports PresentMon missing,
and correctly reports that F3+L has never run on this instance.

**Untested, and it cannot be tested from here:** the keystrokes themselves, PresentMon, and the F3+L
capture. There is no Java on this machine. The first real run is the test.

## Acceptance criteria

- [x] Dry run passes end to end
- [x] Refuses a dirty tree and the wrong GPU
- [x] F3+L driven as a real chord
- [ ] One real session produces a report with all four sources present
- [ ] The CapFrameX/F3+L parsers confirmed against that first capture

## Out of scope

Installing PresentMon. The frozen benchmark world.

---

## สรุปภาษาไทย

### มันทำอะไร

```
pwsh scripts/benchmark/run-session.ps1 -Zone A -Variant baseline -Date 2026-08-29
```

ยืนที่จุด benchmark ในเกม สั่งคำสั่งนี้ อีกราวสามนาทีจะมีรายงานออกมา มันเริ่ม PresentMon สั่ง
spark profiler กับ F3+L เก็บทุกไฟล์ลง `benchmarks/captures/<date>/<commit>/<zone>/<variant>/`
แล้วรัน `session-report.mjs` ให้เลย

### อะไรอัตโนมัติ อะไรไม่ พูดตรง ๆ ไม่กลบ

| ขั้นตอน | ทำยังไง |
|---|---|
| เริ่ม/หยุด PresentMon | ✅ เป็น CLI อัตโนมัติเต็มที่ |
| `/spark profiler --thread * --timeout 60` | ⚠️ **ยิง keystroke เข้าหน้าต่างเกม** |
| F3+L | ⚠️ **ยิง key chord เข้าหน้าต่างเกม** |
| เอาลิงก์ spark กลับมา | ✅ **spark เขียนลง `latest.log` เอง** ไม่ต้องก๊อปจากแชท |
| รวบรวม + วิเคราะห์ | ✅ |

**Minecraft ไม่มีช่องทางสั่งงานจากภายนอกสำหรับ client แบบ singleplayer** สองขั้นตอนในเกมจึงต้องใช้
keystroke นั่นคือจุดที่เปราะ และมันถูกเขียนบอกไว้ในหัวสคริปต์เอง ไม่ได้ซ่อน: ถ้าหน้าต่างหลุด focus
หรือคุณพิมพ์อะไรระหว่างรัน keystroke จะไปลงที่อื่น

**ถ้า keystroke พลาด มันจะรายงานว่าล้มเหลว ไม่ใช่รายงานผลว่าง** หลังรันจบสคริปต์จะไปหา URL ของ spark
ในส่วนของ log ที่เพิ่มขึ้นมา ถ้าไม่มีมันจะบอกว่าไม่มีและบอกเหตุผล

### บั๊กสองตัวที่เจอระหว่างสร้าง ทั้งคู่เจอเพราะทดสอบ ไม่ใช่เพราะอ่าน

**`{F3}L` ไม่มีทางทำงานได้** F3+L เป็น **chord** — ต้องกด F3 *ค้าง* ขณะกด L — และ `SendKeys`
กดค้างไม่ได้ `'{F3}L'` จะกดแล้วปล่อย F3 แล้วค่อยกด L ซึ่งไม่เกิดอะไรขึ้นเลย เปลี่ยนไปใช้
`keybd_event` ที่ทำ chord จริงได้ **อันนี้จะพังเงียบ ๆ ทุกรอบ** ได้ session ที่ไม่มีข้อมูล section
ของ engine และไม่มี error ด้วย

**รายงานฉบับแรก render ตาราง markdown พัง** เพราะ log เป็น CRLF และ `.trim()` เหลือ carriage return
ค้างกลางบรรทัด เจอเพราะไปดูผลลัพธ์จริง ไม่ใช่ดูแค่ exit code

### เงื่อนไขที่มันจะไม่ยอมรัน

- **working tree สกปรก** — commit จะไม่ตรงกับสิ่งที่รัน (`PERF-HARNESS-VARIANTS`)
- **GPU ผิดใบ** — อ่าน `OpenGL Renderer:` จาก log แล้วหยุดถ้าไม่ใช่การ์ดที่คาดไว้ `C-UPFG-07`
  เป็นแบบนี้อยู่หลายสัปดาห์
- **ไม่มีหน้าต่าง Minecraft** — บอกตรง ๆ แทนที่จะพิมพ์ลงโปรแกรมที่กำลัง focus อยู่

ส่วนการไม่มี PresentMon *ไม่* ทำให้หยุด รันต่อได้และสคริปต์จะบอกว่าเสียอะไรไป — ไม่มี frametime
ไม่มี GPU-busy และเพราะงั้น **ตัดสินไม่ได้ว่าติด CPU หรือ GPU** ซึ่งเป็นสิ่งเดียวที่การเทียบข้อมูลทั้งหมดมีไว้เพื่อตอบ

### ทดสอบแล้ว

`-DryRun` รันทุกอย่างยกเว้นส่วนที่แตะเกม — หาพาธ, preflight, เช็ค GPU, อ่าน log, เก็บไฟล์, ออกรายงาน
รันผ่านสะอาด รายงานถูกต้องว่าไม่มี PresentMon และรายงานถูกต้องว่า F3+L ไม่เคยรันบน instance นี้

**ยังไม่ได้ทดสอบ และทดสอบจากที่นี่ไม่ได้:** ตัว keystroke เอง, PresentMon, และการเก็บผล F3+L
เครื่องนี้ไม่มี Java การรันจริงครั้งแรกคือการทดสอบ

### เกณฑ์การปิดงาน

- [x] dry run ผ่านตั้งแต่ต้นจนจบ
- [x] ปฏิเสธ tree สกปรกและ GPU ผิดใบ
- [x] F3+L ทำเป็น chord จริง
- [ ] รันจริงหนึ่งรอบและได้รายงานที่มีครบทั้งสี่แหล่ง
- [ ] ยืนยัน parser ของ CapFrameX/F3+L กับไฟล์จริงชุดแรก

### นอกขอบเขต

การติดตั้ง PresentMon และโลก benchmark
