### PR TITLE
fix(perf): run-session launched the Node REPL instead of the report (#143)

### DIFF
--- a/scripts/benchmark/run-session.ps1
+++ b/scripts/benchmark/run-session.ps1
@@ -247,9 +247,16 @@ if ($sparkUrl) { $reportArgs += @('--spark', ($sparkUrl -split '/')[-1]) }
 if (Test-Path (Join-Path $dest 'profiling-result.txt')) { $reportArgs += @('--profiler', (Join-Path $dest 'profiling-result.txt')) }
 if (Test-Path $csv) { $reportArgs += @('--capframex', $csv) }
 
+# @reportArgs, not the bare automatic one. Splatting PowerShell's AUTOMATIC
+# args variable in a script that declares param() splats nothing, so node
+# launches with no arguments and drops into its REPL -- silently, no error
+# anywhere. That happened once, after a rename that changed the $-form and
+# missed the @-form.
 Push-Location $repo
-& node @args
+& node @reportArgs
+$nodeExit = $LASTEXITCODE
 Pop-Location
+if ($nodeExit -ne 0) { Fail "session-report exited $nodeExit - the report above is incomplete" }
 
 Write-Host "`n$($dest.Replace($repo,'.'))\report.md"
 Write-Host "`nNothing here is a per-mod frame cost. Correlation names suspects;"


### PR DESCRIPTION
Found by the developer running the dry run. The report step printed `Welcome to Node.js` and stopped.

`& node @args` splats PowerShell's **automatic** `args` variable, which is empty in a script that declares `param()`. So node launched with **no arguments at all** and opened its REPL — **with no error anywhere**, exit code 0, and the script carried on printing a path to a report that was never written.

The cause is my own patch in #139: I renamed the `$`-form and missed the `@`-form. The commit message for that change warned that `args` is an automatic variable, which is the part that stings.

Fixed to `@reportArgs`, and the exit code is now checked so a failed report is a failure rather than a silent gap.

Verified: the dry run now writes `report.md` and prints its contents.

---

## สรุปภาษาไทย

เจอตอนผู้พัฒนารัน dry run ขั้นตอน report ขึ้นว่า `Welcome to Node.js` แล้วจบ

`& node @args` เป็นการ splat ตัวแปร **automatic** ชื่อ `args` ของ PowerShell ซึ่งในสคริปต์ที่ประกาศ `param()` มันจะว่าง node เลยถูกเรียก**โดยไม่มี argument เลยสักตัว** แล้วเปิด REPL — **ไม่มี error ที่ไหนเลย** exit code เป็น 0 และสคริปต์ก็พิมพ์พาธของรายงานที่ไม่เคยถูกสร้างต่อไป

ต้นเหตุคือ patch ของผมเองใน #139 ผมเปลี่ยนรูปแบบที่ขึ้นต้นด้วย `$` แต่พลาดรูปแบบที่ขึ้นต้นด้วย `@` และ commit ของรอบนั้นก็เขียนเตือนไว้เองว่า `args` เป็น automatic variable ซึ่งคือส่วนที่เจ็บ

แก้เป็น `@reportArgs` แล้ว และเพิ่มการเช็ค exit code เพื่อให้รายงานที่ล้มเหลวเป็นความล้มเหลว ไม่ใช่ช่องว่างเงียบ ๆ

ยืนยันแล้ว: dry run เขียน `report.md` ออกมาและพิมพ์เนื้อหาให้เห็น
