### PR TITLE
chore: record what this session learned, and correct a wrong memory note (#145)

### DIFF
--- a/Obsidian-minecraft-100day/Home.md
+++ b/Obsidian-minecraft-100day/Home.md
@@ -6,6 +6,7 @@
 ## feedback — how agents should work here
 - [[config-and-kubejs-fail-open]] — this pack swallows its own errors, so "it should work" is never evidence
 - [[measure-before-you-write-a-number]] — every balance figure in the docs is a measurement or it is fiction
+- [[spark-profiles-lie-twice]] — a profile answers only for the threads it sampled, and its JSON double-counts if you sum it
 
 ## project — ongoing goals / constraints not derivable from the code
 - [[create-version-is-the-pin]] — the Create major version decides the whole mod stack; nothing is pinnable before it

--- a/Obsidian-minecraft-100day/dev-machine-tooling.md
+++ b/Obsidian-minecraft-100day/dev-machine-tooling.md
@@ -9,10 +9,11 @@ Measured 2026-08-25 on the developer's Windows 11 machine.
 | Tool | State |
 |---|---|
 | `git` | 2.54.0.windows.1 — on PATH |
-| `node` / `npm` | v22.23.1 / 10.9.8 — on PATH; this is what `scripts/validate/verify.mjs` runs under |
+| `node` / `npm` | v22.23.1 / 10.9.8 under the agent's bash. **A `pwsh` terminal on this machine reports v26.3.1**, so the two shells do not agree — check which one a script will run under before blaming its output |
 | `gh` | **installed but NOT on the shell PATH** — `C:\Program Files\GitHub CLI\gh.exe`, v2.95.0, authenticated as `xenodeve`, scopes `repo`, `workflow`, `gist`, `read:org`, `admin:org_hook` |
-| `packwiz` | not installed |
-| `java` | not on PATH |
+| `packwiz` | **installed, NOT on PATH** — `C:\Users\xenod\go\bin\packwiz.exe`. This note said "not installed" until 2026-08-28 and `CLAUDE.md` repeated it; both were wrong, and the cost was a session that believed it could not re-export the pack |
+| `java` | **not installed** — not on PATH and not under the CurseForge runtime directory. Nothing can be boot-tested or benchmarked from an agent session; every launch is the developer's |
+| `PresentMon` | `tools/PresentMon-2.5.1-x64.exe`, gitignored. **2.x takes double-dash flags** and has no `-no_top`; it needs an **elevated shell** or its CSV comes out empty |
 | `bun` | not installed — and not needed; this repo has no JS package manifest |
 
 **Why:** `command -v gh` returns nothing, so an agent will conclude gh is missing and either try

--- a/Obsidian-minecraft-100day/spark-profiles-lie-twice.md
+++ b/Obsidian-minecraft-100day/spark-profiles-lie-twice.md
@@ -1,0 +1,37 @@
+---
+name: spark-profiles-lie-twice
+description: A spark profile answers only for the threads it sampled, and its JSON is a flat node pool that double-counts if summed naively — both mistakes were made here and both produced confident wrong numbers
+type: feedback
+---
+
+Two independent traps, both hit in one session (#135), both of which produced a number that looked
+authoritative and was not.
+
+**It only knows the threads it sampled.** `/spark profiler` with no `--thread` argument samples the
+**server thread alone**. The profile `QoHXwezfza` contains exactly one thread, and the conclusion
+drawn from it — *"no mod is above 2.1%, so the problem is the environment"* — was then applied to an
+**FPS** complaint, which is a render-thread question. The profile was not wrong. It was asked
+something it had never looked at.
+
+> Always `--thread *`. A profile that did not sample the thread you are asking about cannot exonerate
+> anything on it.
+
+**Its JSON double-counts if you sum it.** `thread.children` is a **flat pool** of every node in the
+tree; each node's `childrenRefs` are **indices into that pool**, and `node.time` is always `0` — the
+real values live in `node.times`, one per time window. Summing every node therefore counts the whole
+tree once per level: on that profile, 49,908 samples against a real total of 1,896, and percentages
+over 2000%.
+
+The correct reading is **self time**: a node's own total minus the totals of its children, attributed
+via spark's `classSources` map, which already records which mod owns which class — so nothing has to
+guess from package names.
+
+> The check that catches it: the self times must reconstruct the thread total. If they do not sum to
+> ~100%, the parse is wrong. `scripts/analyze/spark-profile.mjs` prints that percentage on every run
+> for exactly this reason.
+
+**What generalises past spark.** Both failures share a shape with
+[[measure-before-you-write-a-number]]: the output was well-formed, plausible and confidently
+formatted, and nothing in it announced that it was answering a different question than the one asked.
+The defence is not care — it is a control case. Every parser written here is now pointed at an
+artifact whose answer is already known before it is trusted on one whose answer is not.


### PR DESCRIPTION
Routing through `using-t4` surfaced that memory had not been written this session, and that one note is actively wrong.

**`dev-machine-tooling` said `packwiz` was not installed.** It is, at `C:\Users\xenod\go\bin\packwiz.exe`. `CLAUDE.md` repeated the same claim until #123. The cost was real: a session that believed it could not re-export the pack. Corrected, with the correction's own history kept in the row so it is not quietly re-broken.

Also added there: `PresentMon` at `tools/PresentMon-2.5.1-x64.exe` with its two gotchas (double-dash flags, needs an elevated shell), `java` restated as genuinely absent rather than merely off PATH, and the fact that **bash reports node v22.23.1 while pwsh reports v26.3.1** — the two shells on this machine do not agree.

**New memory: `spark-profiles-lie-twice`.** Two independent traps hit in one session, both producing confident wrong numbers. A profile without `--thread *` samples the server thread alone, and that profile was then used to answer an FPS question it had never looked at. And its JSON is a flat node pool with `childrenRefs` indices and `node.time` always `0`, so summing every node double-counts the tree — 49,908 samples against a real 1,896.

## Gate honesty

Several commits this session carry `simplify=n-a` on changes that **added new code**. `n-a` means the gate does not apply; it did apply. The accurate value was `not-run`. Recording it here rather than quietly using the right word from now on.

## Acceptance criteria

- [x] `dev-machine-tooling` corrected
- [x] The spark trap written as a memory and indexed in `Home.md`
- [x] `verify` green
- [ ] Session-end `xeno-skills` feedback filed

---

## สรุปภาษาไทย

การเดินผ่าน `using-t4` ทำให้เห็นว่า session นี้ยังไม่ได้เขียน memory เลย และมีโน้ตหนึ่งที่ผิดอยู่

**`dev-machine-tooling` เขียนว่า `packwiz` ยังไม่ได้ลง** ซึ่งมันลงแล้วที่ `C:\Users\xenod\go\bin\packwiz.exe` และ `CLAUDE.md` ก็เขียนตามกันมาจนถึง #123 ความเสียหายมีจริง: session หนึ่งเชื่อว่าตัวเอง export แพ็คใหม่ไม่ได้ แก้แล้ว และเก็บประวัติการแก้ไว้ในแถวนั้นเองเพื่อไม่ให้ถูกทำพังซ้ำเงียบ ๆ

เพิ่มด้วย: `PresentMon` ที่ `tools/PresentMon-2.5.1-x64.exe` พร้อมสองกับดักของมัน (flag สองขีด, ต้องใช้ shell แบบ admin), `java` เขียนใหม่ว่าไม่ได้ลงจริง ๆ ไม่ใช่แค่ไม่อยู่บน PATH และข้อเท็จจริงว่า **bash รายงาน node v22.23.1 ส่วน pwsh รายงาน v26.3.1** — สอง shell บนเครื่องนี้ไม่ตรงกัน

**memory ใหม่: `spark-profiles-lie-twice`** กับดักสองอันที่ไม่เกี่ยวกันแต่โดนทั้งคู่ใน session เดียว และทั้งคู่ให้ตัวเลขที่ดูน่าเชื่อแต่ผิด profile ที่ไม่ใส่ `--thread *` จะเก็บแค่ server thread แล้วมันถูกเอาไปตอบคำถามเรื่อง FPS ที่มันไม่เคยมอง และ JSON ของมันเป็นกองแบนที่ใช้ `childrenRefs` เป็น index โดย `node.time` เป็น `0` เสมอ การรวมทุก node จึงนับซ้ำทั้งต้นไม้ — 49,908 sample เทียบกับของจริง 1,896

### เรื่อง gate ที่ต้องพูดตรง ๆ

commit หลายอันใน session นี้เขียน `simplify=n-a` ทั้งที่การเปลี่ยนแปลงนั้น**เพิ่มโค้ดใหม่** คำว่า `n-a` แปลว่า gate นี้ไม่เกี่ยว แต่มันเกี่ยว ค่าที่ถูกคือ `not-run` บันทึกไว้ตรงนี้แทนที่จะเงียบ ๆ แล้วใช้คำที่ถูกตั้งแต่ครั้งหน้า

### เกณฑ์การปิดงาน

- [x] แก้ `dev-machine-tooling`
- [x] เขียนกับดักของ spark เป็น memory และใส่ index ใน `Home.md`
- [x] `verify` เขียว
- [ ] ส่ง feedback ปิด session ไปที่ `xeno-skills`
