### PR TITLE
perf: a double-clickable benchmark.bat (#151)

### DIFF
--- a/.packwizignore
+++ b/.packwizignore
@@ -33,6 +33,13 @@
 /docs/
 *.md
 
+# --- launchers for the developer, not for the pack ---------------------------
+#
+# benchmark.bat sits at the repo root so it can be double-clicked. Without this
+# line packwiz indexes it and every friend downloads a script that tries to run
+# PresentMon against an instance path that does not exist on their machine.
+*.bat
+
 # --- repo metadata -----------------------------------------------------------
 .gitignore
 .gitattributes

--- a/benchmark.bat
+++ b/benchmark.bat
@@ -1,0 +1,64 @@
+@echo off
+setlocal EnableDelayedExpansion
+title Industrial Civilization Survival - benchmark session
+
+rem  Double-click this, or run it with an argument:
+rem
+rem     benchmark.bat          a real session, elevating first if it has to
+rem     benchmark.bat dry      check the wiring, touch nothing, no elevation
+rem     benchmark.bat spike    profile only ticks over 100 ms
+rem
+rem  The shader state names the run, so there is nothing to remember and nothing
+rem  to mislabel: run it once with shaders off and once with them on, and the
+rem  two land in separate folders by themselves.
+rem
+rem  WHY THIS ELEVATES. PresentMon cannot open its trace session without it, and
+rem  the failure is an empty CSV discovered after the run rather than an error
+rem  during it. The dry run skips elevation because it captures nothing.
+
+cd /d "%~dp0"
+
+set "MODE=%~1"
+set "EXTRA="
+if /i "%MODE%"=="dry"   set "EXTRA=-DryRun"
+if /i "%MODE%"=="spike" set "EXTRA=-SpikeProfile"
+
+rem -- the date, from PowerShell rather than %DATE% -----------------------------
+rem  %DATE% is locale-formatted and differs between machines and users; the
+rem  capture folder is part of a path that has to be stable.
+for /f "usebackq delims=" %%i in (`powershell -NoProfile -Command "Get-Date -Format yyyy-MM-dd"`) do set "TODAY=%%i"
+
+rem -- elevate, unless this is a dry run ---------------------------------------
+net session >nul 2>&1
+if errorlevel 1 (
+    if /i "%MODE%"=="dry" (
+        echo.
+        echo   Not elevated. Fine for a dry run - it captures nothing.
+        echo.
+    ) else (
+        echo.
+        echo   Not running as Administrator. PresentMon needs it, so this will
+        echo   ask Windows for permission and reopen in a new window.
+        echo.
+        powershell -NoProfile -Command "Start-Process -Verb RunAs -FilePath '%~f0' -ArgumentList '%MODE%'"
+        exit /b
+    )
+)
+
+echo.
+echo   date    %TODAY%
+echo   zone    A
+if defined EXTRA echo   mode    %EXTRA%
+echo.
+
+pwsh -NoProfile -File "scripts\benchmark\run-session.ps1" -Zone A -Date %TODAY% %EXTRA%
+set "RC=%ERRORLEVEL%"
+
+echo.
+if not "%RC%"=="0" (
+    echo   The session did not complete - exit code %RC%. Nothing above is a result.
+) else (
+    echo   Done. The report is under benchmarks\captures\%TODAY%\
+)
+echo.
+pause

--- a/index.toml
+++ b/index.toml
@@ -922,3 +922,7 @@ hash = "49b4c1cc9f9260ceea290f3694234ae4eeafd72b440baa44c99d3e62c02f88ea"
 [[files]]
 file = "resourcepacks/industrial-civilization-connected-textures/pack.mcmeta"
 hash = "80006d33962df7d359bbef210570fe3ad6269cf4dc5d712b837069332a5cf3c7"
+
+[[files]]
+file = "tools/PresentMon-2.5.1-x64.exe"
+hash = "9bec3083069f58f911e6a512f4806db51a27bd096103087bc1d05ef54c80a191"

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "b94ff2060134651f662562625f08bdcff84d3f84a4ca5f6bc5d92c87f4e549d6"
+hash = "98427c42ec66016752c59786dfdf8ac3348ae39130ee7b7e2c4c559749c9c6e0"
 
 [versions]
 forge = "47.4.23"


### PR DESCRIPTION
`benchmark.bat` at the repo root. Double-click it, or:

```
benchmark.bat          a real session, elevating first if it has to
benchmark.bat dry      check the wiring, touch nothing, no elevation
benchmark.bat spike    profile only ticks over 100 ms
```

Nothing to type and nothing to remember: the shader state names the run, so playing once with shaders off and once with them on puts the two in separate folders by themselves.

## Three decisions worth stating

**It self-elevates, except for `dry`.** PresentMon cannot open its trace session unelevated, and that failure is an empty CSV found *after* the run rather than an error *during* it. The dry run captures nothing, so it stays unelevated and remains usable for checking the wiring.

**The date comes from PowerShell, not `%DATE%`.** `%DATE%` is locale-formatted and differs between machines and users. It ends up in a capture path that has to be stable, so it is produced as `yyyy-MM-dd` explicitly. The underlying script still *requires* an explicit `-Date` — the wrapper supplies it rather than removing the requirement.

**`*.bat` added to `.packwizignore`.** The file sits at the repo root so it can be double-clicked, and root files **are indexed by packwiz**. Without that line every friend downloading the pack would receive a script that tries to run PresentMon against an instance path that does not exist on their machine. Confirmed after `packwiz refresh`: zero index entries for it, still 127 mods.

## Tested

`benchmark.bat dry` end to end: date resolved to `2026-08-28`, unelevated path taken with the correct note, shader state read as **ON — `Bliss-Shader Dev.zip`**, variant derived as `shaders-on`, capture folder created, report written.

The elevated path is **not** tested — accepting a UAC prompt is not something this session can do.

---

## สรุปภาษาไทย

`benchmark.bat` อยู่ที่รากของ repo ดับเบิลคลิกได้เลย หรือ:

```
benchmark.bat          รันจริง ถ้าต้องยกสิทธิ์ก็จะขอเอง
benchmark.bat dry      เช็คว่าต่อกันครบไหม ไม่แตะอะไร ไม่ต้องยกสิทธิ์
benchmark.bat spike    เก็บเฉพาะ tick ที่เกิน 100 ms
```

ไม่ต้องพิมพ์และไม่ต้องจำอะไร สถานะ shader เป็นตัวตั้งชื่อรอบให้เอง เล่นรอบหนึ่งปิด shader อีกรอบเปิด แล้วมันจะแยกโฟลเดอร์ให้เองสองอัน

### สามการตัดสินใจที่ควรพูดไว้

**มันยกสิทธิ์ตัวเอง ยกเว้นโหมด `dry`** PresentMon เปิด trace session ไม่ได้ถ้าไม่ได้เป็น admin และความล้มเหลวแบบนั้นคือ CSV ว่างที่รู้ตอน*หลัง*รัน ไม่ใช่ error ตอน*กำลัง*รัน ส่วน dry ไม่ได้เก็บอะไรเลย เลยไม่ต้องยกสิทธิ์และยังใช้เช็คสายไฟได้

**วันที่มาจาก PowerShell ไม่ใช่ `%DATE%`** เพราะ `%DATE%` ขึ้นกับ locale และต่างกันไปตามเครื่องกับผู้ใช้ มันจะไปอยู่ในพาธของ capture ซึ่งต้องนิ่ง เลยสร้างเป็น `yyyy-MM-dd` ตรง ๆ ส่วนสคริปต์ข้างล่างยัง**บังคับ**ให้ระบุ `-Date` เหมือนเดิม ตัว wrapper แค่เติมให้ ไม่ได้ยกเลิกข้อบังคับ

**เพิ่ม `*.bat` ลง `.packwizignore`** ไฟล์นี้อยู่ที่รากเพื่อให้ดับเบิลคลิกได้ และไฟล์ที่รากจะ**ถูก packwiz index** ถ้าไม่มีบรรทัดนั้น เพื่อนทุกคนที่โหลดแพ็คจะได้สคริปต์ที่พยายามรัน PresentMon ใส่พาธ instance ที่ไม่มีอยู่บนเครื่องเขา ยืนยันหลัง `packwiz refresh` แล้ว: ไม่มีรายการของมันใน index และยัง 127 มอด

### ทดสอบแล้ว

`benchmark.bat dry` ตั้งแต่ต้นจนจบ: วันที่ออกมาเป็น `2026-08-28` เดินเส้นทางไม่ยกสิทธิ์พร้อมข้อความที่ถูกต้อง อ่านสถานะ shader ได้ว่า **ON — `Bliss-Shader Dev.zip`** ตั้งชื่อ variant เป็น `shaders-on` สร้างโฟลเดอร์ capture และเขียนรายงานออกมา

ส่วนเส้นทางที่ยกสิทธิ์ **ยังไม่ได้ทดสอบ** การกดยอมรับ UAC ไม่ใช่สิ่งที่ session นี้ทำได้

