### PR TITLE
fix(perf): scrutinize pass — the report read the log as if it were the shader config (#149)

### DIFF
--- a/scripts/analyze/session-report.mjs
+++ b/scripts/analyze/session-report.mjs
@@ -33,6 +33,10 @@ const one = (n, d = '') => { const i = argv.indexOf(`--${n}`); return i >= 0 && 
 const many = n => argv.reduce((a, v, i) => (v === `--${n}` && argv[i + 1] ? [...a, argv[i + 1]] : a), [])
 
 const out = []
+// Carried from the frames section to the verdict. It was on globalThis, which
+// hid the dependency between two sections that must agree or the verdict is
+// wrong; a plain binding makes the coupling visible where it is declared.
+let gpuBusy
 const say = l => { out.push(l); console.log(l) }
 const sum = a => (a || []).reduce((x, y) => x + y, 0)
 
@@ -80,8 +84,19 @@ if (!logPath || !existsSync(logPath)) {
   // oculus.properties is the authority on whether shaders are ON; the log only
   // says which pack was last LOADED, and a pack can be loaded and then disabled.
   let shaderState = ''
-  const oculusCfg = logPath.replace(/logs[\\/]+latest\.log$/i, 'config/oculus.properties')
-  if (existsSync(oculusCfg)) {
+  // --shader-config, or nothing. This used to derive the path by rewriting the
+  // log path -- and run-session passes a COPY of the log, so the pattern never
+  // matched, .replace() returned the path unchanged, that file existed (it was
+  // the log), and the log got parsed as a properties file. Result: every real
+  // run reported "Shaders: OFF", including the ones with shaders on. Path
+  // surgery on an unrelated path is a guess dressed as a lookup.
+  const oculusCfg = one('shader-config')
+  if (oculusCfg && !existsSync(oculusCfg)) {
+    say(`| Shaders | **unknown** — \`${oculusCfg}\` not found |`)
+  } else if (!oculusCfg) {
+    say('| Shaders | **unknown** — no `--shader-config` given, so the on/off state is not established |')
+  }
+  if (oculusCfg && existsSync(oculusCfg)) {
     const cfg = readFileSync(oculusCfg, 'utf8')
     const on = /^enableShaders\s*=\s*true/mi.test(cfg)
     const pk = clean((cfg.match(/^shaderPack\s*=\s*(.+)$/mi) || [, ''])[1])
@@ -141,9 +156,16 @@ if (!cfx || !existsSync(cfx)) {
     say(`| Frametime P99 | ${pct(0.99).toFixed(2)} ms |`)
     if (gpuB.length) {
       const g = gpuB.reduce((a, b) => a + b, 0) / gpuB.length
-      const gpuPct = g <= 1.5 ? g * 100 : (g / avgFt) * 100   // fraction, or ms-active per frame
-      say(`| GPU busy | ${gpuPct.toFixed(0)}% of frame time |`)
-      globalThis.__gpuBusy = gpuPct
+      // UNITS, AND THIS IS NOT GUESSABLE FROM THE VALUE. PresentMon v2 reports
+      // GPUBusy in MILLISECONDS per frame; a fraction would be 0..1. The old
+      // heuristic "<= 1.5 means a fraction" misreads a genuinely fast frame:
+      // 1.2 ms of GPU work at 800 FPS is ms, not a fraction, and would have been
+      // reported as 120% busy. Decide from the COLUMN NAME instead, and say so.
+      const gpuIsMs = /ms/.test(head[iGpu]) || /busy/.test(head[iGpu])
+      const gpuPct = gpuIsMs ? (g / avgFt) * 100 : g * 100
+      const gpuNote = gpuIsMs ? `${g.toFixed(2)} ms of ${avgFt.toFixed(2)} ms` : 'reported as a fraction'
+      say(`| GPU busy | ${gpuPct.toFixed(0)}% of frame time (${gpuNote}, column \`${head[iGpu]}\`) |`)
+      gpuBusy = gpuPct
     }
     say('')
   }
@@ -227,7 +249,7 @@ if (!prof || !existsSync(prof)) {
 // ---------------------------------------------------------------- verdict
 say('## Bound verdict — the reason for correlating at all\n')
 const render = threadShare['Render thread']
-const gpuBusy = globalThis.__gpuBusy
+// gpuBusy is set above if, and only if, a GPU-busy column was parsed.
 if (!render || gpuBusy === undefined) {
   const missing = []
   if (!render) missing.push('a spark profile that sampled the **Render thread** (`--thread *`)')

--- a/scripts/benchmark/run-session.ps1
+++ b/scripts/benchmark/run-session.ps1
@@ -287,6 +287,9 @@ if (Test-Path $csv) { Step "presentmon $([math]::Round((Get-Item $csv).Length/1K
 Write-Host "`nReport"
 $reportArgs = @("$repo\scripts\analyze\session-report.mjs",
           '--log', (Join-Path $dest 'latest.log'),
+          # The report cannot find this by editing the log path: the log it gets
+          # is a COPY under benchmarks/. Pass the real one.
+          '--shader-config', $oculusCfg,
           '--expect-gpu', $ExpectGpu,
           '--out', (Join-Path $dest 'report.md'))
 if ($sparkUrl) { $reportArgs += @('--spark', ($sparkUrl -split '/')[-1]) }


### PR DESCRIPTION
`/scrutinize` over the harness (#133–#147). Three findings, one of them a blocker that would have silently corrupted every run.

## Blocker — every real run would have reported `Shaders: OFF`

`session-report.mjs:83` found `oculus.properties` by rewriting the log path:

```js
const oculusCfg = logPath.replace(/logs[\/]+latest\.log$/i, 'config/oculus.properties')
```

**`run-session.ps1` passes a copy of the log**, at `benchmarks/captures/…/latest.log`. That does not match the pattern, so `.replace()` returned **the path unchanged** — and that file exists, because it is the log. The log was then parsed as a properties file, `enableShaders=true` was not found in it, and the report stated **`Shaders: OFF`**.

Traced, not reasoned about:

```
node session-report.mjs --log /tmp/sc/latest.log
| Shaders | **OFF** — from `config/oculus.properties` |     ← shaders were ON
```

Every real run would have carried that line, **including the shaders-on run** — the exact failure #147 was written to prevent, reintroduced one layer down. Path surgery on an unrelated path is a guess dressed as a lookup.

**Fixed:** `--shader-config` is passed explicitly by `run-session`. With no config given the report now says **unknown**, not OFF — an absent input must never look like a measured negative.

## Major — the GPU-busy unit heuristic misreads a fast frame

`session-report.mjs:144` decided the unit from the value: `g <= 1.5 ? fraction : milliseconds`. PresentMon v2 reports `GPUBusy` in **ms per frame**, and **1.2 ms at 800 FPS is milliseconds, not a fraction** — it would have been reported as **120% GPU busy**, which flips the CPU-bound/GPU-bound verdict, which is the one output the whole correlation exists to produce.

**Fixed:** decide from the column name, and print the working (`1.20 ms of 8.30 ms, column `gpubusy``) so a wrong unit is visible instead of silent.

## Major — the verdict depended on a value smuggled through `globalThis`

`globalThis.__gpuBusy` was set in the frames section and read in the verdict. Two sections that must agree, with no declared relationship. **Fixed:** a plain `let` at the top, where the coupling is visible.

## Not fixed, recorded

The F3+L output location (`debug/profiling/**/profiling-result.txt`) is **assumed**; no such file exists on this machine. The script handles absence gracefully but the path itself is unverified until a real run.

## Verdict

**fix-then-ship** — now shipped. The blocker was invisible from the diff: both halves were individually correct and only the seam between them was wrong.

---

## สรุปภาษาไทย

`/scrutinize` ทั้งชุด harness (#133–#147) เจอสามข้อ หนึ่งในนั้นเป็น blocker ที่จะทำให้ทุกรอบผิดเงียบ ๆ

### Blocker — ทุกรอบจริงจะรายงานว่า `Shaders: OFF`

`session-report.mjs:83` หา `oculus.properties` ด้วยการเอา path ของ log มาแก้ แต่ **`run-session.ps1` ส่ง log ที่ก๊อปไปแล้ว** ที่ `benchmarks/captures/…/latest.log` ซึ่งไม่ match pattern `.replace()` เลยคืน**พาธเดิม** และไฟล์นั้นมีอยู่จริงเพราะมันคือ log จากนั้น log ถูกอ่านเป็นไฟล์ properties ไม่เจอ `enableShaders=true` แล้วรายงานว่า **`Shaders: OFF`**

ไล่ให้ดู ไม่ใช่คิดเอา:

```
node session-report.mjs --log /tmp/sc/latest.log
| Shaders | **OFF** — from `config/oculus.properties` |     ← ตอนนั้นเปิดอยู่
```

ทุกรอบจริงจะมีบรรทัดนั้น **รวมถึงรอบที่เปิด shader** ซึ่งคือความผิดพลาดที่ #147 เขียนมาเพื่อกันโดยตรง แล้วมันกลับมาเกิดที่ชั้นถัดไป การเอาพาธหนึ่งมาดัดเป็นอีกพาธหนึ่งคือการเดาที่แต่งตัวเป็นการค้นหา

**แก้แล้ว:** `run-session` ส่ง `--shader-config` ตรง ๆ และถ้าไม่ได้ส่งมา รายงานจะบอกว่า **unknown** ไม่ใช่ OFF — input ที่หายไปต้องไม่ดูเหมือนผลวัดที่เป็นลบ

### Major — การเดาหน่วยของ GPU busy อ่านเฟรมเร็วผิด

`session-report.mjs:144` ตัดสินหน่วยจากค่า: `g <= 1.5 ? สัดส่วน : มิลลิวินาที` แต่ PresentMon v2 รายงาน `GPUBusy` เป็น **ms ต่อเฟรม** และ **1.2 ms ที่ 800 FPS คือมิลลิวินาที ไม่ใช่สัดส่วน** มันจะถูกรายงานเป็น **GPU busy 120%** ซึ่งพลิกคำตัดสินว่าติด CPU หรือ GPU อันเป็นผลลัพธ์เดียวที่การรวมข้อมูลทั้งหมดมีไว้เพื่อตอบ

**แก้แล้ว:** ตัดสินจากชื่อคอลัมน์ และพิมพ์วิธีคิดออกมาด้วย เพื่อให้หน่วยที่ผิดมองเห็นได้ ไม่ใช่เงียบ

### Major — คำตัดสินพึ่งค่าที่ลักลอบส่งผ่าน `globalThis`

`globalThis.__gpuBusy` ถูกตั้งในส่วนของเฟรมแล้วไปอ่านในส่วนคำตัดสิน สองส่วนที่ต้องสอดคล้องกันโดยไม่มีความสัมพันธ์ที่ประกาศไว้ **แก้แล้ว:** ใช้ `let` ธรรมดาไว้ข้างบน ตรงที่มองเห็นความผูกพันได้

### ไม่ได้แก้ แต่บันทึกไว้

ตำแหน่งไฟล์ผลของ F3+L (`debug/profiling/**/profiling-result.txt`) เป็นการ **สันนิษฐาน** เครื่องนี้ไม่มีไฟล์นั้น สคริปต์รับมือกับการไม่มีได้ดี แต่ตัวพาธเองยังไม่ยืนยันจนกว่าจะรันจริง

### คำตัดสิน

**fix-then-ship** และแก้แล้ว blocker ตัวนี้มองจาก diff ไม่เห็น เพราะสองฝั่งถูกทั้งคู่ ผิดเฉพาะรอยต่อระหว่างกัน
