### PR TITLE
perf: read the shader state instead of trusting the run's name (#147)

### DIFF
--- a/scripts/analyze/session-report.mjs
+++ b/scripts/analyze/session-report.mjs
@@ -60,16 +60,35 @@ if (!logPath || !existsSync(logPath)) {
   const clean = v => String(v || '').replace(/[\r\n]+/g, ' ').trim()
   const find = re => clean((log.match(re) || [, ''])[1])
   const gpu = find(/OpenGL Renderer:\s*(.+)/)
-  const shader = find(/Using shaderpack:\s*(.+)/)
+  // THE LAST one, not the first. A session where the shader pack was switched
+  // writes several of these -- the log read while building this had six -- and
+  // log.match() returns the first, which reported a pack that had been replaced
+  // twenty minutes earlier.
+  const shaderLines = [...log.matchAll(/Using shaderpack:\s*([^\r\n]+)/g)].map(m => clean(m[1]))
+  const shader = shaderLines.length ? shaderLines[shaderLines.length - 1] : ''
   const mods = find(/Loading (\d+) mods/)
   const fw = clean([...log.matchAll(/Flywheel [Bb]ackend[^\r\n]*/g)].map(m => m[0]).slice(-1)[0])
-  const cw = clean([...log.matchAll(/\[Colorwheel\][^\r\n]*/g)].map(m => m[0]).slice(0, 1)[0])
+  // Also the LAST, and for the same reason: Colorwheel complains once per pack
+  // load, so the first complaint names a pack that may no longer be active.
+  const cwAll = [...log.matchAll(/\[Colorwheel\][^\r\n]*/g)].map(m => clean(m[0]))
+  const cw = cwAll.length ? cwAll[cwAll.length - 1] : ''
   const expect = one('expect-gpu')
 
   say(`| Field | Value |`)
   say(`|---|---|`)
   say(`| GPU | \`${gpu || 'not found'}\` |`)
-  say(`| Shader pack | \`${shader || 'none loaded'}\` |`)
+  // oculus.properties is the authority on whether shaders are ON; the log only
+  // says which pack was last LOADED, and a pack can be loaded and then disabled.
+  let shaderState = ''
+  const oculusCfg = logPath.replace(/logs[\\/]+latest\.log$/i, 'config/oculus.properties')
+  if (existsSync(oculusCfg)) {
+    const cfg = readFileSync(oculusCfg, 'utf8')
+    const on = /^enableShaders\s*=\s*true/mi.test(cfg)
+    const pk = clean((cfg.match(/^shaderPack\s*=\s*(.+)$/mi) || [, ''])[1])
+    shaderState = on ? `ON — \`${pk}\`` : 'OFF'
+    say(`| Shaders | **${shaderState}** — from \`config/oculus.properties\` |`)
+  }
+  say(`| Shader pack last loaded | \`${shader || 'none'}\`${shaderLines.length > 1 ? ` (${shaderLines.length} loads this session)` : ''} |`)
   say(`| Mods loaded | ${mods || '?'} (includes JarJar libraries) |`)
   say(`| Flywheel | \`${fw.replace(/^.*?\]:\s*/, '') || 'no line — not a Create client, or never rendered'}\` |`)
   if (cw) say(`| Colorwheel | \`${cw.replace(/^.*?\[Colorwheel\]\s*/, '')}\` |`)

--- a/scripts/benchmark/run-session.ps1
+++ b/scripts/benchmark/run-session.ps1
@@ -30,7 +30,7 @@
 [CmdletBinding()]
 param(
     [Parameter(Mandatory = $true)][string]$Zone,
-    [Parameter(Mandatory = $true)][string]$Variant,
+    [string]$Variant = '',                                # omit it and the shader state names the run
     [Parameter(Mandatory = $true)][string]$Date,          # YYYY-MM-DD, not the clock: a run
                                                           # stamped from the machine clock is a
                                                           # run nobody can reproduce
@@ -47,7 +47,9 @@ $repo = (Resolve-Path "$PSScriptRoot\..\..").Path
 function Step($m) { Write-Host "  $m" }
 function Fail($m) { Write-Host "`nSTOP: $m" -ForegroundColor Red; exit 1 }
 
-Write-Host "`nBenchmark session - zone $Zone / $Variant / $Date"
+# The variant is not known yet when this prints -- it can be derived from the
+# shader state below -- so the banner names only what is certain here.
+Write-Host "`nBenchmark session - zone $Zone / $Date"
 Write-Host ("=" * 58)
 
 # ---------------------------------------------------------------- preflight
@@ -79,6 +81,50 @@ if ($gpuLine) {
     }
 } else {
     Step "gpu        (no OpenGL Renderer line yet - the client may not have finished starting)"
+}
+
+# SHADER STATE, READ RATHER THAN REMEMBERED.
+#
+# config/oculus.properties is the authority: the game rewrites it the moment you
+# change the setting. The log is not -- it records every pack LOADED, so a
+# session where you switched packs has several lines and the first one is stale.
+# The log read while writing this had six.
+#
+# The point of checking is not convenience. Mislabelling which run had shaders on
+# is the worst benchmark error available, because nothing downstream can detect
+# it: two runs get compared, the delta is attributed to the wrong variable, and
+# the number looks fine.
+$oculusCfg = Join-Path $InstanceDir 'config\oculus.properties'
+$shadersOn = $null
+$shaderPack = ''
+if (Test-Path $oculusCfg) {
+    $cfg = Get-Content $oculusCfg -Raw
+    $shadersOn = $cfg -match '(?m)^enableShaders\s*=\s*true'
+    if ($cfg -match '(?m)^shaderPack\s*=\s*(.+)$') { $shaderPack = $Matches[1].Trim() }
+    if ($shadersOn) { Step "shaders    ON - $shaderPack" } else { Step "shaders    OFF" }
+} else {
+    Step "shaders    unknown - no config\oculus.properties (Oculus may never have run)"
+}
+
+# Name the run from the state if the developer did not name it.
+if (-not $Variant) {
+    if ($null -eq $shadersOn) { Fail "-Variant is required when the shader state cannot be read." }
+    $Variant = if ($shadersOn) { 'shaders-on' } else { 'shaders-off' }
+    Step "variant    $Variant (derived from the shader state)"
+} else {
+    Step "variant    $Variant"
+}
+
+# And refuse a name that contradicts what was read.
+if ($null -ne $shadersOn) {
+    $claimsOff = $Variant -match '(?i)shaders?-?off|no-?shader'
+    $claimsOn  = $Variant -match '(?i)shaders?-?on'
+    if ($claimsOff -and $shadersOn) {
+        Fail "variant '$Variant' says shaders are off, but oculus.properties has enableShaders=true ($shaderPack). Turn them off in game, or rename the run."
+    }
+    if ($claimsOn -and -not $shadersOn) {
+        Fail "variant '$Variant' says shaders are on, but oculus.properties has enableShaders=false. Turn them on in game, or rename the run."
+    }
 }
 
 # PresentMon is optional, and what it costs to skip is stated rather than implied.


### PR DESCRIPTION
`config/oculus.properties` is the authority — the game rewrites it the moment the setting changes — so the shader state can be read rather than typed.

```
shaderPack=Bliss-Shader Dev.zip
enableShaders=true
```

**Why it matters more than convenience.** Mislabelling which run had shaders on is the worst benchmark error available: nothing downstream can detect it, the two runs get compared anyway, and the delta is attributed to the wrong variable. The number comes out looking fine.

So `-Variant` is now **optional** — omit it and the run is named `shaders-on` or `shaders-off` from what was read — and a name that **contradicts** the config is refused:

```
STOP: variant 'shaders-off' says shaders are off, but oculus.properties has
enableShaders=true (Bliss-Shader Dev.zip). Turn them off in game, or rename the run.
```

## A reporting bug found while checking this

The log holds **one `Using shaderpack:` line per load**, and the log read here had **six** — the packs were switched during the session. `session-report` took the **first**, so it reported `Shrimple_v0.11.zip` when the pack actually in use was `Bliss-Shader Dev.zip`. Same fault on the Colorwheel complaint line.

Both now take the **last** occurrence, and the report additionally states the authoritative on/off from `oculus.properties` rather than inferring it from a load line.

**And that surfaced something new:** with the correct line, Colorwheel reports **`Bliss-Shader Dev.zip` is not compatible** either — so it is not only Shrimple. Two of the six installed packs are now confirmed rejected by name (`C12`).

## Tested

Shaders are currently on, so: omitting `-Variant` derives `shaders-on`; passing `-Variant shaders-off` is refused with the message above. Both run clean.

---

## สรุปภาษาไทย

`config/oculus.properties` คือแหล่งที่เชื่อถือได้ — เกมเขียนทับทันทีที่เปลี่ยนค่า — เพราะงั้นสถานะ shader อ่านเอาได้ ไม่ต้องพิมพ์

```
shaderPack=Bliss-Shader Dev.zip
enableShaders=true
```

**ทำไมมันสำคัญกว่าแค่ความสะดวก** การติดป้ายผิดว่ารอบไหนเปิด shader คือความผิดพลาดที่ร้ายที่สุดของการ benchmark เพราะไม่มีอะไรข้างหลังตรวจจับได้ สองรอบจะถูกเอามาเทียบกันอยู่ดี แล้ว delta จะถูกยกให้ตัวแปรผิดตัว ตัวเลขที่ออกมาจะดูปกติดี

`-Variant` เลยเป็น **ไม่บังคับ** แล้ว — ไม่ใส่ก็จะตั้งชื่อเป็น `shaders-on` หรือ `shaders-off` จากค่าที่อ่านได้ — และถ้าชื่อที่ใส่มา **ขัดกับ** config มันจะไม่ยอมรัน

## บั๊กของรายงานที่เจอระหว่างตรวจเรื่องนี้

log มีบรรทัด `Using shaderpack:` **หนึ่งบรรทัดต่อการโหลดหนึ่งครั้ง** และ log ที่อ่านมามีถึง **หกบรรทัด** เพราะมีการสลับ pack ระหว่างเล่น ส่วน `session-report` หยิบ**บรรทัดแรก** มันเลยรายงาน `Shrimple_v0.11.zip` ทั้งที่ pack ที่ใช้จริงคือ `Bliss-Shader Dev.zip` บรรทัดของ Colorwheel ก็ผิดแบบเดียวกัน

ตอนนี้ทั้งคู่หยิบ**บรรทัดสุดท้าย** และรายงานยังบอกสถานะเปิด/ปิดจาก `oculus.properties` ตรง ๆ แทนการเดาจากบรรทัดที่โหลด

**และมันเผยของใหม่:** พอได้บรรทัดที่ถูก Colorwheel รายงานว่า **`Bliss-Shader Dev.zip` ก็ไม่รองรับ** เหมือนกัน ไม่ใช่แค่ Shrimple ตอนนี้ยืนยันแล้วสองในหก pack ที่ลงไว้ว่าถูกปฏิเสธโดยระบุชื่อ (`C12`)

## ทดสอบแล้ว

ตอนนี้ shader เปิดอยู่ ดังนั้น: ไม่ใส่ `-Variant` จะได้ `shaders-on` และใส่ `-Variant shaders-off` จะถูกปฏิเสธพร้อมข้อความข้างบน ทั้งสองกรณีรันผ่านสะอาด
