### PR TITLE
fix(perf): find PresentMon by glob and use its 2.x flags (#141)

### DIFF
--- a/scripts/benchmark/run-session.ps1
+++ b/scripts/benchmark/run-session.ps1
@@ -83,14 +83,26 @@ if ($gpuLine) {
 
 # PresentMon is optional, and what it costs to skip is stated rather than implied.
 if (-not $PresentMon) {
-    foreach ($c in @("$env:ProgramFiles\PresentMon\PresentMon.exe",
-                     "$repo\tools\PresentMon.exe",
-                     "$env:USERPROFILE\Downloads\PresentMon.exe")) {
-        if (Test-Path $c) { $PresentMon = $c; break }
+    # Glob, not an exact name: the GitHub asset is PresentMon-2.5.1-x64.exe and
+    # requiring a rename is a step that will be forgotten exactly once.
+    foreach ($dir in @("$repo\tools", "$env:ProgramFiles\PresentMon", "$env:USERPROFILE\Downloads")) {
+        if (-not (Test-Path $dir)) { continue }
+        $hit = Get-ChildItem $dir -Filter 'PresentMon*.exe' -ErrorAction SilentlyContinue |
+               Sort-Object Name -Descending | Select-Object -First 1
+        if ($hit) { $PresentMon = $hit.FullName; break }
     }
 }
 if ($PresentMon -and (Test-Path $PresentMon)) {
     Step "presentmon $PresentMon"
+    $admin = ([Security.Principal.WindowsPrincipal] `
+              [Security.Principal.WindowsIdentity]::GetCurrent()
+             ).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+    if (-not $admin) {
+        Step "           NOT RUNNING AS ADMIN. PresentMon needs an elevated shell to"
+        Step "           open its trace session; without it the CSV comes out empty"
+        Step "           and you find out after the run. Reopen PowerShell as"
+        Step "           Administrator, or accept no frame data this session."
+    }
 } else {
     $PresentMon = ""
     Step "presentmon NOT FOUND - no frametimes, no GPU-busy, and therefore NO"
@@ -143,9 +155,18 @@ public class Win {
 $csv = Join-Path $dest 'presentmon.csv'
 $pm = $null
 if ($PresentMon -and -not $DryRun) {
+    # PresentMon 2.x flags are double-dash and there is no -no_top; --no_console_stats
+    # replaced it. Read from `--help` on the actual binary, not from memory of 1.x.
+    # --v2_metrics pins the CSV column names so the parser is not guessing.
     $pm = Start-Process -FilePath $PresentMon `
-        -ArgumentList @('-process_name', 'javaw.exe', '-output_file', "`"$csv`"", '-terminate_after_timed',
-                        '-timed', ($Seconds + 20), '-no_top', '-stop_existing_session') `
+        -ArgumentList @('--process_name', 'javaw.exe',
+                        '--output_file', "`"$csv`"",
+                        '--timed', ($Seconds + 20),
+                        '--terminate_after_timed',
+                        '--terminate_on_proc_exit',
+                        '--no_console_stats',
+                        '--stop_existing_session',
+                        '--v2_metrics') `
         -PassThru -WindowStyle Hidden
     Write-Host "`nPresentMon capturing"
 }

--- a/tools/.gitignore
+++ b/tools/.gitignore
@@ -1,0 +1,4 @@
+# PresentMon and anything else downloaded to run a benchmark.
+# Not part of the pack, not ours to redistribute.
+*
+!.gitignore


### PR DESCRIPTION
Found by the developer running the dry run. Two faults, both of which would have wasted a **real** session rather than a dry one.

**The name.** The GitHub asset is `PresentMon-2.5.1-x64.exe`; the script looked for an exact `PresentMon.exe`. Requiring a rename is a step that gets forgotten exactly once. Now globs `PresentMon*.exe`.

**The flags were 1.x.** Read from `--help` on the actual binary: PresentMon 2.x takes **double-dash** flags and `-no_top` no longer exists — `--no_console_stats` replaced it. The old argument list would have failed **at launch, mid-session, after the countdown, with the game focused and the keyboard off limits.** Also passing `--v2_metrics` so the CSV columns are pinned rather than guessed.

**Elevation, said at preflight.** PresentMon needs an elevated shell for its trace session; without it the CSV is empty and you find out an hour later.

`tools/` is gitignored — PresentMon is not ours to redistribute.

Verified by dry run: binary found, non-elevated shell reported. The capture itself is still untested here; no Java on this machine.

---

## สรุปภาษาไทย

เจอตอนผู้พัฒนารัน dry run เอง สองจุด และทั้งคู่จะไปพังตอน**รันจริง** ไม่ใช่ตอนซ้อม

**ชื่อไฟล์** ไฟล์จาก GitHub ชื่อ `PresentMon-2.5.1-x64.exe` แต่สคริปต์หา `PresentMon.exe` ตรง ๆ การบังคับให้เปลี่ยนชื่อคือขั้นตอนที่จะถูกลืมแน่นอนสักครั้ง ตอนนี้ใช้ glob `PresentMon*.exe` แล้ว

**flag เป็นของ 1.x** อ่านจาก `--help` ของไฟล์จริง: PresentMon 2.x ใช้ flag **สองขีด** และไม่มี `-no_top` แล้ว เปลี่ยนเป็น `--no_console_stats` ชุด argument เดิมจะพัง**ตอนเริ่ม กลาง session หลังนับถอยหลังจบ ตอนที่เกม focus อยู่และห้ามแตะคีย์บอร์ด** และใส่ `--v2_metrics` เพื่อล็อกชื่อคอลัมน์ใน CSV ไม่ให้ parser ต้องเดา

**เรื่องสิทธิ์ admin บอกตั้งแต่ preflight** PresentMon ต้องใช้ shell ที่รันแบบ admin ถึงจะเปิด trace session ได้ ถ้าไม่ใช่ CSV จะว่างเปล่าและจะรู้ตอนผ่านไปชั่วโมงหนึ่งแล้ว

`tools/` ใส่ gitignore ไว้ — PresentMon ไม่ใช่ของเราที่จะเอาไปแจก

ยืนยันด้วย dry run: หาไฟล์เจอ และรายงานว่า shell ไม่ได้เป็น admin ส่วนตัว capture เองยังทดสอบจากที่นี่ไม่ได้ เครื่องนี้ไม่มี Java
